### PR TITLE
Fix unique index definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,6 @@
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 # --------------------------------------------------------------
-BASH := ${shell type -p bash}
-SHELL := ${BASH}
 
 # ANSI color escape codes
 BOLD   := \033[1m

--- a/backends/ent/backend.go
+++ b/backends/ent/backend.go
@@ -77,7 +77,6 @@ func (backend *Backend) CloseClient() {
 
 func (backend *Backend) Debug() *Backend {
 	backend.Options.Debug = true
-	backend.client.Debug()
 
 	return backend
 }

--- a/internal/backends/ent/client.go
+++ b/internal/backends/ent/client.go
@@ -362,7 +362,7 @@ func (c *DocumentClient) UpdateOne(d *Document) *DocumentUpdateOne {
 }
 
 // UpdateOneID returns an update builder for the given id.
-func (c *DocumentClient) UpdateOneID(id int) *DocumentUpdateOne {
+func (c *DocumentClient) UpdateOneID(id string) *DocumentUpdateOne {
 	mutation := newDocumentMutation(c.config, OpUpdateOne, withDocumentID(id))
 	return &DocumentUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
 }
@@ -379,7 +379,7 @@ func (c *DocumentClient) DeleteOne(d *Document) *DocumentDeleteOne {
 }
 
 // DeleteOneID returns a builder for deleting the given entity by its id.
-func (c *DocumentClient) DeleteOneID(id int) *DocumentDeleteOne {
+func (c *DocumentClient) DeleteOneID(id string) *DocumentDeleteOne {
 	builder := c.Delete().Where(document.ID(id))
 	builder.mutation.id = &id
 	builder.mutation.op = OpDeleteOne
@@ -396,12 +396,12 @@ func (c *DocumentClient) Query() *DocumentQuery {
 }
 
 // Get returns a Document entity by its id.
-func (c *DocumentClient) Get(ctx context.Context, id int) (*Document, error) {
+func (c *DocumentClient) Get(ctx context.Context, id string) (*Document, error) {
 	return c.Query().Where(document.ID(id)).Only(ctx)
 }
 
 // GetX is like Get, but panics if an error occurs.
-func (c *DocumentClient) GetX(ctx context.Context, id int) *Document {
+func (c *DocumentClient) GetX(ctx context.Context, id string) *Document {
 	obj, err := c.Get(ctx, id)
 	if err != nil {
 		panic(err)
@@ -417,7 +417,7 @@ func (c *DocumentClient) QueryMetadata(d *Document) *MetadataQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(document.Table, document.FieldID, id),
 			sqlgraph.To(metadata.Table, metadata.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, document.MetadataTable, document.MetadataColumn),
+			sqlgraph.Edge(sqlgraph.O2O, false, document.MetadataTable, document.MetadataColumn),
 		)
 		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
 		return fromV, nil
@@ -433,7 +433,7 @@ func (c *DocumentClient) QueryNodeList(d *Document) *NodeListQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(document.Table, document.FieldID, id),
 			sqlgraph.To(nodelist.Table, nodelist.FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, document.NodeListTable, document.NodeListColumn),
+			sqlgraph.Edge(sqlgraph.O2O, false, document.NodeListTable, document.NodeListColumn),
 		)
 		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
 		return fromV, nil
@@ -1423,7 +1423,7 @@ func (c *MetadataClient) QueryDocument(m *Metadata) *DocumentQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(metadata.Table, metadata.FieldID, id),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, metadata.DocumentTable, metadata.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.O2O, true, metadata.DocumentTable, metadata.DocumentColumn),
 		)
 		fromV = sqlgraph.Neighbors(m.driver.Dialect(), step)
 		return fromV, nil
@@ -1881,7 +1881,7 @@ func (c *NodeListClient) QueryDocument(nl *NodeList) *DocumentQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(nodelist.Table, nodelist.FieldID, id),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, nodelist.DocumentTable, nodelist.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.O2O, true, nodelist.DocumentTable, nodelist.DocumentColumn),
 		)
 		fromV = sqlgraph.Neighbors(nl.driver.Dialect(), step)
 		return fromV, nil

--- a/internal/backends/ent/document.go
+++ b/internal/backends/ent/document.go
@@ -19,13 +19,9 @@ import (
 
 // Document is the model entity for the Document schema.
 type Document struct {
-	config `json:"-"`
+	config
 	// ID of the ent.
-	ID int `json:"id,omitempty"`
-	// MetadataID holds the value of the "metadata_id" field.
-	MetadataID string `json:"metadata_id,omitempty"`
-	// NodeListID holds the value of the "node_list_id" field.
-	NodeListID int `json:"node_list_id,omitempty"`
+	ID string `json:"id,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the DocumentQuery when eager-loading is set.
 	Edges        DocumentEdges `json:"edges"`
@@ -70,9 +66,7 @@ func (*Document) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case document.FieldID, document.FieldNodeListID:
-			values[i] = new(sql.NullInt64)
-		case document.FieldMetadataID:
+		case document.FieldID:
 			values[i] = new(sql.NullString)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -90,22 +84,10 @@ func (d *Document) assignValues(columns []string, values []any) error {
 	for i := range columns {
 		switch columns[i] {
 		case document.FieldID:
-			value, ok := values[i].(*sql.NullInt64)
-			if !ok {
-				return fmt.Errorf("unexpected type %T for field id", value)
-			}
-			d.ID = int(value.Int64)
-		case document.FieldMetadataID:
 			if value, ok := values[i].(*sql.NullString); !ok {
-				return fmt.Errorf("unexpected type %T for field metadata_id", values[i])
+				return fmt.Errorf("unexpected type %T for field id", values[i])
 			} else if value.Valid {
-				d.MetadataID = value.String
-			}
-		case document.FieldNodeListID:
-			if value, ok := values[i].(*sql.NullInt64); !ok {
-				return fmt.Errorf("unexpected type %T for field node_list_id", values[i])
-			} else if value.Valid {
-				d.NodeListID = int(value.Int64)
+				d.ID = value.String
 			}
 		default:
 			d.selectValues.Set(columns[i], values[i])
@@ -152,12 +134,7 @@ func (d *Document) Unwrap() *Document {
 func (d *Document) String() string {
 	var builder strings.Builder
 	builder.WriteString("Document(")
-	builder.WriteString(fmt.Sprintf("id=%v, ", d.ID))
-	builder.WriteString("metadata_id=")
-	builder.WriteString(d.MetadataID)
-	builder.WriteString(", ")
-	builder.WriteString("node_list_id=")
-	builder.WriteString(fmt.Sprintf("%v", d.NodeListID))
+	builder.WriteString(fmt.Sprintf("id=%v", d.ID))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/internal/backends/ent/document/document.go
+++ b/internal/backends/ent/document/document.go
@@ -17,10 +17,6 @@ const (
 	Label = "document"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
-	// FieldMetadataID holds the string denoting the metadata_id field in the database.
-	FieldMetadataID = "metadata_id"
-	// FieldNodeListID holds the string denoting the node_list_id field in the database.
-	FieldNodeListID = "node_list_id"
 	// EdgeMetadata holds the string denoting the metadata edge name in mutations.
 	EdgeMetadata = "metadata"
 	// EdgeNodeList holds the string denoting the node_list edge name in mutations.
@@ -28,26 +24,24 @@ const (
 	// Table holds the table name of the document in the database.
 	Table = "documents"
 	// MetadataTable is the table that holds the metadata relation/edge.
-	MetadataTable = "documents"
+	MetadataTable = "metadata"
 	// MetadataInverseTable is the table name for the Metadata entity.
 	// It exists in this package in order to avoid circular dependency with the "metadata" package.
 	MetadataInverseTable = "metadata"
 	// MetadataColumn is the table column denoting the metadata relation/edge.
-	MetadataColumn = "metadata_id"
+	MetadataColumn = "id"
 	// NodeListTable is the table that holds the node_list relation/edge.
-	NodeListTable = "documents"
+	NodeListTable = "node_lists"
 	// NodeListInverseTable is the table name for the NodeList entity.
 	// It exists in this package in order to avoid circular dependency with the "nodelist" package.
 	NodeListInverseTable = "node_lists"
 	// NodeListColumn is the table column denoting the node_list relation/edge.
-	NodeListColumn = "node_list_id"
+	NodeListColumn = "document_id"
 )
 
 // Columns holds all SQL columns for document fields.
 var Columns = []string{
 	FieldID,
-	FieldMetadataID,
-	FieldNodeListID,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -68,16 +62,6 @@ func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
-// ByMetadataID orders the results by the metadata_id field.
-func ByMetadataID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldMetadataID, opts...).ToFunc()
-}
-
-// ByNodeListID orders the results by the node_list_id field.
-func ByNodeListID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldNodeListID, opts...).ToFunc()
-}
-
 // ByMetadataField orders the results by metadata field.
 func ByMetadataField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -95,13 +79,13 @@ func newMetadataStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(MetadataInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, true, MetadataTable, MetadataColumn),
+		sqlgraph.Edge(sqlgraph.O2O, false, MetadataTable, MetadataColumn),
 	)
 }
 func newNodeListStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(NodeListInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2O, true, NodeListTable, NodeListColumn),
+		sqlgraph.Edge(sqlgraph.O2O, false, NodeListTable, NodeListColumn),
 	)
 }

--- a/internal/backends/ent/document/where.go
+++ b/internal/backends/ent/document/where.go
@@ -14,143 +14,58 @@ import (
 )
 
 // ID filters vertices based on their ID field.
-func ID(id int) predicate.Document {
+func ID(id string) predicate.Document {
 	return predicate.Document(sql.FieldEQ(FieldID, id))
 }
 
 // IDEQ applies the EQ predicate on the ID field.
-func IDEQ(id int) predicate.Document {
+func IDEQ(id string) predicate.Document {
 	return predicate.Document(sql.FieldEQ(FieldID, id))
 }
 
 // IDNEQ applies the NEQ predicate on the ID field.
-func IDNEQ(id int) predicate.Document {
+func IDNEQ(id string) predicate.Document {
 	return predicate.Document(sql.FieldNEQ(FieldID, id))
 }
 
 // IDIn applies the In predicate on the ID field.
-func IDIn(ids ...int) predicate.Document {
+func IDIn(ids ...string) predicate.Document {
 	return predicate.Document(sql.FieldIn(FieldID, ids...))
 }
 
 // IDNotIn applies the NotIn predicate on the ID field.
-func IDNotIn(ids ...int) predicate.Document {
+func IDNotIn(ids ...string) predicate.Document {
 	return predicate.Document(sql.FieldNotIn(FieldID, ids...))
 }
 
 // IDGT applies the GT predicate on the ID field.
-func IDGT(id int) predicate.Document {
+func IDGT(id string) predicate.Document {
 	return predicate.Document(sql.FieldGT(FieldID, id))
 }
 
 // IDGTE applies the GTE predicate on the ID field.
-func IDGTE(id int) predicate.Document {
+func IDGTE(id string) predicate.Document {
 	return predicate.Document(sql.FieldGTE(FieldID, id))
 }
 
 // IDLT applies the LT predicate on the ID field.
-func IDLT(id int) predicate.Document {
+func IDLT(id string) predicate.Document {
 	return predicate.Document(sql.FieldLT(FieldID, id))
 }
 
 // IDLTE applies the LTE predicate on the ID field.
-func IDLTE(id int) predicate.Document {
+func IDLTE(id string) predicate.Document {
 	return predicate.Document(sql.FieldLTE(FieldID, id))
 }
 
-// MetadataID applies equality check predicate on the "metadata_id" field. It's identical to MetadataIDEQ.
-func MetadataID(v string) predicate.Document {
-	return predicate.Document(sql.FieldEQ(FieldMetadataID, v))
+// IDEqualFold applies the EqualFold predicate on the ID field.
+func IDEqualFold(id string) predicate.Document {
+	return predicate.Document(sql.FieldEqualFold(FieldID, id))
 }
 
-// NodeListID applies equality check predicate on the "node_list_id" field. It's identical to NodeListIDEQ.
-func NodeListID(v int) predicate.Document {
-	return predicate.Document(sql.FieldEQ(FieldNodeListID, v))
-}
-
-// MetadataIDEQ applies the EQ predicate on the "metadata_id" field.
-func MetadataIDEQ(v string) predicate.Document {
-	return predicate.Document(sql.FieldEQ(FieldMetadataID, v))
-}
-
-// MetadataIDNEQ applies the NEQ predicate on the "metadata_id" field.
-func MetadataIDNEQ(v string) predicate.Document {
-	return predicate.Document(sql.FieldNEQ(FieldMetadataID, v))
-}
-
-// MetadataIDIn applies the In predicate on the "metadata_id" field.
-func MetadataIDIn(vs ...string) predicate.Document {
-	return predicate.Document(sql.FieldIn(FieldMetadataID, vs...))
-}
-
-// MetadataIDNotIn applies the NotIn predicate on the "metadata_id" field.
-func MetadataIDNotIn(vs ...string) predicate.Document {
-	return predicate.Document(sql.FieldNotIn(FieldMetadataID, vs...))
-}
-
-// MetadataIDGT applies the GT predicate on the "metadata_id" field.
-func MetadataIDGT(v string) predicate.Document {
-	return predicate.Document(sql.FieldGT(FieldMetadataID, v))
-}
-
-// MetadataIDGTE applies the GTE predicate on the "metadata_id" field.
-func MetadataIDGTE(v string) predicate.Document {
-	return predicate.Document(sql.FieldGTE(FieldMetadataID, v))
-}
-
-// MetadataIDLT applies the LT predicate on the "metadata_id" field.
-func MetadataIDLT(v string) predicate.Document {
-	return predicate.Document(sql.FieldLT(FieldMetadataID, v))
-}
-
-// MetadataIDLTE applies the LTE predicate on the "metadata_id" field.
-func MetadataIDLTE(v string) predicate.Document {
-	return predicate.Document(sql.FieldLTE(FieldMetadataID, v))
-}
-
-// MetadataIDContains applies the Contains predicate on the "metadata_id" field.
-func MetadataIDContains(v string) predicate.Document {
-	return predicate.Document(sql.FieldContains(FieldMetadataID, v))
-}
-
-// MetadataIDHasPrefix applies the HasPrefix predicate on the "metadata_id" field.
-func MetadataIDHasPrefix(v string) predicate.Document {
-	return predicate.Document(sql.FieldHasPrefix(FieldMetadataID, v))
-}
-
-// MetadataIDHasSuffix applies the HasSuffix predicate on the "metadata_id" field.
-func MetadataIDHasSuffix(v string) predicate.Document {
-	return predicate.Document(sql.FieldHasSuffix(FieldMetadataID, v))
-}
-
-// MetadataIDEqualFold applies the EqualFold predicate on the "metadata_id" field.
-func MetadataIDEqualFold(v string) predicate.Document {
-	return predicate.Document(sql.FieldEqualFold(FieldMetadataID, v))
-}
-
-// MetadataIDContainsFold applies the ContainsFold predicate on the "metadata_id" field.
-func MetadataIDContainsFold(v string) predicate.Document {
-	return predicate.Document(sql.FieldContainsFold(FieldMetadataID, v))
-}
-
-// NodeListIDEQ applies the EQ predicate on the "node_list_id" field.
-func NodeListIDEQ(v int) predicate.Document {
-	return predicate.Document(sql.FieldEQ(FieldNodeListID, v))
-}
-
-// NodeListIDNEQ applies the NEQ predicate on the "node_list_id" field.
-func NodeListIDNEQ(v int) predicate.Document {
-	return predicate.Document(sql.FieldNEQ(FieldNodeListID, v))
-}
-
-// NodeListIDIn applies the In predicate on the "node_list_id" field.
-func NodeListIDIn(vs ...int) predicate.Document {
-	return predicate.Document(sql.FieldIn(FieldNodeListID, vs...))
-}
-
-// NodeListIDNotIn applies the NotIn predicate on the "node_list_id" field.
-func NodeListIDNotIn(vs ...int) predicate.Document {
-	return predicate.Document(sql.FieldNotIn(FieldNodeListID, vs...))
+// IDContainsFold applies the ContainsFold predicate on the ID field.
+func IDContainsFold(id string) predicate.Document {
+	return predicate.Document(sql.FieldContainsFold(FieldID, id))
 }
 
 // HasMetadata applies the HasEdge predicate on the "metadata" edge.
@@ -158,7 +73,7 @@ func HasMetadata() predicate.Document {
 	return predicate.Document(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, MetadataTable, MetadataColumn),
+			sqlgraph.Edge(sqlgraph.O2O, false, MetadataTable, MetadataColumn),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -181,7 +96,7 @@ func HasNodeList() predicate.Document {
 	return predicate.Document(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, NodeListTable, NodeListColumn),
+			sqlgraph.Edge(sqlgraph.O2O, false, NodeListTable, NodeListColumn),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})

--- a/internal/backends/ent/document_delete.go
+++ b/internal/backends/ent/document_delete.go
@@ -44,7 +44,7 @@ func (dd *DocumentDelete) ExecX(ctx context.Context) int {
 }
 
 func (dd *DocumentDelete) sqlExec(ctx context.Context) (int, error) {
-	_spec := sqlgraph.NewDeleteSpec(document.Table, sqlgraph.NewFieldSpec(document.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewDeleteSpec(document.Table, sqlgraph.NewFieldSpec(document.FieldID, field.TypeString))
 	if ps := dd.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {

--- a/internal/backends/ent/document_query.go
+++ b/internal/backends/ent/document_query.go
@@ -8,6 +8,7 @@ package ent
 
 import (
 	"context"
+	"database/sql/driver"
 	"fmt"
 	"math"
 
@@ -79,7 +80,7 @@ func (dq *DocumentQuery) QueryMetadata() *MetadataQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(document.Table, document.FieldID, selector),
 			sqlgraph.To(metadata.Table, metadata.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, document.MetadataTable, document.MetadataColumn),
+			sqlgraph.Edge(sqlgraph.O2O, false, document.MetadataTable, document.MetadataColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(dq.driver.Dialect(), step)
 		return fromU, nil
@@ -101,7 +102,7 @@ func (dq *DocumentQuery) QueryNodeList() *NodeListQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(document.Table, document.FieldID, selector),
 			sqlgraph.To(nodelist.Table, nodelist.FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, document.NodeListTable, document.NodeListColumn),
+			sqlgraph.Edge(sqlgraph.O2O, false, document.NodeListTable, document.NodeListColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(dq.driver.Dialect(), step)
 		return fromU, nil
@@ -133,8 +134,8 @@ func (dq *DocumentQuery) FirstX(ctx context.Context) *Document {
 
 // FirstID returns the first Document ID from the query.
 // Returns a *NotFoundError when no Document ID was found.
-func (dq *DocumentQuery) FirstID(ctx context.Context) (id int, err error) {
-	var ids []int
+func (dq *DocumentQuery) FirstID(ctx context.Context) (id string, err error) {
+	var ids []string
 	if ids, err = dq.Limit(1).IDs(setContextOp(ctx, dq.ctx, "FirstID")); err != nil {
 		return
 	}
@@ -146,7 +147,7 @@ func (dq *DocumentQuery) FirstID(ctx context.Context) (id int, err error) {
 }
 
 // FirstIDX is like FirstID, but panics if an error occurs.
-func (dq *DocumentQuery) FirstIDX(ctx context.Context) int {
+func (dq *DocumentQuery) FirstIDX(ctx context.Context) string {
 	id, err := dq.FirstID(ctx)
 	if err != nil && !IsNotFound(err) {
 		panic(err)
@@ -184,8 +185,8 @@ func (dq *DocumentQuery) OnlyX(ctx context.Context) *Document {
 // OnlyID is like Only, but returns the only Document ID in the query.
 // Returns a *NotSingularError when more than one Document ID is found.
 // Returns a *NotFoundError when no entities are found.
-func (dq *DocumentQuery) OnlyID(ctx context.Context) (id int, err error) {
-	var ids []int
+func (dq *DocumentQuery) OnlyID(ctx context.Context) (id string, err error) {
+	var ids []string
 	if ids, err = dq.Limit(2).IDs(setContextOp(ctx, dq.ctx, "OnlyID")); err != nil {
 		return
 	}
@@ -201,7 +202,7 @@ func (dq *DocumentQuery) OnlyID(ctx context.Context) (id int, err error) {
 }
 
 // OnlyIDX is like OnlyID, but panics if an error occurs.
-func (dq *DocumentQuery) OnlyIDX(ctx context.Context) int {
+func (dq *DocumentQuery) OnlyIDX(ctx context.Context) string {
 	id, err := dq.OnlyID(ctx)
 	if err != nil {
 		panic(err)
@@ -229,7 +230,7 @@ func (dq *DocumentQuery) AllX(ctx context.Context) []*Document {
 }
 
 // IDs executes the query and returns a list of Document IDs.
-func (dq *DocumentQuery) IDs(ctx context.Context) (ids []int, err error) {
+func (dq *DocumentQuery) IDs(ctx context.Context) (ids []string, err error) {
 	if dq.ctx.Unique == nil && dq.path != nil {
 		dq.Unique(true)
 	}
@@ -241,7 +242,7 @@ func (dq *DocumentQuery) IDs(ctx context.Context) (ids []int, err error) {
 }
 
 // IDsX is like IDs, but panics if an error occurs.
-func (dq *DocumentQuery) IDsX(ctx context.Context) []int {
+func (dq *DocumentQuery) IDsX(ctx context.Context) []string {
 	ids, err := dq.IDs(ctx)
 	if err != nil {
 		panic(err)
@@ -333,18 +334,6 @@ func (dq *DocumentQuery) WithNodeList(opts ...func(*NodeListQuery)) *DocumentQue
 
 // GroupBy is used to group vertices by one or more fields/columns.
 // It is often used with aggregate functions, like: count, max, mean, min, sum.
-//
-// Example:
-//
-//	var v []struct {
-//		MetadataID string `json:"metadata_id,omitempty"`
-//		Count int `json:"count,omitempty"`
-//	}
-//
-//	client.Document.Query().
-//		GroupBy(document.FieldMetadataID).
-//		Aggregate(ent.Count()).
-//		Scan(ctx, &v)
 func (dq *DocumentQuery) GroupBy(field string, fields ...string) *DocumentGroupBy {
 	dq.ctx.Fields = append([]string{field}, fields...)
 	grbuild := &DocumentGroupBy{build: dq}
@@ -356,16 +345,6 @@ func (dq *DocumentQuery) GroupBy(field string, fields ...string) *DocumentGroupB
 
 // Select allows the selection one or more fields/columns for the given query,
 // instead of selecting all fields in the entity.
-//
-// Example:
-//
-//	var v []struct {
-//		MetadataID string `json:"metadata_id,omitempty"`
-//	}
-//
-//	client.Document.Query().
-//		Select(document.FieldMetadataID).
-//		Scan(ctx, &v)
 func (dq *DocumentQuery) Select(fields ...string) *DocumentSelect {
 	dq.ctx.Fields = append(dq.ctx.Fields, fields...)
 	sbuild := &DocumentSelect{DocumentQuery: dq}
@@ -448,60 +427,53 @@ func (dq *DocumentQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Doc
 }
 
 func (dq *DocumentQuery) loadMetadata(ctx context.Context, query *MetadataQuery, nodes []*Document, init func(*Document), assign func(*Document, *Metadata)) error {
-	ids := make([]string, 0, len(nodes))
-	nodeids := make(map[string][]*Document)
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[string]*Document)
 	for i := range nodes {
-		fk := nodes[i].MetadataID
-		if _, ok := nodeids[fk]; !ok {
-			ids = append(ids, fk)
-		}
-		nodeids[fk] = append(nodeids[fk], nodes[i])
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
 	}
-	if len(ids) == 0 {
-		return nil
-	}
-	query.Where(metadata.IDIn(ids...))
+	query.Where(predicate.Metadata(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(document.MetadataColumn), fks...))
+	}))
 	neighbors, err := query.All(ctx)
 	if err != nil {
 		return err
 	}
 	for _, n := range neighbors {
-		nodes, ok := nodeids[n.ID]
+		fk := n.ID
+		node, ok := nodeids[fk]
 		if !ok {
-			return fmt.Errorf(`unexpected foreign-key "metadata_id" returned %v`, n.ID)
+			return fmt.Errorf(`unexpected referenced foreign-key "id" returned %v for node %v`, fk, n.ID)
 		}
-		for i := range nodes {
-			assign(nodes[i], n)
-		}
+		assign(node, n)
 	}
 	return nil
 }
 func (dq *DocumentQuery) loadNodeList(ctx context.Context, query *NodeListQuery, nodes []*Document, init func(*Document), assign func(*Document, *NodeList)) error {
-	ids := make([]int, 0, len(nodes))
-	nodeids := make(map[int][]*Document)
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[string]*Document)
 	for i := range nodes {
-		fk := nodes[i].NodeListID
-		if _, ok := nodeids[fk]; !ok {
-			ids = append(ids, fk)
-		}
-		nodeids[fk] = append(nodeids[fk], nodes[i])
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
 	}
-	if len(ids) == 0 {
-		return nil
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(nodelist.FieldDocumentID)
 	}
-	query.Where(nodelist.IDIn(ids...))
+	query.Where(predicate.NodeList(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(document.NodeListColumn), fks...))
+	}))
 	neighbors, err := query.All(ctx)
 	if err != nil {
 		return err
 	}
 	for _, n := range neighbors {
-		nodes, ok := nodeids[n.ID]
+		fk := n.DocumentID
+		node, ok := nodeids[fk]
 		if !ok {
-			return fmt.Errorf(`unexpected foreign-key "node_list_id" returned %v`, n.ID)
+			return fmt.Errorf(`unexpected referenced foreign-key "document_id" returned %v for node %v`, fk, n.ID)
 		}
-		for i := range nodes {
-			assign(nodes[i], n)
-		}
+		assign(node, n)
 	}
 	return nil
 }
@@ -516,7 +488,7 @@ func (dq *DocumentQuery) sqlCount(ctx context.Context) (int, error) {
 }
 
 func (dq *DocumentQuery) querySpec() *sqlgraph.QuerySpec {
-	_spec := sqlgraph.NewQuerySpec(document.Table, document.Columns, sqlgraph.NewFieldSpec(document.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewQuerySpec(document.Table, document.Columns, sqlgraph.NewFieldSpec(document.FieldID, field.TypeString))
 	_spec.From = dq.sql
 	if unique := dq.ctx.Unique; unique != nil {
 		_spec.Unique = *unique
@@ -530,12 +502,6 @@ func (dq *DocumentQuery) querySpec() *sqlgraph.QuerySpec {
 			if fields[i] != document.FieldID {
 				_spec.Node.Columns = append(_spec.Node.Columns, fields[i])
 			}
-		}
-		if dq.withMetadata != nil {
-			_spec.Node.AddColumnOnce(document.FieldMetadataID)
-		}
-		if dq.withNodeList != nil {
-			_spec.Node.AddColumnOnce(document.FieldNodeListID)
 		}
 	}
 	if ps := dq.predicates; len(ps) > 0 {

--- a/internal/backends/ent/document_update.go
+++ b/internal/backends/ent/document_update.go
@@ -63,22 +63,8 @@ func (du *DocumentUpdate) ExecX(ctx context.Context) {
 	}
 }
 
-// check runs all checks and user-defined validators on the builder.
-func (du *DocumentUpdate) check() error {
-	if _, ok := du.mutation.MetadataID(); du.mutation.MetadataCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "Document.metadata"`)
-	}
-	if _, ok := du.mutation.NodeListID(); du.mutation.NodeListCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "Document.node_list"`)
-	}
-	return nil
-}
-
 func (du *DocumentUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	if err := du.check(); err != nil {
-		return n, err
-	}
-	_spec := sqlgraph.NewUpdateSpec(document.Table, document.Columns, sqlgraph.NewFieldSpec(document.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewUpdateSpec(document.Table, document.Columns, sqlgraph.NewFieldSpec(document.FieldID, field.TypeString))
 	if ps := du.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
@@ -151,22 +137,8 @@ func (duo *DocumentUpdateOne) ExecX(ctx context.Context) {
 	}
 }
 
-// check runs all checks and user-defined validators on the builder.
-func (duo *DocumentUpdateOne) check() error {
-	if _, ok := duo.mutation.MetadataID(); duo.mutation.MetadataCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "Document.metadata"`)
-	}
-	if _, ok := duo.mutation.NodeListID(); duo.mutation.NodeListCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "Document.node_list"`)
-	}
-	return nil
-}
-
 func (duo *DocumentUpdateOne) sqlSave(ctx context.Context) (_node *Document, err error) {
-	if err := duo.check(); err != nil {
-		return _node, err
-	}
-	_spec := sqlgraph.NewUpdateSpec(document.Table, document.Columns, sqlgraph.NewFieldSpec(document.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewUpdateSpec(document.Table, document.Columns, sqlgraph.NewFieldSpec(document.FieldID, field.TypeString))
 	id, ok := duo.mutation.ID()
 	if !ok {
 		return nil, &ValidationError{Name: "id", err: errors.New(`ent: missing "Document.id" for update`)}

--- a/internal/backends/ent/metadata.go
+++ b/internal/backends/ent/metadata.go
@@ -13,6 +13,7 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
+	"github.com/protobom/storage/internal/backends/ent/document"
 	"github.com/protobom/storage/internal/backends/ent/metadata"
 )
 
@@ -44,7 +45,7 @@ type MetadataEdges struct {
 	// DocumentTypes holds the value of the document_types edge.
 	DocumentTypes []*DocumentType `json:"document_types,omitempty"`
 	// Document holds the value of the document edge.
-	Document []*Document `json:"document,omitempty"`
+	Document *Document `json:"document,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
 	loadedTypes [4]bool
@@ -78,10 +79,12 @@ func (e MetadataEdges) DocumentTypesOrErr() ([]*DocumentType, error) {
 }
 
 // DocumentOrErr returns the Document value or an error if the edge
-// was not loaded in eager-loading.
-func (e MetadataEdges) DocumentOrErr() ([]*Document, error) {
-	if e.loadedTypes[3] {
+// was not loaded in eager-loading, or loaded but was not found.
+func (e MetadataEdges) DocumentOrErr() (*Document, error) {
+	if e.Document != nil {
 		return e.Document, nil
+	} else if e.loadedTypes[3] {
+		return nil, &NotFoundError{label: document.Label}
 	}
 	return nil, &NotLoadedError{edge: "document"}
 }

--- a/internal/backends/ent/metadata/metadata.go
+++ b/internal/backends/ent/metadata/metadata.go
@@ -57,12 +57,12 @@ const (
 	// DocumentTypesColumn is the table column denoting the document_types relation/edge.
 	DocumentTypesColumn = "metadata_id"
 	// DocumentTable is the table that holds the document relation/edge.
-	DocumentTable = "documents"
+	DocumentTable = "metadata"
 	// DocumentInverseTable is the table name for the Document entity.
 	// It exists in this package in order to avoid circular dependency with the "document" package.
 	DocumentInverseTable = "documents"
 	// DocumentColumn is the table column denoting the document relation/edge.
-	DocumentColumn = "metadata_id"
+	DocumentColumn = "id"
 )
 
 // Columns holds all SQL columns for metadata fields.
@@ -159,17 +159,10 @@ func ByDocumentTypes(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	}
 }
 
-// ByDocumentCount orders the results by document count.
-func ByDocumentCount(opts ...sql.OrderTermOption) OrderOption {
+// ByDocumentField orders the results by document field.
+func ByDocumentField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborsCount(s, newDocumentStep(), opts...)
-	}
-}
-
-// ByDocument orders the results by document terms.
-func ByDocument(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newDocumentStep(), append([]sql.OrderTerm{term}, terms...)...)
+		sqlgraph.OrderByNeighborTerms(s, newDocumentStep(), sql.OrderByField(field, opts...))
 	}
 }
 func newToolsStep() *sqlgraph.Step {
@@ -197,6 +190,6 @@ func newDocumentStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(DocumentInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2M, false, DocumentTable, DocumentColumn),
+		sqlgraph.Edge(sqlgraph.O2O, true, DocumentTable, DocumentColumn),
 	)
 }

--- a/internal/backends/ent/metadata/where.go
+++ b/internal/backends/ent/metadata/where.go
@@ -399,7 +399,7 @@ func HasDocument() predicate.Metadata {
 	return predicate.Metadata(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, DocumentTable, DocumentColumn),
+			sqlgraph.Edge(sqlgraph.O2O, true, DocumentTable, DocumentColumn),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})

--- a/internal/backends/ent/metadata_query.go
+++ b/internal/backends/ent/metadata_query.go
@@ -150,7 +150,7 @@ func (mq *MetadataQuery) QueryDocument() *DocumentQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(metadata.Table, metadata.FieldID, selector),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, metadata.DocumentTable, metadata.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.O2O, true, metadata.DocumentTable, metadata.DocumentColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(mq.driver.Dialect(), step)
 		return fromU, nil
@@ -529,9 +529,8 @@ func (mq *MetadataQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Met
 		}
 	}
 	if query := mq.withDocument; query != nil {
-		if err := mq.loadDocument(ctx, query, nodes,
-			func(n *Metadata) { n.Edges.Document = []*Document{} },
-			func(n *Metadata, e *Document) { n.Edges.Document = append(n.Edges.Document, e) }); err != nil {
+		if err := mq.loadDocument(ctx, query, nodes, nil,
+			func(n *Metadata, e *Document) { n.Edges.Document = e }); err != nil {
 			return nil, err
 		}
 	}
@@ -630,32 +629,31 @@ func (mq *MetadataQuery) loadDocumentTypes(ctx context.Context, query *DocumentT
 	return nil
 }
 func (mq *MetadataQuery) loadDocument(ctx context.Context, query *DocumentQuery, nodes []*Metadata, init func(*Metadata), assign func(*Metadata, *Document)) error {
-	fks := make([]driver.Value, 0, len(nodes))
-	nodeids := make(map[string]*Metadata)
+	ids := make([]string, 0, len(nodes))
+	nodeids := make(map[string][]*Metadata)
 	for i := range nodes {
-		fks = append(fks, nodes[i].ID)
-		nodeids[nodes[i].ID] = nodes[i]
-		if init != nil {
-			init(nodes[i])
+		fk := nodes[i].ID
+		if _, ok := nodeids[fk]; !ok {
+			ids = append(ids, fk)
 		}
+		nodeids[fk] = append(nodeids[fk], nodes[i])
 	}
-	if len(query.ctx.Fields) > 0 {
-		query.ctx.AppendFieldOnce(document.FieldMetadataID)
+	if len(ids) == 0 {
+		return nil
 	}
-	query.Where(predicate.Document(func(s *sql.Selector) {
-		s.Where(sql.InValues(s.C(metadata.DocumentColumn), fks...))
-	}))
+	query.Where(document.IDIn(ids...))
 	neighbors, err := query.All(ctx)
 	if err != nil {
 		return err
 	}
 	for _, n := range neighbors {
-		fk := n.MetadataID
-		node, ok := nodeids[fk]
+		nodes, ok := nodeids[n.ID]
 		if !ok {
-			return fmt.Errorf(`unexpected referenced foreign-key "metadata_id" returned %v for node %v`, fk, n.ID)
+			return fmt.Errorf(`unexpected foreign-key "id" returned %v`, n.ID)
 		}
-		assign(node, n)
+		for i := range nodes {
+			assign(nodes[i], n)
+		}
 	}
 	return nil
 }

--- a/internal/backends/ent/migrate/schema.go
+++ b/internal/backends/ent/migrate/schema.go
@@ -41,9 +41,9 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "document_metadata_id_node_list_id",
+				Name:    "document_metadata_id",
 				Unique:  true,
-				Columns: []*schema.Column{DocumentsColumns[1], DocumentsColumns[2]},
+				Columns: []*schema.Column{DocumentsColumns[1]},
 			},
 		},
 	}
@@ -139,9 +139,9 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "externalreference_node_id",
+				Name:    "externalreference_node_id_url_type",
 				Unique:  true,
-				Columns: []*schema.Column{ExternalReferencesColumns[5]},
+				Columns: []*schema.Column{ExternalReferencesColumns[5], ExternalReferencesColumns[1], ExternalReferencesColumns[4]},
 			},
 		},
 	}
@@ -284,13 +284,6 @@ var (
 		Name:       "node_lists",
 		Columns:    NodeListsColumns,
 		PrimaryKey: []*schema.Column{NodeListsColumns[0]},
-		Indexes: []*schema.Index{
-			{
-				Name:    "nodelist_root_elements",
-				Unique:  true,
-				Columns: []*schema.Column{NodeListsColumns[1]},
-			},
-		},
 	}
 	// PersonsColumns holds the columns for the "persons" table.
 	PersonsColumns = []*schema.Column{

--- a/internal/backends/ent/migrate/schema.go
+++ b/internal/backends/ent/migrate/schema.go
@@ -16,36 +16,13 @@ import (
 var (
 	// DocumentsColumns holds the columns for the "documents" table.
 	DocumentsColumns = []*schema.Column{
-		{Name: "id", Type: field.TypeInt, Increment: true},
-		{Name: "metadata_id", Type: field.TypeString},
-		{Name: "node_list_id", Type: field.TypeInt, Unique: true},
+		{Name: "id", Type: field.TypeString, Unique: true},
 	}
 	// DocumentsTable holds the schema information for the "documents" table.
 	DocumentsTable = &schema.Table{
 		Name:       "documents",
 		Columns:    DocumentsColumns,
 		PrimaryKey: []*schema.Column{DocumentsColumns[0]},
-		ForeignKeys: []*schema.ForeignKey{
-			{
-				Symbol:     "documents_metadata_document",
-				Columns:    []*schema.Column{DocumentsColumns[1]},
-				RefColumns: []*schema.Column{MetadataColumns[0]},
-				OnDelete:   schema.NoAction,
-			},
-			{
-				Symbol:     "documents_node_lists_document",
-				Columns:    []*schema.Column{DocumentsColumns[2]},
-				RefColumns: []*schema.Column{NodeListsColumns[0]},
-				OnDelete:   schema.NoAction,
-			},
-		},
-		Indexes: []*schema.Index{
-			{
-				Name:    "document_metadata_id",
-				Unique:  true,
-				Columns: []*schema.Column{DocumentsColumns[1]},
-			},
-		},
 	}
 	// DocumentTypesColumns holds the columns for the "document_types" table.
 	DocumentTypesColumns = []*schema.Column{
@@ -221,6 +198,14 @@ var (
 		Name:       "metadata",
 		Columns:    MetadataColumns,
 		PrimaryKey: []*schema.Column{MetadataColumns[0]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "metadata_documents_metadata",
+				Columns:    []*schema.Column{MetadataColumns[0]},
+				RefColumns: []*schema.Column{DocumentsColumns[0]},
+				OnDelete:   schema.NoAction,
+			},
+		},
 		Indexes: []*schema.Index{
 			{
 				Name:    "metadata_id_version_name",
@@ -278,12 +263,31 @@ var (
 	NodeListsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "root_elements", Type: field.TypeJSON},
+		{Name: "document_id", Type: field.TypeString, Unique: true},
 	}
 	// NodeListsTable holds the schema information for the "node_lists" table.
 	NodeListsTable = &schema.Table{
 		Name:       "node_lists",
 		Columns:    NodeListsColumns,
 		PrimaryKey: []*schema.Column{NodeListsColumns[0]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "node_lists_documents_node_list",
+				Columns:    []*schema.Column{NodeListsColumns[2]},
+				RefColumns: []*schema.Column{DocumentsColumns[0]},
+				OnDelete:   schema.NoAction,
+			},
+		},
+		Indexes: []*schema.Index{
+			{
+				Name:    "nodelist_document_id_root_elements",
+				Unique:  true,
+				Columns: []*schema.Column{NodeListsColumns[2], NodeListsColumns[1]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "root_elements IS NOT NULL",
+				},
+			},
+		},
 	}
 	// PersonsColumns holds the columns for the "persons" table.
 	PersonsColumns = []*schema.Column{
@@ -422,8 +426,6 @@ var (
 )
 
 func init() {
-	DocumentsTable.ForeignKeys[0].RefTable = MetadataTable
-	DocumentsTable.ForeignKeys[1].RefTable = NodeListsTable
 	DocumentTypesTable.ForeignKeys[0].RefTable = MetadataTable
 	EdgeTypesTable.ForeignKeys[0].RefTable = NodesTable
 	EdgeTypesTable.ForeignKeys[1].RefTable = NodesTable
@@ -431,7 +433,9 @@ func init() {
 	HashesEntriesTable.ForeignKeys[0].RefTable = ExternalReferencesTable
 	HashesEntriesTable.ForeignKeys[1].RefTable = NodesTable
 	IdentifiersEntriesTable.ForeignKeys[0].RefTable = NodesTable
+	MetadataTable.ForeignKeys[0].RefTable = DocumentsTable
 	NodesTable.ForeignKeys[0].RefTable = NodeListsTable
+	NodeListsTable.ForeignKeys[0].RefTable = DocumentsTable
 	PersonsTable.ForeignKeys[0].RefTable = MetadataTable
 	PersonsTable.ForeignKeys[1].RefTable = NodesTable
 	PersonsTable.ForeignKeys[2].RefTable = NodesTable

--- a/internal/backends/ent/mutation.go
+++ b/internal/backends/ent/mutation.go
@@ -58,7 +58,7 @@ type DocumentMutation struct {
 	config
 	op               Op
 	typ              string
-	id               *int
+	id               *string
 	clearedFields    map[string]struct{}
 	metadata         *string
 	clearedmetadata  bool
@@ -89,7 +89,7 @@ func newDocumentMutation(c config, op Op, opts ...documentOption) *DocumentMutat
 }
 
 // withDocumentID sets the ID field of the mutation.
-func withDocumentID(id int) documentOption {
+func withDocumentID(id string) documentOption {
 	return func(m *DocumentMutation) {
 		var (
 			err   error
@@ -139,9 +139,15 @@ func (m DocumentMutation) Tx() (*Tx, error) {
 	return tx, nil
 }
 
+// SetID sets the value of the id field. Note that this
+// operation is only accepted on creation of Document entities.
+func (m *DocumentMutation) SetID(id string) {
+	m.id = &id
+}
+
 // ID returns the ID value in the mutation. Note that the ID is only available
 // if it was provided to the builder or after it was returned from the database.
-func (m *DocumentMutation) ID() (id int, exists bool) {
+func (m *DocumentMutation) ID() (id string, exists bool) {
 	if m.id == nil {
 		return
 	}
@@ -152,12 +158,12 @@ func (m *DocumentMutation) ID() (id int, exists bool) {
 // That means, if the mutation is applied within a transaction with an isolation level such
 // as sql.LevelSerializable, the returned ids match the ids of the rows that will be updated
 // or updated by the mutation.
-func (m *DocumentMutation) IDs(ctx context.Context) ([]int, error) {
+func (m *DocumentMutation) IDs(ctx context.Context) ([]string, error) {
 	switch {
 	case m.op.Is(OpUpdateOne | OpDeleteOne):
 		id, exists := m.ID()
 		if exists {
-			return []int{id}, nil
+			return []string{id}, nil
 		}
 		fallthrough
 	case m.op.Is(OpUpdate | OpDelete):
@@ -167,87 +173,27 @@ func (m *DocumentMutation) IDs(ctx context.Context) ([]int, error) {
 	}
 }
 
-// SetMetadataID sets the "metadata_id" field.
-func (m *DocumentMutation) SetMetadataID(s string) {
-	m.metadata = &s
-}
-
-// MetadataID returns the value of the "metadata_id" field in the mutation.
-func (m *DocumentMutation) MetadataID() (r string, exists bool) {
-	v := m.metadata
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldMetadataID returns the old "metadata_id" field's value of the Document entity.
-// If the Document object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *DocumentMutation) OldMetadataID(ctx context.Context) (v string, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldMetadataID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldMetadataID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldMetadataID: %w", err)
-	}
-	return oldValue.MetadataID, nil
-}
-
-// ResetMetadataID resets all changes to the "metadata_id" field.
-func (m *DocumentMutation) ResetMetadataID() {
-	m.metadata = nil
-}
-
-// SetNodeListID sets the "node_list_id" field.
-func (m *DocumentMutation) SetNodeListID(i int) {
-	m.node_list = &i
-}
-
-// NodeListID returns the value of the "node_list_id" field in the mutation.
-func (m *DocumentMutation) NodeListID() (r int, exists bool) {
-	v := m.node_list
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldNodeListID returns the old "node_list_id" field's value of the Document entity.
-// If the Document object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *DocumentMutation) OldNodeListID(ctx context.Context) (v int, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldNodeListID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldNodeListID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldNodeListID: %w", err)
-	}
-	return oldValue.NodeListID, nil
-}
-
-// ResetNodeListID resets all changes to the "node_list_id" field.
-func (m *DocumentMutation) ResetNodeListID() {
-	m.node_list = nil
+// SetMetadataID sets the "metadata" edge to the Metadata entity by id.
+func (m *DocumentMutation) SetMetadataID(id string) {
+	m.metadata = &id
 }
 
 // ClearMetadata clears the "metadata" edge to the Metadata entity.
 func (m *DocumentMutation) ClearMetadata() {
 	m.clearedmetadata = true
-	m.clearedFields[document.FieldMetadataID] = struct{}{}
 }
 
 // MetadataCleared reports if the "metadata" edge to the Metadata entity was cleared.
 func (m *DocumentMutation) MetadataCleared() bool {
 	return m.clearedmetadata
+}
+
+// MetadataID returns the "metadata" edge ID in the mutation.
+func (m *DocumentMutation) MetadataID() (id string, exists bool) {
+	if m.metadata != nil {
+		return *m.metadata, true
+	}
+	return
 }
 
 // MetadataIDs returns the "metadata" edge IDs in the mutation.
@@ -266,15 +212,27 @@ func (m *DocumentMutation) ResetMetadata() {
 	m.clearedmetadata = false
 }
 
+// SetNodeListID sets the "node_list" edge to the NodeList entity by id.
+func (m *DocumentMutation) SetNodeListID(id int) {
+	m.node_list = &id
+}
+
 // ClearNodeList clears the "node_list" edge to the NodeList entity.
 func (m *DocumentMutation) ClearNodeList() {
 	m.clearednode_list = true
-	m.clearedFields[document.FieldNodeListID] = struct{}{}
 }
 
 // NodeListCleared reports if the "node_list" edge to the NodeList entity was cleared.
 func (m *DocumentMutation) NodeListCleared() bool {
 	return m.clearednode_list
+}
+
+// NodeListID returns the "node_list" edge ID in the mutation.
+func (m *DocumentMutation) NodeListID() (id int, exists bool) {
+	if m.node_list != nil {
+		return *m.node_list, true
+	}
+	return
 }
 
 // NodeListIDs returns the "node_list" edge IDs in the mutation.
@@ -327,13 +285,7 @@ func (m *DocumentMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *DocumentMutation) Fields() []string {
-	fields := make([]string, 0, 2)
-	if m.metadata != nil {
-		fields = append(fields, document.FieldMetadataID)
-	}
-	if m.node_list != nil {
-		fields = append(fields, document.FieldNodeListID)
-	}
+	fields := make([]string, 0, 0)
 	return fields
 }
 
@@ -341,12 +293,6 @@ func (m *DocumentMutation) Fields() []string {
 // return value indicates that this field was not set, or was not defined in the
 // schema.
 func (m *DocumentMutation) Field(name string) (ent.Value, bool) {
-	switch name {
-	case document.FieldMetadataID:
-		return m.MetadataID()
-	case document.FieldNodeListID:
-		return m.NodeListID()
-	}
 	return nil, false
 }
 
@@ -354,12 +300,6 @@ func (m *DocumentMutation) Field(name string) (ent.Value, bool) {
 // returned if the mutation operation is not UpdateOne, or the query to the
 // database failed.
 func (m *DocumentMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
-	switch name {
-	case document.FieldMetadataID:
-		return m.OldMetadataID(ctx)
-	case document.FieldNodeListID:
-		return m.OldNodeListID(ctx)
-	}
 	return nil, fmt.Errorf("unknown Document field %s", name)
 }
 
@@ -368,20 +308,6 @@ func (m *DocumentMutation) OldField(ctx context.Context, name string) (ent.Value
 // type.
 func (m *DocumentMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case document.FieldMetadataID:
-		v, ok := value.(string)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetMetadataID(v)
-		return nil
-	case document.FieldNodeListID:
-		v, ok := value.(int)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetNodeListID(v)
-		return nil
 	}
 	return fmt.Errorf("unknown Document field %s", name)
 }
@@ -389,16 +315,13 @@ func (m *DocumentMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *DocumentMutation) AddedFields() []string {
-	var fields []string
-	return fields
+	return nil
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *DocumentMutation) AddedField(name string) (ent.Value, bool) {
-	switch name {
-	}
 	return nil, false
 }
 
@@ -406,8 +329,6 @@ func (m *DocumentMutation) AddedField(name string) (ent.Value, bool) {
 // the field is not defined in the schema, or if the type mismatched the field
 // type.
 func (m *DocumentMutation) AddField(name string, value ent.Value) error {
-	switch name {
-	}
 	return fmt.Errorf("unknown Document numeric field %s", name)
 }
 
@@ -433,14 +354,6 @@ func (m *DocumentMutation) ClearField(name string) error {
 // ResetField resets all changes in the mutation for the field with the given name.
 // It returns an error if the field is not defined in the schema.
 func (m *DocumentMutation) ResetField(name string) error {
-	switch name {
-	case document.FieldMetadataID:
-		m.ResetMetadataID()
-		return nil
-	case document.FieldNodeListID:
-		m.ResetNodeListID()
-		return nil
-	}
 	return fmt.Errorf("unknown Document field %s", name)
 }
 
@@ -3412,8 +3325,7 @@ type MetadataMutation struct {
 	document_types        map[int]struct{}
 	removeddocument_types map[int]struct{}
 	cleareddocument_types bool
-	document              map[int]struct{}
-	removeddocument       map[int]struct{}
+	document              *string
 	cleareddocument       bool
 	done                  bool
 	oldValue              func(context.Context) (*Metadata, error)
@@ -3830,14 +3742,9 @@ func (m *MetadataMutation) ResetDocumentTypes() {
 	m.removeddocument_types = nil
 }
 
-// AddDocumentIDs adds the "document" edge to the Document entity by ids.
-func (m *MetadataMutation) AddDocumentIDs(ids ...int) {
-	if m.document == nil {
-		m.document = make(map[int]struct{})
-	}
-	for i := range ids {
-		m.document[ids[i]] = struct{}{}
-	}
+// SetDocumentID sets the "document" edge to the Document entity by id.
+func (m *MetadataMutation) SetDocumentID(id string) {
+	m.document = &id
 }
 
 // ClearDocument clears the "document" edge to the Document entity.
@@ -3850,29 +3757,20 @@ func (m *MetadataMutation) DocumentCleared() bool {
 	return m.cleareddocument
 }
 
-// RemoveDocumentIDs removes the "document" edge to the Document entity by IDs.
-func (m *MetadataMutation) RemoveDocumentIDs(ids ...int) {
-	if m.removeddocument == nil {
-		m.removeddocument = make(map[int]struct{})
-	}
-	for i := range ids {
-		delete(m.document, ids[i])
-		m.removeddocument[ids[i]] = struct{}{}
-	}
-}
-
-// RemovedDocument returns the removed IDs of the "document" edge to the Document entity.
-func (m *MetadataMutation) RemovedDocumentIDs() (ids []int) {
-	for id := range m.removeddocument {
-		ids = append(ids, id)
+// DocumentID returns the "document" edge ID in the mutation.
+func (m *MetadataMutation) DocumentID() (id string, exists bool) {
+	if m.document != nil {
+		return *m.document, true
 	}
 	return
 }
 
 // DocumentIDs returns the "document" edge IDs in the mutation.
-func (m *MetadataMutation) DocumentIDs() (ids []int) {
-	for id := range m.document {
-		ids = append(ids, id)
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// DocumentID instead. It exists only for internal usage by the builders.
+func (m *MetadataMutation) DocumentIDs() (ids []string) {
+	if id := m.document; id != nil {
+		ids = append(ids, *id)
 	}
 	return
 }
@@ -3881,7 +3779,6 @@ func (m *MetadataMutation) DocumentIDs() (ids []int) {
 func (m *MetadataMutation) ResetDocument() {
 	m.document = nil
 	m.cleareddocument = false
-	m.removeddocument = nil
 }
 
 // Where appends a list predicates to the MetadataMutation builder.
@@ -4107,11 +4004,9 @@ func (m *MetadataMutation) AddedIDs(name string) []ent.Value {
 		}
 		return ids
 	case metadata.EdgeDocument:
-		ids := make([]ent.Value, 0, len(m.document))
-		for id := range m.document {
-			ids = append(ids, id)
+		if id := m.document; id != nil {
+			return []ent.Value{*id}
 		}
-		return ids
 	}
 	return nil
 }
@@ -4127,9 +4022,6 @@ func (m *MetadataMutation) RemovedEdges() []string {
 	}
 	if m.removeddocument_types != nil {
 		edges = append(edges, metadata.EdgeDocumentTypes)
-	}
-	if m.removeddocument != nil {
-		edges = append(edges, metadata.EdgeDocument)
 	}
 	return edges
 }
@@ -4153,12 +4045,6 @@ func (m *MetadataMutation) RemovedIDs(name string) []ent.Value {
 	case metadata.EdgeDocumentTypes:
 		ids := make([]ent.Value, 0, len(m.removeddocument_types))
 		for id := range m.removeddocument_types {
-			ids = append(ids, id)
-		}
-		return ids
-	case metadata.EdgeDocument:
-		ids := make([]ent.Value, 0, len(m.removeddocument))
-		for id := range m.removeddocument {
 			ids = append(ids, id)
 		}
 		return ids
@@ -4204,6 +4090,9 @@ func (m *MetadataMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *MetadataMutation) ClearEdge(name string) error {
 	switch name {
+	case metadata.EdgeDocument:
+		m.ClearDocument()
+		return nil
 	}
 	return fmt.Errorf("unknown Metadata unique edge %s", name)
 }
@@ -6474,7 +6363,7 @@ type NodeListMutation struct {
 	nodes               map[string]struct{}
 	removednodes        map[string]struct{}
 	clearednodes        bool
-	document            *int
+	document            *string
 	cleareddocument     bool
 	done                bool
 	oldValue            func(context.Context) (*NodeList, error)
@@ -6577,6 +6466,42 @@ func (m *NodeListMutation) IDs(ctx context.Context) ([]int, error) {
 	default:
 		return nil, fmt.Errorf("IDs is not allowed on %s operations", m.op)
 	}
+}
+
+// SetDocumentID sets the "document_id" field.
+func (m *NodeListMutation) SetDocumentID(s string) {
+	m.document = &s
+}
+
+// DocumentID returns the value of the "document_id" field in the mutation.
+func (m *NodeListMutation) DocumentID() (r string, exists bool) {
+	v := m.document
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentID returns the old "document_id" field's value of the NodeList entity.
+// If the NodeList object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *NodeListMutation) OldDocumentID(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
+	}
+	return oldValue.DocumentID, nil
+}
+
+// ResetDocumentID resets all changes to the "document_id" field.
+func (m *NodeListMutation) ResetDocumentID() {
+	m.document = nil
 }
 
 // SetRootElements sets the "root_elements" field.
@@ -6684,14 +6609,10 @@ func (m *NodeListMutation) ResetNodes() {
 	m.removednodes = nil
 }
 
-// SetDocumentID sets the "document" edge to the Document entity by id.
-func (m *NodeListMutation) SetDocumentID(id int) {
-	m.document = &id
-}
-
 // ClearDocument clears the "document" edge to the Document entity.
 func (m *NodeListMutation) ClearDocument() {
 	m.cleareddocument = true
+	m.clearedFields[nodelist.FieldDocumentID] = struct{}{}
 }
 
 // DocumentCleared reports if the "document" edge to the Document entity was cleared.
@@ -6699,18 +6620,10 @@ func (m *NodeListMutation) DocumentCleared() bool {
 	return m.cleareddocument
 }
 
-// DocumentID returns the "document" edge ID in the mutation.
-func (m *NodeListMutation) DocumentID() (id int, exists bool) {
-	if m.document != nil {
-		return *m.document, true
-	}
-	return
-}
-
 // DocumentIDs returns the "document" edge IDs in the mutation.
 // Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
 // DocumentID instead. It exists only for internal usage by the builders.
-func (m *NodeListMutation) DocumentIDs() (ids []int) {
+func (m *NodeListMutation) DocumentIDs() (ids []string) {
 	if id := m.document; id != nil {
 		ids = append(ids, *id)
 	}
@@ -6757,7 +6670,10 @@ func (m *NodeListMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *NodeListMutation) Fields() []string {
-	fields := make([]string, 0, 1)
+	fields := make([]string, 0, 2)
+	if m.document != nil {
+		fields = append(fields, nodelist.FieldDocumentID)
+	}
 	if m.root_elements != nil {
 		fields = append(fields, nodelist.FieldRootElements)
 	}
@@ -6769,6 +6685,8 @@ func (m *NodeListMutation) Fields() []string {
 // schema.
 func (m *NodeListMutation) Field(name string) (ent.Value, bool) {
 	switch name {
+	case nodelist.FieldDocumentID:
+		return m.DocumentID()
 	case nodelist.FieldRootElements:
 		return m.RootElements()
 	}
@@ -6780,6 +6698,8 @@ func (m *NodeListMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *NodeListMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
+	case nodelist.FieldDocumentID:
+		return m.OldDocumentID(ctx)
 	case nodelist.FieldRootElements:
 		return m.OldRootElements(ctx)
 	}
@@ -6791,6 +6711,13 @@ func (m *NodeListMutation) OldField(ctx context.Context, name string) (ent.Value
 // type.
 func (m *NodeListMutation) SetField(name string, value ent.Value) error {
 	switch name {
+	case nodelist.FieldDocumentID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentID(v)
+		return nil
 	case nodelist.FieldRootElements:
 		v, ok := value.([]string)
 		if !ok {
@@ -6847,6 +6774,9 @@ func (m *NodeListMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *NodeListMutation) ResetField(name string) error {
 	switch name {
+	case nodelist.FieldDocumentID:
+		m.ResetDocumentID()
+		return nil
 	case nodelist.FieldRootElements:
 		m.ResetRootElements()
 		return nil

--- a/internal/backends/ent/nodelist.go
+++ b/internal/backends/ent/nodelist.go
@@ -22,6 +22,8 @@ type NodeList struct {
 	config `json:"-"`
 	// ID of the ent.
 	ID int `json:"id,omitempty"`
+	// DocumentID holds the value of the "document_id" field.
+	DocumentID string `json:"document_id,omitempty"`
 	// RootElements holds the value of the "root_elements" field.
 	RootElements []string `json:"root_elements,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -70,6 +72,8 @@ func (*NodeList) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case nodelist.FieldID:
 			values[i] = new(sql.NullInt64)
+		case nodelist.FieldDocumentID:
+			values[i] = new(sql.NullString)
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -91,6 +95,12 @@ func (nl *NodeList) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field id", value)
 			}
 			nl.ID = int(value.Int64)
+		case nodelist.FieldDocumentID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_id", values[i])
+			} else if value.Valid {
+				nl.DocumentID = value.String
+			}
 		case nodelist.FieldRootElements:
 			if value, ok := values[i].(*[]byte); !ok {
 				return fmt.Errorf("unexpected type %T for field root_elements", values[i])
@@ -145,6 +155,9 @@ func (nl *NodeList) String() string {
 	var builder strings.Builder
 	builder.WriteString("NodeList(")
 	builder.WriteString(fmt.Sprintf("id=%v, ", nl.ID))
+	builder.WriteString("document_id=")
+	builder.WriteString(nl.DocumentID)
+	builder.WriteString(", ")
 	builder.WriteString("root_elements=")
 	builder.WriteString(fmt.Sprintf("%v", nl.RootElements))
 	builder.WriteByte(')')

--- a/internal/backends/ent/nodelist/nodelist.go
+++ b/internal/backends/ent/nodelist/nodelist.go
@@ -17,6 +17,8 @@ const (
 	Label = "node_list"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
+	// FieldDocumentID holds the string denoting the document_id field in the database.
+	FieldDocumentID = "document_id"
 	// FieldRootElements holds the string denoting the root_elements field in the database.
 	FieldRootElements = "root_elements"
 	// EdgeNodes holds the string denoting the nodes edge name in mutations.
@@ -33,17 +35,18 @@ const (
 	// NodesColumn is the table column denoting the nodes relation/edge.
 	NodesColumn = "node_list_id"
 	// DocumentTable is the table that holds the document relation/edge.
-	DocumentTable = "documents"
+	DocumentTable = "node_lists"
 	// DocumentInverseTable is the table name for the Document entity.
 	// It exists in this package in order to avoid circular dependency with the "document" package.
 	DocumentInverseTable = "documents"
 	// DocumentColumn is the table column denoting the document relation/edge.
-	DocumentColumn = "node_list_id"
+	DocumentColumn = "document_id"
 )
 
 // Columns holds all SQL columns for nodelist fields.
 var Columns = []string{
 	FieldID,
+	FieldDocumentID,
 	FieldRootElements,
 }
 
@@ -63,6 +66,11 @@ type OrderOption func(*sql.Selector)
 // ByID orders the results by the id field.
 func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByDocumentID orders the results by the document_id field.
+func ByDocumentID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentID, opts...).ToFunc()
 }
 
 // ByNodesCount orders the results by nodes count.
@@ -96,6 +104,6 @@ func newDocumentStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(DocumentInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2O, false, DocumentTable, DocumentColumn),
+		sqlgraph.Edge(sqlgraph.O2O, true, DocumentTable, DocumentColumn),
 	)
 }

--- a/internal/backends/ent/nodelist/where.go
+++ b/internal/backends/ent/nodelist/where.go
@@ -58,6 +58,76 @@ func IDLTE(id int) predicate.NodeList {
 	return predicate.NodeList(sql.FieldLTE(FieldID, id))
 }
 
+// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
+func DocumentID(v string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldEQ(FieldDocumentID, v))
+}
+
+// DocumentIDEQ applies the EQ predicate on the "document_id" field.
+func DocumentIDEQ(v string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldEQ(FieldDocumentID, v))
+}
+
+// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
+func DocumentIDNEQ(v string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldNEQ(FieldDocumentID, v))
+}
+
+// DocumentIDIn applies the In predicate on the "document_id" field.
+func DocumentIDIn(vs ...string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldIn(FieldDocumentID, vs...))
+}
+
+// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
+func DocumentIDNotIn(vs ...string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldNotIn(FieldDocumentID, vs...))
+}
+
+// DocumentIDGT applies the GT predicate on the "document_id" field.
+func DocumentIDGT(v string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldGT(FieldDocumentID, v))
+}
+
+// DocumentIDGTE applies the GTE predicate on the "document_id" field.
+func DocumentIDGTE(v string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldGTE(FieldDocumentID, v))
+}
+
+// DocumentIDLT applies the LT predicate on the "document_id" field.
+func DocumentIDLT(v string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldLT(FieldDocumentID, v))
+}
+
+// DocumentIDLTE applies the LTE predicate on the "document_id" field.
+func DocumentIDLTE(v string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldLTE(FieldDocumentID, v))
+}
+
+// DocumentIDContains applies the Contains predicate on the "document_id" field.
+func DocumentIDContains(v string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldContains(FieldDocumentID, v))
+}
+
+// DocumentIDHasPrefix applies the HasPrefix predicate on the "document_id" field.
+func DocumentIDHasPrefix(v string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldHasPrefix(FieldDocumentID, v))
+}
+
+// DocumentIDHasSuffix applies the HasSuffix predicate on the "document_id" field.
+func DocumentIDHasSuffix(v string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldHasSuffix(FieldDocumentID, v))
+}
+
+// DocumentIDEqualFold applies the EqualFold predicate on the "document_id" field.
+func DocumentIDEqualFold(v string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldEqualFold(FieldDocumentID, v))
+}
+
+// DocumentIDContainsFold applies the ContainsFold predicate on the "document_id" field.
+func DocumentIDContainsFold(v string) predicate.NodeList {
+	return predicate.NodeList(sql.FieldContainsFold(FieldDocumentID, v))
+}
+
 // HasNodes applies the HasEdge predicate on the "nodes" edge.
 func HasNodes() predicate.NodeList {
 	return predicate.NodeList(func(s *sql.Selector) {
@@ -86,7 +156,7 @@ func HasDocument() predicate.NodeList {
 	return predicate.NodeList(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, DocumentTable, DocumentColumn),
+			sqlgraph.Edge(sqlgraph.O2O, true, DocumentTable, DocumentColumn),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})

--- a/internal/backends/ent/nodelist_create.go
+++ b/internal/backends/ent/nodelist_create.go
@@ -27,6 +27,12 @@ type NodeListCreate struct {
 	conflict []sql.ConflictOption
 }
 
+// SetDocumentID sets the "document_id" field.
+func (nlc *NodeListCreate) SetDocumentID(s string) *NodeListCreate {
+	nlc.mutation.SetDocumentID(s)
+	return nlc
+}
+
 // SetRootElements sets the "root_elements" field.
 func (nlc *NodeListCreate) SetRootElements(s []string) *NodeListCreate {
 	nlc.mutation.SetRootElements(s)
@@ -46,20 +52,6 @@ func (nlc *NodeListCreate) AddNodes(n ...*Node) *NodeListCreate {
 		ids[i] = n[i].ID
 	}
 	return nlc.AddNodeIDs(ids...)
-}
-
-// SetDocumentID sets the "document" edge to the Document entity by ID.
-func (nlc *NodeListCreate) SetDocumentID(id int) *NodeListCreate {
-	nlc.mutation.SetDocumentID(id)
-	return nlc
-}
-
-// SetNillableDocumentID sets the "document" edge to the Document entity by ID if the given value is not nil.
-func (nlc *NodeListCreate) SetNillableDocumentID(id *int) *NodeListCreate {
-	if id != nil {
-		nlc = nlc.SetDocumentID(*id)
-	}
-	return nlc
 }
 
 // SetDocument sets the "document" edge to the Document entity.
@@ -101,8 +93,14 @@ func (nlc *NodeListCreate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (nlc *NodeListCreate) check() error {
+	if _, ok := nlc.mutation.DocumentID(); !ok {
+		return &ValidationError{Name: "document_id", err: errors.New(`ent: missing required field "NodeList.document_id"`)}
+	}
 	if _, ok := nlc.mutation.RootElements(); !ok {
 		return &ValidationError{Name: "root_elements", err: errors.New(`ent: missing required field "NodeList.root_elements"`)}
+	}
+	if _, ok := nlc.mutation.DocumentID(); !ok {
+		return &ValidationError{Name: "document", err: errors.New(`ent: missing required edge "NodeList.document"`)}
 	}
 	return nil
 }
@@ -154,17 +152,18 @@ func (nlc *NodeListCreate) createSpec() (*NodeList, *sqlgraph.CreateSpec) {
 	if nodes := nlc.mutation.DocumentIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2O,
-			Inverse: false,
+			Inverse: true,
 			Table:   nodelist.DocumentTable,
 			Columns: []string{nodelist.DocumentColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
+		_node.DocumentID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec
@@ -174,7 +173,7 @@ func (nlc *NodeListCreate) createSpec() (*NodeList, *sqlgraph.CreateSpec) {
 // of the `INSERT` statement. For example:
 //
 //	client.NodeList.Create().
-//		SetRootElements(v).
+//		SetDocumentID(v).
 //		OnConflict(
 //			// Update the row with the new values
 //			// the was proposed for insertion.
@@ -183,7 +182,7 @@ func (nlc *NodeListCreate) createSpec() (*NodeList, *sqlgraph.CreateSpec) {
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.NodeListUpsert) {
-//			SetRootElements(v+v).
+//			SetDocumentID(v+v).
 //		}).
 //		Exec(ctx)
 func (nlc *NodeListCreate) OnConflict(opts ...sql.ConflictOption) *NodeListUpsertOne {
@@ -218,6 +217,18 @@ type (
 		*sql.UpdateSet
 	}
 )
+
+// SetDocumentID sets the "document_id" field.
+func (u *NodeListUpsert) SetDocumentID(v string) *NodeListUpsert {
+	u.Set(nodelist.FieldDocumentID, v)
+	return u
+}
+
+// UpdateDocumentID sets the "document_id" field to the value that was provided on create.
+func (u *NodeListUpsert) UpdateDocumentID() *NodeListUpsert {
+	u.SetExcluded(nodelist.FieldDocumentID)
+	return u
+}
 
 // SetRootElements sets the "root_elements" field.
 func (u *NodeListUpsert) SetRootElements(v []string) *NodeListUpsert {
@@ -269,6 +280,20 @@ func (u *NodeListUpsertOne) Update(set func(*NodeListUpsert)) *NodeListUpsertOne
 		set(&NodeListUpsert{UpdateSet: update})
 	}))
 	return u
+}
+
+// SetDocumentID sets the "document_id" field.
+func (u *NodeListUpsertOne) SetDocumentID(v string) *NodeListUpsertOne {
+	return u.Update(func(s *NodeListUpsert) {
+		s.SetDocumentID(v)
+	})
+}
+
+// UpdateDocumentID sets the "document_id" field to the value that was provided on create.
+func (u *NodeListUpsertOne) UpdateDocumentID() *NodeListUpsertOne {
+	return u.Update(func(s *NodeListUpsert) {
+		s.UpdateDocumentID()
+	})
 }
 
 // SetRootElements sets the "root_elements" field.
@@ -419,7 +444,7 @@ func (nlcb *NodeListCreateBulk) ExecX(ctx context.Context) {
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.NodeListUpsert) {
-//			SetRootElements(v+v).
+//			SetDocumentID(v+v).
 //		}).
 //		Exec(ctx)
 func (nlcb *NodeListCreateBulk) OnConflict(opts ...sql.ConflictOption) *NodeListUpsertBulk {
@@ -486,6 +511,20 @@ func (u *NodeListUpsertBulk) Update(set func(*NodeListUpsert)) *NodeListUpsertBu
 		set(&NodeListUpsert{UpdateSet: update})
 	}))
 	return u
+}
+
+// SetDocumentID sets the "document_id" field.
+func (u *NodeListUpsertBulk) SetDocumentID(v string) *NodeListUpsertBulk {
+	return u.Update(func(s *NodeListUpsert) {
+		s.SetDocumentID(v)
+	})
+}
+
+// UpdateDocumentID sets the "document_id" field to the value that was provided on create.
+func (u *NodeListUpsertBulk) UpdateDocumentID() *NodeListUpsertBulk {
+	return u.Update(func(s *NodeListUpsert) {
+		s.UpdateDocumentID()
+	})
 }
 
 // SetRootElements sets the "root_elements" field.

--- a/internal/backends/ent/nodelist_query.go
+++ b/internal/backends/ent/nodelist_query.go
@@ -102,7 +102,7 @@ func (nlq *NodeListQuery) QueryDocument() *DocumentQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(nodelist.Table, nodelist.FieldID, selector),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, nodelist.DocumentTable, nodelist.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.O2O, true, nodelist.DocumentTable, nodelist.DocumentColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(nlq.driver.Dialect(), step)
 		return fromU, nil
@@ -338,12 +338,12 @@ func (nlq *NodeListQuery) WithDocument(opts ...func(*DocumentQuery)) *NodeListQu
 // Example:
 //
 //	var v []struct {
-//		RootElements []string `json:"root_elements,omitempty"`
+//		DocumentID string `json:"document_id,omitempty"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
 //	client.NodeList.Query().
-//		GroupBy(nodelist.FieldRootElements).
+//		GroupBy(nodelist.FieldDocumentID).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
 func (nlq *NodeListQuery) GroupBy(field string, fields ...string) *NodeListGroupBy {
@@ -361,11 +361,11 @@ func (nlq *NodeListQuery) GroupBy(field string, fields ...string) *NodeListGroup
 // Example:
 //
 //	var v []struct {
-//		RootElements []string `json:"root_elements,omitempty"`
+//		DocumentID string `json:"document_id,omitempty"`
 //	}
 //
 //	client.NodeList.Query().
-//		Select(nodelist.FieldRootElements).
+//		Select(nodelist.FieldDocumentID).
 //		Scan(ctx, &v)
 func (nlq *NodeListQuery) Select(fields ...string) *NodeListSelect {
 	nlq.ctx.Fields = append(nlq.ctx.Fields, fields...)
@@ -480,29 +480,31 @@ func (nlq *NodeListQuery) loadNodes(ctx context.Context, query *NodeQuery, nodes
 	return nil
 }
 func (nlq *NodeListQuery) loadDocument(ctx context.Context, query *DocumentQuery, nodes []*NodeList, init func(*NodeList), assign func(*NodeList, *Document)) error {
-	fks := make([]driver.Value, 0, len(nodes))
-	nodeids := make(map[int]*NodeList)
+	ids := make([]string, 0, len(nodes))
+	nodeids := make(map[string][]*NodeList)
 	for i := range nodes {
-		fks = append(fks, nodes[i].ID)
-		nodeids[nodes[i].ID] = nodes[i]
+		fk := nodes[i].DocumentID
+		if _, ok := nodeids[fk]; !ok {
+			ids = append(ids, fk)
+		}
+		nodeids[fk] = append(nodeids[fk], nodes[i])
 	}
-	if len(query.ctx.Fields) > 0 {
-		query.ctx.AppendFieldOnce(document.FieldNodeListID)
+	if len(ids) == 0 {
+		return nil
 	}
-	query.Where(predicate.Document(func(s *sql.Selector) {
-		s.Where(sql.InValues(s.C(nodelist.DocumentColumn), fks...))
-	}))
+	query.Where(document.IDIn(ids...))
 	neighbors, err := query.All(ctx)
 	if err != nil {
 		return err
 	}
 	for _, n := range neighbors {
-		fk := n.NodeListID
-		node, ok := nodeids[fk]
+		nodes, ok := nodeids[n.ID]
 		if !ok {
-			return fmt.Errorf(`unexpected referenced foreign-key "node_list_id" returned %v for node %v`, fk, n.ID)
+			return fmt.Errorf(`unexpected foreign-key "document_id" returned %v`, n.ID)
 		}
-		assign(node, n)
+		for i := range nodes {
+			assign(nodes[i], n)
+		}
 	}
 	return nil
 }
@@ -531,6 +533,9 @@ func (nlq *NodeListQuery) querySpec() *sqlgraph.QuerySpec {
 			if fields[i] != nodelist.FieldID {
 				_spec.Node.Columns = append(_spec.Node.Columns, fields[i])
 			}
+		}
+		if nlq.withDocument != nil {
+			_spec.Node.AddColumnOnce(nodelist.FieldDocumentID)
 		}
 	}
 	if ps := nlq.predicates; len(ps) > 0 {

--- a/internal/backends/ent/nodelist_update.go
+++ b/internal/backends/ent/nodelist_update.go
@@ -34,6 +34,20 @@ func (nlu *NodeListUpdate) Where(ps ...predicate.NodeList) *NodeListUpdate {
 	return nlu
 }
 
+// SetDocumentID sets the "document_id" field.
+func (nlu *NodeListUpdate) SetDocumentID(s string) *NodeListUpdate {
+	nlu.mutation.SetDocumentID(s)
+	return nlu
+}
+
+// SetNillableDocumentID sets the "document_id" field if the given value is not nil.
+func (nlu *NodeListUpdate) SetNillableDocumentID(s *string) *NodeListUpdate {
+	if s != nil {
+		nlu.SetDocumentID(*s)
+	}
+	return nlu
+}
+
 // SetRootElements sets the "root_elements" field.
 func (nlu *NodeListUpdate) SetRootElements(s []string) *NodeListUpdate {
 	nlu.mutation.SetRootElements(s)
@@ -59,20 +73,6 @@ func (nlu *NodeListUpdate) AddNodes(n ...*Node) *NodeListUpdate {
 		ids[i] = n[i].ID
 	}
 	return nlu.AddNodeIDs(ids...)
-}
-
-// SetDocumentID sets the "document" edge to the Document entity by ID.
-func (nlu *NodeListUpdate) SetDocumentID(id int) *NodeListUpdate {
-	nlu.mutation.SetDocumentID(id)
-	return nlu
-}
-
-// SetNillableDocumentID sets the "document" edge to the Document entity by ID if the given value is not nil.
-func (nlu *NodeListUpdate) SetNillableDocumentID(id *int) *NodeListUpdate {
-	if id != nil {
-		nlu = nlu.SetDocumentID(*id)
-	}
-	return nlu
 }
 
 // SetDocument sets the "document" edge to the Document entity.
@@ -139,7 +139,18 @@ func (nlu *NodeListUpdate) ExecX(ctx context.Context) {
 	}
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (nlu *NodeListUpdate) check() error {
+	if _, ok := nlu.mutation.DocumentID(); nlu.mutation.DocumentCleared() && !ok {
+		return errors.New(`ent: clearing a required unique edge "NodeList.document"`)
+	}
+	return nil
+}
+
 func (nlu *NodeListUpdate) sqlSave(ctx context.Context) (n int, err error) {
+	if err := nlu.check(); err != nil {
+		return n, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(nodelist.Table, nodelist.Columns, sqlgraph.NewFieldSpec(nodelist.FieldID, field.TypeInt))
 	if ps := nlu.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
@@ -204,12 +215,12 @@ func (nlu *NodeListUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if nlu.mutation.DocumentCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2O,
-			Inverse: false,
+			Inverse: true,
 			Table:   nodelist.DocumentTable,
 			Columns: []string{nodelist.DocumentColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeString),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -217,12 +228,12 @@ func (nlu *NodeListUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if nodes := nlu.mutation.DocumentIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2O,
-			Inverse: false,
+			Inverse: true,
 			Table:   nodelist.DocumentTable,
 			Columns: []string{nodelist.DocumentColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {
@@ -250,6 +261,20 @@ type NodeListUpdateOne struct {
 	mutation *NodeListMutation
 }
 
+// SetDocumentID sets the "document_id" field.
+func (nluo *NodeListUpdateOne) SetDocumentID(s string) *NodeListUpdateOne {
+	nluo.mutation.SetDocumentID(s)
+	return nluo
+}
+
+// SetNillableDocumentID sets the "document_id" field if the given value is not nil.
+func (nluo *NodeListUpdateOne) SetNillableDocumentID(s *string) *NodeListUpdateOne {
+	if s != nil {
+		nluo.SetDocumentID(*s)
+	}
+	return nluo
+}
+
 // SetRootElements sets the "root_elements" field.
 func (nluo *NodeListUpdateOne) SetRootElements(s []string) *NodeListUpdateOne {
 	nluo.mutation.SetRootElements(s)
@@ -275,20 +300,6 @@ func (nluo *NodeListUpdateOne) AddNodes(n ...*Node) *NodeListUpdateOne {
 		ids[i] = n[i].ID
 	}
 	return nluo.AddNodeIDs(ids...)
-}
-
-// SetDocumentID sets the "document" edge to the Document entity by ID.
-func (nluo *NodeListUpdateOne) SetDocumentID(id int) *NodeListUpdateOne {
-	nluo.mutation.SetDocumentID(id)
-	return nluo
-}
-
-// SetNillableDocumentID sets the "document" edge to the Document entity by ID if the given value is not nil.
-func (nluo *NodeListUpdateOne) SetNillableDocumentID(id *int) *NodeListUpdateOne {
-	if id != nil {
-		nluo = nluo.SetDocumentID(*id)
-	}
-	return nluo
 }
 
 // SetDocument sets the "document" edge to the Document entity.
@@ -368,7 +379,18 @@ func (nluo *NodeListUpdateOne) ExecX(ctx context.Context) {
 	}
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (nluo *NodeListUpdateOne) check() error {
+	if _, ok := nluo.mutation.DocumentID(); nluo.mutation.DocumentCleared() && !ok {
+		return errors.New(`ent: clearing a required unique edge "NodeList.document"`)
+	}
+	return nil
+}
+
 func (nluo *NodeListUpdateOne) sqlSave(ctx context.Context) (_node *NodeList, err error) {
+	if err := nluo.check(); err != nil {
+		return _node, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(nodelist.Table, nodelist.Columns, sqlgraph.NewFieldSpec(nodelist.FieldID, field.TypeInt))
 	id, ok := nluo.mutation.ID()
 	if !ok {
@@ -450,12 +472,12 @@ func (nluo *NodeListUpdateOne) sqlSave(ctx context.Context) (_node *NodeList, er
 	if nluo.mutation.DocumentCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2O,
-			Inverse: false,
+			Inverse: true,
 			Table:   nodelist.DocumentTable,
 			Columns: []string{nodelist.DocumentColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeString),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -463,12 +485,12 @@ func (nluo *NodeListUpdateOne) sqlSave(ctx context.Context) (_node *NodeList, er
 	if nodes := nluo.mutation.DocumentIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2O,
-			Inverse: false,
+			Inverse: true,
 			Table:   nodelist.DocumentTable,
 			Columns: []string{nodelist.DocumentColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/internal/backends/ent/schema/document.go
+++ b/internal/backends/ent/schema/document.go
@@ -9,7 +9,6 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
-	"entgo.io/ent/schema/index"
 )
 
 type Document struct {
@@ -18,30 +17,18 @@ type Document struct {
 
 func (Document) Fields() []ent.Field {
 	return []ent.Field{
-		field.String("metadata_id").Immutable(),
-		field.Int("node_list_id").Immutable(),
+		field.String("id").Unique().Immutable(),
 	}
 }
 
 func (Document) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("metadata", Metadata.Type).
-			Ref("document").
-			Required().
+		edge.To("metadata", Metadata.Type).
 			Unique().
 			Immutable().
-			Field("metadata_id"),
-		edge.From("node_list", NodeList.Type).
-			Ref("document").
-			Required().
+			StorageKey(edge.Column("id")),
+		edge.To("node_list", NodeList.Type).
 			Unique().
-			Immutable().
-			Field("node_list_id"),
-	}
-}
-
-func (Document) Indexes() []ent.Index {
-	return []ent.Index{
-		index.Fields("metadata_id").Unique(),
+			Immutable(),
 	}
 }

--- a/internal/backends/ent/schema/document.go
+++ b/internal/backends/ent/schema/document.go
@@ -42,6 +42,6 @@ func (Document) Edges() []ent.Edge {
 
 func (Document) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("metadata_id", "node_list_id").Unique(),
+		index.Fields("metadata_id").Unique(),
 	}
 }

--- a/internal/backends/ent/schema/external_reference.go
+++ b/internal/backends/ent/schema/external_reference.go
@@ -97,6 +97,6 @@ func (ExternalReference) Edges() []ent.Edge {
 
 func (ExternalReference) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("node_id").Unique(),
+		index.Fields("node_id", "url", "type").Unique(),
 	}
 }

--- a/internal/backends/ent/schema/metadata.go
+++ b/internal/backends/ent/schema/metadata.go
@@ -31,7 +31,7 @@ func (Metadata) Edges() []ent.Edge {
 		edge.To("tools", Tool.Type),
 		edge.To("authors", Person.Type),
 		edge.To("document_types", DocumentType.Type),
-		edge.To("document", Document.Type),
+		edge.From("document", Document.Type).Ref("metadata").Required().Unique().Immutable(),
 	}
 }
 

--- a/internal/backends/ent/schema/node_list.go
+++ b/internal/backends/ent/schema/node_list.go
@@ -7,8 +7,10 @@ package schema
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
 )
 
 type NodeList struct {
@@ -17,6 +19,7 @@ type NodeList struct {
 
 func (NodeList) Fields() []ent.Field {
 	return []ent.Field{
+		field.String("document_id"),
 		field.Strings("root_elements"),
 	}
 }
@@ -24,6 +27,16 @@ func (NodeList) Fields() []ent.Field {
 func (NodeList) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("nodes", Node.Type),
-		edge.To("document", Document.Type).Unique(),
+		edge.From("document", Document.Type).Ref("node_list").Required().Unique().Field("document_id"),
+	}
+}
+
+func (NodeList) Indexes() []ent.Index {
+	return []ent.Index{
+		index.Fields("document_id", "root_elements").
+			Unique().
+			Annotations(
+				entsql.IndexWhere("root_elements IS NOT NULL"),
+			),
 	}
 }

--- a/internal/backends/ent/schema/node_list.go
+++ b/internal/backends/ent/schema/node_list.go
@@ -9,7 +9,6 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
-	"entgo.io/ent/schema/index"
 )
 
 type NodeList struct {
@@ -26,11 +25,5 @@ func (NodeList) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("nodes", Node.Type),
 		edge.To("document", Document.Type).Unique(),
-	}
-}
-
-func (NodeList) Indexes() []ent.Index {
-	return []ent.Index{
-		index.Fields("root_elements").Unique(),
 	}
 }


### PR DESCRIPTION
This PR contains fixes for schema unique index definitions and `Document` relations.

#### Document

- Use `Metadata.ID` string as ID
- Set `Document` as owner of its `NodeList` and `Metadata` edges (reverse `edge.To()` and `edge.From()` definitions in schemas)
- Store document ID (which is now `Metadata.ID`) as a field in `NodeList` schema

#### ExternalReference

- Fix unique index to include `URL` and `Type` fields

#### NodeList

- Fix unique index to include `DocumentID` field

#### Miscellaneous

- Fix backend debug option (client was `nil` at the time of calling its `Debug()` method)