### PR TITLE
chore: gitignore allow list

### DIFF
--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,0 +1,1 @@
+!workflows/*.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,16 @@
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
-#
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
+# Ignore everything
+*
 
-# Test binary, built with `go test -c`
-*.test
+# Whitelist patterns anchored to project root
+!/.golangci.yml
 
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
+# Whitelist patterns found anywhere in project
+!*.go
+!.gitignore
+!go.mod
+!go.sum
+!LICENSE
+!Makefile
+!README.md
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
-
-# Go workspace file
-go.work
+!*/


### PR DESCRIPTION
This PR updates `.gitignore` to use the allow-list pattern for ignoring changed files.

> [!IMPORTANT]
> Includes changes from #7 and #5, should be merged prior to this PR