### PR TITLE
refactor: additional retrieval methods

### DIFF
--- a/backends/ent/retrieve.go
+++ b/backends/ent/retrieve.go
@@ -6,6 +6,7 @@
 package ent
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -17,6 +18,8 @@ import (
 	"github.com/protobom/storage/internal/backends/ent/document"
 	"github.com/protobom/storage/internal/backends/ent/externalreference"
 )
+
+var errMultipleDocuments = errors.New("multiple documents matching ID")
 
 // Retrieve implements the storage.Retriever interface.
 func (backend *Backend) Retrieve(id string, _ *storage.RetrieveOptions) (*sbom.Document, error) {
@@ -34,7 +37,7 @@ func (backend *Backend) Retrieve(id string, _ *storage.RetrieveOptions) (*sbom.D
 	}
 
 	if len(documents) > 1 {
-		return nil, fmt.Errorf("multiple documents matching ID %s: %w", id, err)
+		return nil, fmt.Errorf("%w %s", err, id)
 	}
 
 	return documents[0], nil

--- a/backends/ent/retrieve.go
+++ b/backends/ent/retrieve.go
@@ -19,7 +19,10 @@ import (
 	"github.com/protobom/storage/internal/backends/ent/externalreference"
 )
 
-var errMultipleDocuments = errors.New("multiple documents matching ID")
+var (
+	errMultipleDocuments = errors.New("multiple documents matching ID")
+	errNoDocuments       = errors.New("no documents matching IDs")
+)
 
 // Retrieve implements the storage.Retriever interface.
 func (backend *Backend) Retrieve(id string, _ *storage.RetrieveOptions) (*sbom.Document, error) {
@@ -57,6 +60,10 @@ func (backend *Backend) GetDocumentsByID(ids ...string) ([]*sbom.Document, error
 	entDocs, err := query.All(backend.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("querying documents table: %w", err)
+	}
+
+	if len(entDocs) == 0 {
+		return nil, fmt.Errorf("%w %s", errNoDocuments, ids)
 	}
 
 	for _, entDoc := range entDocs {

--- a/backends/ent/retrieve.go
+++ b/backends/ent/retrieve.go
@@ -37,7 +37,7 @@ func (backend *Backend) Retrieve(id string, _ *storage.RetrieveOptions) (*sbom.D
 	}
 
 	if len(documents) > 1 {
-		return nil, fmt.Errorf("%w %s", err, id)
+		return nil, fmt.Errorf("%w %s", errMultipleDocuments, id)
 	}
 
 	return documents[0], nil

--- a/backends/ent/store.go
+++ b/backends/ent/store.go
@@ -55,18 +55,18 @@ func (backend *Backend) Store(doc *sbom.Document, opts *storage.StoreOptions) er
 		return fmt.Errorf("ent.Document: %w", err)
 	}
 
-	if err := backend.StoreMetadata(doc.Metadata); err != nil {
+	if err := backend.saveMetadata(doc.Metadata); err != nil {
 		return err
 	}
 
-	if err := backend.StoreNodeList(doc.NodeList); err != nil {
+	if err := backend.saveNodeList(doc.NodeList); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (backend *Backend) StoreDocumentTypes(docTypes []*sbom.DocumentType) error {
+func (backend *Backend) saveDocumentTypes(docTypes []*sbom.DocumentType) error {
 	if backend.client == nil {
 		return fmt.Errorf("%w", errUninitializedClient)
 	}
@@ -92,7 +92,7 @@ func (backend *Backend) StoreDocumentTypes(docTypes []*sbom.DocumentType) error 
 	return nil
 }
 
-func (backend *Backend) StoreEdges(edges []*sbom.Edge) error {
+func (backend *Backend) saveEdges(edges []*sbom.Edge) error {
 	if backend.client == nil {
 		return fmt.Errorf("%w", errUninitializedClient)
 	}
@@ -114,7 +114,7 @@ func (backend *Backend) StoreEdges(edges []*sbom.Edge) error {
 	return nil
 }
 
-func (backend *Backend) StoreExternalReferences(refs []*sbom.ExternalReference) error {
+func (backend *Backend) saveExternalReferences(refs []*sbom.ExternalReference) error {
 	if backend.client == nil {
 		return fmt.Errorf("%w", errUninitializedClient)
 	}
@@ -137,7 +137,7 @@ func (backend *Backend) StoreExternalReferences(refs []*sbom.ExternalReference) 
 
 		backend.ctx = context.WithValue(backend.ctx, externalReferenceIDKey{}, id)
 
-		if err := backend.StoreHashesEntries(ref.Hashes); err != nil {
+		if err := backend.saveHashesEntries(ref.Hashes); err != nil {
 			return err
 		}
 	}
@@ -145,7 +145,7 @@ func (backend *Backend) StoreExternalReferences(refs []*sbom.ExternalReference) 
 	return nil
 }
 
-func (backend *Backend) StoreHashesEntries(hashes map[int32]string) error {
+func (backend *Backend) saveHashesEntries(hashes map[int32]string) error {
 	if backend.client == nil {
 		return fmt.Errorf("%w", errUninitializedClient)
 	}
@@ -178,7 +178,7 @@ func (backend *Backend) StoreHashesEntries(hashes map[int32]string) error {
 	return nil
 }
 
-func (backend *Backend) StoreIdentifiersEntries(idents map[int32]string) error {
+func (backend *Backend) saveIdentifiersEntries(idents map[int32]string) error {
 	if backend.client == nil {
 		return fmt.Errorf("%w", errUninitializedClient)
 	}
@@ -207,7 +207,7 @@ func (backend *Backend) StoreIdentifiersEntries(idents map[int32]string) error {
 	return nil
 }
 
-func (backend *Backend) StoreMetadata(md *sbom.Metadata) error {
+func (backend *Backend) saveMetadata(md *sbom.Metadata) error {
 	if backend.client == nil {
 		return fmt.Errorf("%w", errUninitializedClient)
 	}
@@ -227,22 +227,22 @@ func (backend *Backend) StoreMetadata(md *sbom.Metadata) error {
 
 	backend.ctx = context.WithValue(backend.ctx, metadataIDKey{}, md.Id)
 
-	if err := backend.StorePersons(md.Authors); err != nil {
+	if err := backend.savePersons(md.Authors); err != nil {
 		return err
 	}
 
-	if err := backend.StoreDocumentTypes(md.DocumentTypes); err != nil {
+	if err := backend.saveDocumentTypes(md.DocumentTypes); err != nil {
 		return err
 	}
 
-	if err := backend.StoreTools(md.Tools); err != nil {
+	if err := backend.saveTools(md.Tools); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (backend *Backend) StoreNodeList(nodeList *sbom.NodeList) error {
+func (backend *Backend) saveNodeList(nodeList *sbom.NodeList) error {
 	if backend.client == nil {
 		return fmt.Errorf("%w", errUninitializedClient)
 	}
@@ -261,19 +261,19 @@ func (backend *Backend) StoreNodeList(nodeList *sbom.NodeList) error {
 
 	backend.ctx = context.WithValue(backend.ctx, nodeListIDKey{}, id)
 
-	if err := backend.StoreNodes(nodeList.Nodes); err != nil {
+	if err := backend.saveNodes(nodeList.Nodes); err != nil {
 		return err
 	}
 
 	// Update nodes of this node list with their typed edges.
-	if err := backend.StoreEdges(nodeList.Edges); err != nil {
+	if err := backend.saveEdges(nodeList.Edges); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (backend *Backend) StoreNodes(nodes []*sbom.Node) error { //nolint:cyclop
+func (backend *Backend) saveNodes(nodes []*sbom.Node) error { //nolint:cyclop
 	if backend.client == nil {
 		return fmt.Errorf("%w", errUninitializedClient)
 	}
@@ -288,27 +288,27 @@ func (backend *Backend) StoreNodes(nodes []*sbom.Node) error { //nolint:cyclop
 
 		backend.ctx = context.WithValue(backend.ctx, nodeIDKey{}, n.Id)
 
-		if err := backend.StoreExternalReferences(n.ExternalReferences); err != nil {
+		if err := backend.saveExternalReferences(n.ExternalReferences); err != nil {
 			return err
 		}
 
-		if err := backend.StorePersons(n.Originators); err != nil {
+		if err := backend.savePersons(n.Originators); err != nil {
 			return err
 		}
 
-		if err := backend.StorePersons(n.Suppliers); err != nil {
+		if err := backend.savePersons(n.Suppliers); err != nil {
 			return err
 		}
 
-		if err := backend.StorePurposes(n.PrimaryPurpose); err != nil {
+		if err := backend.savePurposes(n.PrimaryPurpose); err != nil {
 			return err
 		}
 
-		if err := backend.StoreHashesEntries(n.Hashes); err != nil {
+		if err := backend.saveHashesEntries(n.Hashes); err != nil {
 			return err
 		}
 
-		if err := backend.StoreIdentifiersEntries(n.Identifiers); err != nil {
+		if err := backend.saveIdentifiersEntries(n.Identifiers); err != nil {
 			return err
 		}
 	}
@@ -316,7 +316,7 @@ func (backend *Backend) StoreNodes(nodes []*sbom.Node) error { //nolint:cyclop
 	return nil
 }
 
-func (backend *Backend) StorePersons(persons []*sbom.Person) error {
+func (backend *Backend) savePersons(persons []*sbom.Person) error {
 	if backend.client == nil {
 		return fmt.Errorf("%w", errUninitializedClient)
 	}
@@ -344,7 +344,7 @@ func (backend *Backend) StorePersons(persons []*sbom.Person) error {
 
 		backend.ctx = context.WithValue(backend.ctx, contactOwnerIDKey{}, id)
 
-		if err := backend.StorePersons(p.Contacts); err != nil {
+		if err := backend.savePersons(p.Contacts); err != nil {
 			return err
 		}
 	}
@@ -352,7 +352,7 @@ func (backend *Backend) StorePersons(persons []*sbom.Person) error {
 	return nil
 }
 
-func (backend *Backend) StorePurposes(purposes []sbom.Purpose) error {
+func (backend *Backend) savePurposes(purposes []sbom.Purpose) error {
 	if backend.client == nil {
 		return fmt.Errorf("%w", errUninitializedClient)
 	}
@@ -381,7 +381,7 @@ func (backend *Backend) StorePurposes(purposes []sbom.Purpose) error {
 	return nil
 }
 
-func (backend *Backend) StoreTools(tools []*sbom.Tool) error {
+func (backend *Backend) saveTools(tools []*sbom.Tool) error {
 	if backend.client == nil {
 		return fmt.Errorf("%w", errUninitializedClient)
 	}

--- a/internal/backends/ent/externalreference/externalreference.go
+++ b/internal/backends/ent/externalreference/externalreference.go
@@ -41,7 +41,7 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "hashesentry" package.
 	HashesInverseTable = "hashes_entries"
 	// HashesColumn is the table column denoting the hashes relation/edge.
-	HashesColumn = "external_reference_hashes"
+	HashesColumn = "external_reference_id"
 	// NodeTable is the table that holds the node relation/edge.
 	NodeTable = "external_references"
 	// NodeInverseTable is the table name for the Node entity.

--- a/internal/backends/ent/externalreference_query.go
+++ b/internal/backends/ent/externalreference_query.go
@@ -459,7 +459,9 @@ func (erq *ExternalReferenceQuery) loadHashes(ctx context.Context, query *Hashes
 			init(nodes[i])
 		}
 	}
-	query.withFKs = true
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(hashesentry.FieldExternalReferenceID)
+	}
 	query.Where(predicate.HashesEntry(func(s *sql.Selector) {
 		s.Where(sql.InValues(s.C(externalreference.HashesColumn), fks...))
 	}))
@@ -468,13 +470,10 @@ func (erq *ExternalReferenceQuery) loadHashes(ctx context.Context, query *Hashes
 		return err
 	}
 	for _, n := range neighbors {
-		fk := n.external_reference_hashes
-		if fk == nil {
-			return fmt.Errorf(`foreign-key "external_reference_hashes" is nil for node %v`, n.ID)
-		}
-		node, ok := nodeids[*fk]
+		fk := n.ExternalReferenceID
+		node, ok := nodeids[fk]
 		if !ok {
-			return fmt.Errorf(`unexpected referenced foreign-key "external_reference_hashes" returned %v for node %v`, *fk, n.ID)
+			return fmt.Errorf(`unexpected referenced foreign-key "external_reference_id" returned %v for node %v`, fk, n.ID)
 		}
 		assign(node, n)
 	}

--- a/internal/backends/ent/hashesentry/hashesentry.go
+++ b/internal/backends/ent/hashesentry/hashesentry.go
@@ -19,6 +19,10 @@ const (
 	Label = "hashes_entry"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
+	// FieldExternalReferenceID holds the string denoting the external_reference_id field in the database.
+	FieldExternalReferenceID = "external_reference_id"
+	// FieldNodeID holds the string denoting the node_id field in the database.
+	FieldNodeID = "node_id"
 	// FieldHashAlgorithmType holds the string denoting the hash_algorithm_type field in the database.
 	FieldHashAlgorithmType = "hash_algorithm_type"
 	// FieldHashData holds the string denoting the hash_data field in the database.
@@ -35,39 +39,29 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "externalreference" package.
 	ExternalReferenceInverseTable = "external_references"
 	// ExternalReferenceColumn is the table column denoting the external_reference relation/edge.
-	ExternalReferenceColumn = "external_reference_hashes"
+	ExternalReferenceColumn = "external_reference_id"
 	// NodeTable is the table that holds the node relation/edge.
 	NodeTable = "hashes_entries"
 	// NodeInverseTable is the table name for the Node entity.
 	// It exists in this package in order to avoid circular dependency with the "node" package.
 	NodeInverseTable = "nodes"
 	// NodeColumn is the table column denoting the node relation/edge.
-	NodeColumn = "node_hashes"
+	NodeColumn = "node_id"
 )
 
 // Columns holds all SQL columns for hashesentry fields.
 var Columns = []string{
 	FieldID,
+	FieldExternalReferenceID,
+	FieldNodeID,
 	FieldHashAlgorithmType,
 	FieldHashData,
-}
-
-// ForeignKeys holds the SQL foreign-keys that are owned by the "hashes_entries"
-// table and are not defined as standalone fields in the schema.
-var ForeignKeys = []string{
-	"external_reference_hashes",
-	"node_hashes",
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
-			return true
-		}
-	}
-	for i := range ForeignKeys {
-		if column == ForeignKeys[i] {
 			return true
 		}
 	}
@@ -119,6 +113,16 @@ type OrderOption func(*sql.Selector)
 // ByID orders the results by the id field.
 func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByExternalReferenceID orders the results by the external_reference_id field.
+func ByExternalReferenceID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldExternalReferenceID, opts...).ToFunc()
+}
+
+// ByNodeID orders the results by the node_id field.
+func ByNodeID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldNodeID, opts...).ToFunc()
 }
 
 // ByHashAlgorithmType orders the results by the hash_algorithm_type field.

--- a/internal/backends/ent/hashesentry/where.go
+++ b/internal/backends/ent/hashesentry/where.go
@@ -58,9 +58,124 @@ func IDLTE(id int) predicate.HashesEntry {
 	return predicate.HashesEntry(sql.FieldLTE(FieldID, id))
 }
 
+// ExternalReferenceID applies equality check predicate on the "external_reference_id" field. It's identical to ExternalReferenceIDEQ.
+func ExternalReferenceID(v int) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldEQ(FieldExternalReferenceID, v))
+}
+
+// NodeID applies equality check predicate on the "node_id" field. It's identical to NodeIDEQ.
+func NodeID(v string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldEQ(FieldNodeID, v))
+}
+
 // HashData applies equality check predicate on the "hash_data" field. It's identical to HashDataEQ.
 func HashData(v string) predicate.HashesEntry {
 	return predicate.HashesEntry(sql.FieldEQ(FieldHashData, v))
+}
+
+// ExternalReferenceIDEQ applies the EQ predicate on the "external_reference_id" field.
+func ExternalReferenceIDEQ(v int) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldEQ(FieldExternalReferenceID, v))
+}
+
+// ExternalReferenceIDNEQ applies the NEQ predicate on the "external_reference_id" field.
+func ExternalReferenceIDNEQ(v int) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldNEQ(FieldExternalReferenceID, v))
+}
+
+// ExternalReferenceIDIn applies the In predicate on the "external_reference_id" field.
+func ExternalReferenceIDIn(vs ...int) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldIn(FieldExternalReferenceID, vs...))
+}
+
+// ExternalReferenceIDNotIn applies the NotIn predicate on the "external_reference_id" field.
+func ExternalReferenceIDNotIn(vs ...int) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldNotIn(FieldExternalReferenceID, vs...))
+}
+
+// ExternalReferenceIDIsNil applies the IsNil predicate on the "external_reference_id" field.
+func ExternalReferenceIDIsNil() predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldIsNull(FieldExternalReferenceID))
+}
+
+// ExternalReferenceIDNotNil applies the NotNil predicate on the "external_reference_id" field.
+func ExternalReferenceIDNotNil() predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldNotNull(FieldExternalReferenceID))
+}
+
+// NodeIDEQ applies the EQ predicate on the "node_id" field.
+func NodeIDEQ(v string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldEQ(FieldNodeID, v))
+}
+
+// NodeIDNEQ applies the NEQ predicate on the "node_id" field.
+func NodeIDNEQ(v string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldNEQ(FieldNodeID, v))
+}
+
+// NodeIDIn applies the In predicate on the "node_id" field.
+func NodeIDIn(vs ...string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldIn(FieldNodeID, vs...))
+}
+
+// NodeIDNotIn applies the NotIn predicate on the "node_id" field.
+func NodeIDNotIn(vs ...string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldNotIn(FieldNodeID, vs...))
+}
+
+// NodeIDGT applies the GT predicate on the "node_id" field.
+func NodeIDGT(v string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldGT(FieldNodeID, v))
+}
+
+// NodeIDGTE applies the GTE predicate on the "node_id" field.
+func NodeIDGTE(v string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldGTE(FieldNodeID, v))
+}
+
+// NodeIDLT applies the LT predicate on the "node_id" field.
+func NodeIDLT(v string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldLT(FieldNodeID, v))
+}
+
+// NodeIDLTE applies the LTE predicate on the "node_id" field.
+func NodeIDLTE(v string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldLTE(FieldNodeID, v))
+}
+
+// NodeIDContains applies the Contains predicate on the "node_id" field.
+func NodeIDContains(v string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldContains(FieldNodeID, v))
+}
+
+// NodeIDHasPrefix applies the HasPrefix predicate on the "node_id" field.
+func NodeIDHasPrefix(v string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldHasPrefix(FieldNodeID, v))
+}
+
+// NodeIDHasSuffix applies the HasSuffix predicate on the "node_id" field.
+func NodeIDHasSuffix(v string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldHasSuffix(FieldNodeID, v))
+}
+
+// NodeIDIsNil applies the IsNil predicate on the "node_id" field.
+func NodeIDIsNil() predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldIsNull(FieldNodeID))
+}
+
+// NodeIDNotNil applies the NotNil predicate on the "node_id" field.
+func NodeIDNotNil() predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldNotNull(FieldNodeID))
+}
+
+// NodeIDEqualFold applies the EqualFold predicate on the "node_id" field.
+func NodeIDEqualFold(v string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldEqualFold(FieldNodeID, v))
+}
+
+// NodeIDContainsFold applies the ContainsFold predicate on the "node_id" field.
+func NodeIDContainsFold(v string) predicate.HashesEntry {
+	return predicate.HashesEntry(sql.FieldContainsFold(FieldNodeID, v))
 }
 
 // HashAlgorithmTypeEQ applies the EQ predicate on the "hash_algorithm_type" field.

--- a/internal/backends/ent/hashesentry_create.go
+++ b/internal/backends/ent/hashesentry_create.go
@@ -27,6 +27,34 @@ type HashesEntryCreate struct {
 	conflict []sql.ConflictOption
 }
 
+// SetExternalReferenceID sets the "external_reference_id" field.
+func (hec *HashesEntryCreate) SetExternalReferenceID(i int) *HashesEntryCreate {
+	hec.mutation.SetExternalReferenceID(i)
+	return hec
+}
+
+// SetNillableExternalReferenceID sets the "external_reference_id" field if the given value is not nil.
+func (hec *HashesEntryCreate) SetNillableExternalReferenceID(i *int) *HashesEntryCreate {
+	if i != nil {
+		hec.SetExternalReferenceID(*i)
+	}
+	return hec
+}
+
+// SetNodeID sets the "node_id" field.
+func (hec *HashesEntryCreate) SetNodeID(s string) *HashesEntryCreate {
+	hec.mutation.SetNodeID(s)
+	return hec
+}
+
+// SetNillableNodeID sets the "node_id" field if the given value is not nil.
+func (hec *HashesEntryCreate) SetNillableNodeID(s *string) *HashesEntryCreate {
+	if s != nil {
+		hec.SetNodeID(*s)
+	}
+	return hec
+}
+
 // SetHashAlgorithmType sets the "hash_algorithm_type" field.
 func (hec *HashesEntryCreate) SetHashAlgorithmType(hat hashesentry.HashAlgorithmType) *HashesEntryCreate {
 	hec.mutation.SetHashAlgorithmType(hat)
@@ -39,37 +67,9 @@ func (hec *HashesEntryCreate) SetHashData(s string) *HashesEntryCreate {
 	return hec
 }
 
-// SetExternalReferenceID sets the "external_reference" edge to the ExternalReference entity by ID.
-func (hec *HashesEntryCreate) SetExternalReferenceID(id int) *HashesEntryCreate {
-	hec.mutation.SetExternalReferenceID(id)
-	return hec
-}
-
-// SetNillableExternalReferenceID sets the "external_reference" edge to the ExternalReference entity by ID if the given value is not nil.
-func (hec *HashesEntryCreate) SetNillableExternalReferenceID(id *int) *HashesEntryCreate {
-	if id != nil {
-		hec = hec.SetExternalReferenceID(*id)
-	}
-	return hec
-}
-
 // SetExternalReference sets the "external_reference" edge to the ExternalReference entity.
 func (hec *HashesEntryCreate) SetExternalReference(e *ExternalReference) *HashesEntryCreate {
 	return hec.SetExternalReferenceID(e.ID)
-}
-
-// SetNodeID sets the "node" edge to the Node entity by ID.
-func (hec *HashesEntryCreate) SetNodeID(id string) *HashesEntryCreate {
-	hec.mutation.SetNodeID(id)
-	return hec
-}
-
-// SetNillableNodeID sets the "node" edge to the Node entity by ID if the given value is not nil.
-func (hec *HashesEntryCreate) SetNillableNodeID(id *string) *HashesEntryCreate {
-	if id != nil {
-		hec = hec.SetNodeID(*id)
-	}
-	return hec
 }
 
 // SetNode sets the "node" edge to the Node entity.
@@ -171,7 +171,7 @@ func (hec *HashesEntryCreate) createSpec() (*HashesEntry, *sqlgraph.CreateSpec) 
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.external_reference_hashes = &nodes[0]
+		_node.ExternalReferenceID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := hec.mutation.NodeIDs(); len(nodes) > 0 {
@@ -188,7 +188,7 @@ func (hec *HashesEntryCreate) createSpec() (*HashesEntry, *sqlgraph.CreateSpec) 
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.node_hashes = &nodes[0]
+		_node.NodeID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec
@@ -198,7 +198,7 @@ func (hec *HashesEntryCreate) createSpec() (*HashesEntry, *sqlgraph.CreateSpec) 
 // of the `INSERT` statement. For example:
 //
 //	client.HashesEntry.Create().
-//		SetHashAlgorithmType(v).
+//		SetExternalReferenceID(v).
 //		OnConflict(
 //			// Update the row with the new values
 //			// the was proposed for insertion.
@@ -207,7 +207,7 @@ func (hec *HashesEntryCreate) createSpec() (*HashesEntry, *sqlgraph.CreateSpec) 
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.HashesEntryUpsert) {
-//			SetHashAlgorithmType(v+v).
+//			SetExternalReferenceID(v+v).
 //		}).
 //		Exec(ctx)
 func (hec *HashesEntryCreate) OnConflict(opts ...sql.ConflictOption) *HashesEntryUpsertOne {
@@ -242,6 +242,42 @@ type (
 		*sql.UpdateSet
 	}
 )
+
+// SetExternalReferenceID sets the "external_reference_id" field.
+func (u *HashesEntryUpsert) SetExternalReferenceID(v int) *HashesEntryUpsert {
+	u.Set(hashesentry.FieldExternalReferenceID, v)
+	return u
+}
+
+// UpdateExternalReferenceID sets the "external_reference_id" field to the value that was provided on create.
+func (u *HashesEntryUpsert) UpdateExternalReferenceID() *HashesEntryUpsert {
+	u.SetExcluded(hashesentry.FieldExternalReferenceID)
+	return u
+}
+
+// ClearExternalReferenceID clears the value of the "external_reference_id" field.
+func (u *HashesEntryUpsert) ClearExternalReferenceID() *HashesEntryUpsert {
+	u.SetNull(hashesentry.FieldExternalReferenceID)
+	return u
+}
+
+// SetNodeID sets the "node_id" field.
+func (u *HashesEntryUpsert) SetNodeID(v string) *HashesEntryUpsert {
+	u.Set(hashesentry.FieldNodeID, v)
+	return u
+}
+
+// UpdateNodeID sets the "node_id" field to the value that was provided on create.
+func (u *HashesEntryUpsert) UpdateNodeID() *HashesEntryUpsert {
+	u.SetExcluded(hashesentry.FieldNodeID)
+	return u
+}
+
+// ClearNodeID clears the value of the "node_id" field.
+func (u *HashesEntryUpsert) ClearNodeID() *HashesEntryUpsert {
+	u.SetNull(hashesentry.FieldNodeID)
+	return u
+}
 
 // SetHashAlgorithmType sets the "hash_algorithm_type" field.
 func (u *HashesEntryUpsert) SetHashAlgorithmType(v hashesentry.HashAlgorithmType) *HashesEntryUpsert {
@@ -305,6 +341,48 @@ func (u *HashesEntryUpsertOne) Update(set func(*HashesEntryUpsert)) *HashesEntry
 		set(&HashesEntryUpsert{UpdateSet: update})
 	}))
 	return u
+}
+
+// SetExternalReferenceID sets the "external_reference_id" field.
+func (u *HashesEntryUpsertOne) SetExternalReferenceID(v int) *HashesEntryUpsertOne {
+	return u.Update(func(s *HashesEntryUpsert) {
+		s.SetExternalReferenceID(v)
+	})
+}
+
+// UpdateExternalReferenceID sets the "external_reference_id" field to the value that was provided on create.
+func (u *HashesEntryUpsertOne) UpdateExternalReferenceID() *HashesEntryUpsertOne {
+	return u.Update(func(s *HashesEntryUpsert) {
+		s.UpdateExternalReferenceID()
+	})
+}
+
+// ClearExternalReferenceID clears the value of the "external_reference_id" field.
+func (u *HashesEntryUpsertOne) ClearExternalReferenceID() *HashesEntryUpsertOne {
+	return u.Update(func(s *HashesEntryUpsert) {
+		s.ClearExternalReferenceID()
+	})
+}
+
+// SetNodeID sets the "node_id" field.
+func (u *HashesEntryUpsertOne) SetNodeID(v string) *HashesEntryUpsertOne {
+	return u.Update(func(s *HashesEntryUpsert) {
+		s.SetNodeID(v)
+	})
+}
+
+// UpdateNodeID sets the "node_id" field to the value that was provided on create.
+func (u *HashesEntryUpsertOne) UpdateNodeID() *HashesEntryUpsertOne {
+	return u.Update(func(s *HashesEntryUpsert) {
+		s.UpdateNodeID()
+	})
+}
+
+// ClearNodeID clears the value of the "node_id" field.
+func (u *HashesEntryUpsertOne) ClearNodeID() *HashesEntryUpsertOne {
+	return u.Update(func(s *HashesEntryUpsert) {
+		s.ClearNodeID()
+	})
 }
 
 // SetHashAlgorithmType sets the "hash_algorithm_type" field.
@@ -469,7 +547,7 @@ func (hecb *HashesEntryCreateBulk) ExecX(ctx context.Context) {
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.HashesEntryUpsert) {
-//			SetHashAlgorithmType(v+v).
+//			SetExternalReferenceID(v+v).
 //		}).
 //		Exec(ctx)
 func (hecb *HashesEntryCreateBulk) OnConflict(opts ...sql.ConflictOption) *HashesEntryUpsertBulk {
@@ -536,6 +614,48 @@ func (u *HashesEntryUpsertBulk) Update(set func(*HashesEntryUpsert)) *HashesEntr
 		set(&HashesEntryUpsert{UpdateSet: update})
 	}))
 	return u
+}
+
+// SetExternalReferenceID sets the "external_reference_id" field.
+func (u *HashesEntryUpsertBulk) SetExternalReferenceID(v int) *HashesEntryUpsertBulk {
+	return u.Update(func(s *HashesEntryUpsert) {
+		s.SetExternalReferenceID(v)
+	})
+}
+
+// UpdateExternalReferenceID sets the "external_reference_id" field to the value that was provided on create.
+func (u *HashesEntryUpsertBulk) UpdateExternalReferenceID() *HashesEntryUpsertBulk {
+	return u.Update(func(s *HashesEntryUpsert) {
+		s.UpdateExternalReferenceID()
+	})
+}
+
+// ClearExternalReferenceID clears the value of the "external_reference_id" field.
+func (u *HashesEntryUpsertBulk) ClearExternalReferenceID() *HashesEntryUpsertBulk {
+	return u.Update(func(s *HashesEntryUpsert) {
+		s.ClearExternalReferenceID()
+	})
+}
+
+// SetNodeID sets the "node_id" field.
+func (u *HashesEntryUpsertBulk) SetNodeID(v string) *HashesEntryUpsertBulk {
+	return u.Update(func(s *HashesEntryUpsert) {
+		s.SetNodeID(v)
+	})
+}
+
+// UpdateNodeID sets the "node_id" field to the value that was provided on create.
+func (u *HashesEntryUpsertBulk) UpdateNodeID() *HashesEntryUpsertBulk {
+	return u.Update(func(s *HashesEntryUpsert) {
+		s.UpdateNodeID()
+	})
+}
+
+// ClearNodeID clears the value of the "node_id" field.
+func (u *HashesEntryUpsertBulk) ClearNodeID() *HashesEntryUpsertBulk {
+	return u.Update(func(s *HashesEntryUpsert) {
+		s.ClearNodeID()
+	})
 }
 
 // SetHashAlgorithmType sets the "hash_algorithm_type" field.

--- a/internal/backends/ent/hashesentry_update.go
+++ b/internal/backends/ent/hashesentry_update.go
@@ -33,6 +33,46 @@ func (heu *HashesEntryUpdate) Where(ps ...predicate.HashesEntry) *HashesEntryUpd
 	return heu
 }
 
+// SetExternalReferenceID sets the "external_reference_id" field.
+func (heu *HashesEntryUpdate) SetExternalReferenceID(i int) *HashesEntryUpdate {
+	heu.mutation.SetExternalReferenceID(i)
+	return heu
+}
+
+// SetNillableExternalReferenceID sets the "external_reference_id" field if the given value is not nil.
+func (heu *HashesEntryUpdate) SetNillableExternalReferenceID(i *int) *HashesEntryUpdate {
+	if i != nil {
+		heu.SetExternalReferenceID(*i)
+	}
+	return heu
+}
+
+// ClearExternalReferenceID clears the value of the "external_reference_id" field.
+func (heu *HashesEntryUpdate) ClearExternalReferenceID() *HashesEntryUpdate {
+	heu.mutation.ClearExternalReferenceID()
+	return heu
+}
+
+// SetNodeID sets the "node_id" field.
+func (heu *HashesEntryUpdate) SetNodeID(s string) *HashesEntryUpdate {
+	heu.mutation.SetNodeID(s)
+	return heu
+}
+
+// SetNillableNodeID sets the "node_id" field if the given value is not nil.
+func (heu *HashesEntryUpdate) SetNillableNodeID(s *string) *HashesEntryUpdate {
+	if s != nil {
+		heu.SetNodeID(*s)
+	}
+	return heu
+}
+
+// ClearNodeID clears the value of the "node_id" field.
+func (heu *HashesEntryUpdate) ClearNodeID() *HashesEntryUpdate {
+	heu.mutation.ClearNodeID()
+	return heu
+}
+
 // SetHashAlgorithmType sets the "hash_algorithm_type" field.
 func (heu *HashesEntryUpdate) SetHashAlgorithmType(hat hashesentry.HashAlgorithmType) *HashesEntryUpdate {
 	heu.mutation.SetHashAlgorithmType(hat)
@@ -61,37 +101,9 @@ func (heu *HashesEntryUpdate) SetNillableHashData(s *string) *HashesEntryUpdate 
 	return heu
 }
 
-// SetExternalReferenceID sets the "external_reference" edge to the ExternalReference entity by ID.
-func (heu *HashesEntryUpdate) SetExternalReferenceID(id int) *HashesEntryUpdate {
-	heu.mutation.SetExternalReferenceID(id)
-	return heu
-}
-
-// SetNillableExternalReferenceID sets the "external_reference" edge to the ExternalReference entity by ID if the given value is not nil.
-func (heu *HashesEntryUpdate) SetNillableExternalReferenceID(id *int) *HashesEntryUpdate {
-	if id != nil {
-		heu = heu.SetExternalReferenceID(*id)
-	}
-	return heu
-}
-
 // SetExternalReference sets the "external_reference" edge to the ExternalReference entity.
 func (heu *HashesEntryUpdate) SetExternalReference(e *ExternalReference) *HashesEntryUpdate {
 	return heu.SetExternalReferenceID(e.ID)
-}
-
-// SetNodeID sets the "node" edge to the Node entity by ID.
-func (heu *HashesEntryUpdate) SetNodeID(id string) *HashesEntryUpdate {
-	heu.mutation.SetNodeID(id)
-	return heu
-}
-
-// SetNillableNodeID sets the "node" edge to the Node entity by ID if the given value is not nil.
-func (heu *HashesEntryUpdate) SetNillableNodeID(id *string) *HashesEntryUpdate {
-	if id != nil {
-		heu = heu.SetNodeID(*id)
-	}
-	return heu
 }
 
 // SetNode sets the "node" edge to the Node entity.
@@ -249,6 +261,46 @@ type HashesEntryUpdateOne struct {
 	mutation *HashesEntryMutation
 }
 
+// SetExternalReferenceID sets the "external_reference_id" field.
+func (heuo *HashesEntryUpdateOne) SetExternalReferenceID(i int) *HashesEntryUpdateOne {
+	heuo.mutation.SetExternalReferenceID(i)
+	return heuo
+}
+
+// SetNillableExternalReferenceID sets the "external_reference_id" field if the given value is not nil.
+func (heuo *HashesEntryUpdateOne) SetNillableExternalReferenceID(i *int) *HashesEntryUpdateOne {
+	if i != nil {
+		heuo.SetExternalReferenceID(*i)
+	}
+	return heuo
+}
+
+// ClearExternalReferenceID clears the value of the "external_reference_id" field.
+func (heuo *HashesEntryUpdateOne) ClearExternalReferenceID() *HashesEntryUpdateOne {
+	heuo.mutation.ClearExternalReferenceID()
+	return heuo
+}
+
+// SetNodeID sets the "node_id" field.
+func (heuo *HashesEntryUpdateOne) SetNodeID(s string) *HashesEntryUpdateOne {
+	heuo.mutation.SetNodeID(s)
+	return heuo
+}
+
+// SetNillableNodeID sets the "node_id" field if the given value is not nil.
+func (heuo *HashesEntryUpdateOne) SetNillableNodeID(s *string) *HashesEntryUpdateOne {
+	if s != nil {
+		heuo.SetNodeID(*s)
+	}
+	return heuo
+}
+
+// ClearNodeID clears the value of the "node_id" field.
+func (heuo *HashesEntryUpdateOne) ClearNodeID() *HashesEntryUpdateOne {
+	heuo.mutation.ClearNodeID()
+	return heuo
+}
+
 // SetHashAlgorithmType sets the "hash_algorithm_type" field.
 func (heuo *HashesEntryUpdateOne) SetHashAlgorithmType(hat hashesentry.HashAlgorithmType) *HashesEntryUpdateOne {
 	heuo.mutation.SetHashAlgorithmType(hat)
@@ -277,37 +329,9 @@ func (heuo *HashesEntryUpdateOne) SetNillableHashData(s *string) *HashesEntryUpd
 	return heuo
 }
 
-// SetExternalReferenceID sets the "external_reference" edge to the ExternalReference entity by ID.
-func (heuo *HashesEntryUpdateOne) SetExternalReferenceID(id int) *HashesEntryUpdateOne {
-	heuo.mutation.SetExternalReferenceID(id)
-	return heuo
-}
-
-// SetNillableExternalReferenceID sets the "external_reference" edge to the ExternalReference entity by ID if the given value is not nil.
-func (heuo *HashesEntryUpdateOne) SetNillableExternalReferenceID(id *int) *HashesEntryUpdateOne {
-	if id != nil {
-		heuo = heuo.SetExternalReferenceID(*id)
-	}
-	return heuo
-}
-
 // SetExternalReference sets the "external_reference" edge to the ExternalReference entity.
 func (heuo *HashesEntryUpdateOne) SetExternalReference(e *ExternalReference) *HashesEntryUpdateOne {
 	return heuo.SetExternalReferenceID(e.ID)
-}
-
-// SetNodeID sets the "node" edge to the Node entity by ID.
-func (heuo *HashesEntryUpdateOne) SetNodeID(id string) *HashesEntryUpdateOne {
-	heuo.mutation.SetNodeID(id)
-	return heuo
-}
-
-// SetNillableNodeID sets the "node" edge to the Node entity by ID if the given value is not nil.
-func (heuo *HashesEntryUpdateOne) SetNillableNodeID(id *string) *HashesEntryUpdateOne {
-	if id != nil {
-		heuo = heuo.SetNodeID(*id)
-	}
-	return heuo
 }
 
 // SetNode sets the "node" edge to the Node entity.

--- a/internal/backends/ent/identifiersentry/identifiersentry.go
+++ b/internal/backends/ent/identifiersentry/identifiersentry.go
@@ -19,6 +19,8 @@ const (
 	Label = "identifiers_entry"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
+	// FieldNodeID holds the string denoting the node_id field in the database.
+	FieldNodeID = "node_id"
 	// FieldSoftwareIdentifierType holds the string denoting the software_identifier_type field in the database.
 	FieldSoftwareIdentifierType = "software_identifier_type"
 	// FieldSoftwareIdentifierValue holds the string denoting the software_identifier_value field in the database.
@@ -33,31 +35,21 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "node" package.
 	NodeInverseTable = "nodes"
 	// NodeColumn is the table column denoting the node relation/edge.
-	NodeColumn = "node_identifiers"
+	NodeColumn = "node_id"
 )
 
 // Columns holds all SQL columns for identifiersentry fields.
 var Columns = []string{
 	FieldID,
+	FieldNodeID,
 	FieldSoftwareIdentifierType,
 	FieldSoftwareIdentifierValue,
-}
-
-// ForeignKeys holds the SQL foreign-keys that are owned by the "identifiers_entries"
-// table and are not defined as standalone fields in the schema.
-var ForeignKeys = []string{
-	"node_identifiers",
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
-			return true
-		}
-	}
-	for i := range ForeignKeys {
-		if column == ForeignKeys[i] {
 			return true
 		}
 	}
@@ -96,6 +88,11 @@ type OrderOption func(*sql.Selector)
 // ByID orders the results by the id field.
 func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByNodeID orders the results by the node_id field.
+func ByNodeID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldNodeID, opts...).ToFunc()
 }
 
 // BySoftwareIdentifierType orders the results by the software_identifier_type field.

--- a/internal/backends/ent/identifiersentry/where.go
+++ b/internal/backends/ent/identifiersentry/where.go
@@ -58,9 +58,89 @@ func IDLTE(id int) predicate.IdentifiersEntry {
 	return predicate.IdentifiersEntry(sql.FieldLTE(FieldID, id))
 }
 
+// NodeID applies equality check predicate on the "node_id" field. It's identical to NodeIDEQ.
+func NodeID(v string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldEQ(FieldNodeID, v))
+}
+
 // SoftwareIdentifierValue applies equality check predicate on the "software_identifier_value" field. It's identical to SoftwareIdentifierValueEQ.
 func SoftwareIdentifierValue(v string) predicate.IdentifiersEntry {
 	return predicate.IdentifiersEntry(sql.FieldEQ(FieldSoftwareIdentifierValue, v))
+}
+
+// NodeIDEQ applies the EQ predicate on the "node_id" field.
+func NodeIDEQ(v string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldEQ(FieldNodeID, v))
+}
+
+// NodeIDNEQ applies the NEQ predicate on the "node_id" field.
+func NodeIDNEQ(v string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldNEQ(FieldNodeID, v))
+}
+
+// NodeIDIn applies the In predicate on the "node_id" field.
+func NodeIDIn(vs ...string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldIn(FieldNodeID, vs...))
+}
+
+// NodeIDNotIn applies the NotIn predicate on the "node_id" field.
+func NodeIDNotIn(vs ...string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldNotIn(FieldNodeID, vs...))
+}
+
+// NodeIDGT applies the GT predicate on the "node_id" field.
+func NodeIDGT(v string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldGT(FieldNodeID, v))
+}
+
+// NodeIDGTE applies the GTE predicate on the "node_id" field.
+func NodeIDGTE(v string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldGTE(FieldNodeID, v))
+}
+
+// NodeIDLT applies the LT predicate on the "node_id" field.
+func NodeIDLT(v string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldLT(FieldNodeID, v))
+}
+
+// NodeIDLTE applies the LTE predicate on the "node_id" field.
+func NodeIDLTE(v string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldLTE(FieldNodeID, v))
+}
+
+// NodeIDContains applies the Contains predicate on the "node_id" field.
+func NodeIDContains(v string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldContains(FieldNodeID, v))
+}
+
+// NodeIDHasPrefix applies the HasPrefix predicate on the "node_id" field.
+func NodeIDHasPrefix(v string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldHasPrefix(FieldNodeID, v))
+}
+
+// NodeIDHasSuffix applies the HasSuffix predicate on the "node_id" field.
+func NodeIDHasSuffix(v string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldHasSuffix(FieldNodeID, v))
+}
+
+// NodeIDIsNil applies the IsNil predicate on the "node_id" field.
+func NodeIDIsNil() predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldIsNull(FieldNodeID))
+}
+
+// NodeIDNotNil applies the NotNil predicate on the "node_id" field.
+func NodeIDNotNil() predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldNotNull(FieldNodeID))
+}
+
+// NodeIDEqualFold applies the EqualFold predicate on the "node_id" field.
+func NodeIDEqualFold(v string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldEqualFold(FieldNodeID, v))
+}
+
+// NodeIDContainsFold applies the ContainsFold predicate on the "node_id" field.
+func NodeIDContainsFold(v string) predicate.IdentifiersEntry {
+	return predicate.IdentifiersEntry(sql.FieldContainsFold(FieldNodeID, v))
 }
 
 // SoftwareIdentifierTypeEQ applies the EQ predicate on the "software_identifier_type" field.

--- a/internal/backends/ent/identifiersentry_create.go
+++ b/internal/backends/ent/identifiersentry_create.go
@@ -26,6 +26,20 @@ type IdentifiersEntryCreate struct {
 	conflict []sql.ConflictOption
 }
 
+// SetNodeID sets the "node_id" field.
+func (iec *IdentifiersEntryCreate) SetNodeID(s string) *IdentifiersEntryCreate {
+	iec.mutation.SetNodeID(s)
+	return iec
+}
+
+// SetNillableNodeID sets the "node_id" field if the given value is not nil.
+func (iec *IdentifiersEntryCreate) SetNillableNodeID(s *string) *IdentifiersEntryCreate {
+	if s != nil {
+		iec.SetNodeID(*s)
+	}
+	return iec
+}
+
 // SetSoftwareIdentifierType sets the "software_identifier_type" field.
 func (iec *IdentifiersEntryCreate) SetSoftwareIdentifierType(iit identifiersentry.SoftwareIdentifierType) *IdentifiersEntryCreate {
 	iec.mutation.SetSoftwareIdentifierType(iit)
@@ -35,20 +49,6 @@ func (iec *IdentifiersEntryCreate) SetSoftwareIdentifierType(iit identifiersentr
 // SetSoftwareIdentifierValue sets the "software_identifier_value" field.
 func (iec *IdentifiersEntryCreate) SetSoftwareIdentifierValue(s string) *IdentifiersEntryCreate {
 	iec.mutation.SetSoftwareIdentifierValue(s)
-	return iec
-}
-
-// SetNodeID sets the "node" edge to the Node entity by ID.
-func (iec *IdentifiersEntryCreate) SetNodeID(id string) *IdentifiersEntryCreate {
-	iec.mutation.SetNodeID(id)
-	return iec
-}
-
-// SetNillableNodeID sets the "node" edge to the Node entity by ID if the given value is not nil.
-func (iec *IdentifiersEntryCreate) SetNillableNodeID(id *string) *IdentifiersEntryCreate {
-	if id != nil {
-		iec = iec.SetNodeID(*id)
-	}
 	return iec
 }
 
@@ -151,7 +151,7 @@ func (iec *IdentifiersEntryCreate) createSpec() (*IdentifiersEntry, *sqlgraph.Cr
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.node_identifiers = &nodes[0]
+		_node.NodeID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec
@@ -161,7 +161,7 @@ func (iec *IdentifiersEntryCreate) createSpec() (*IdentifiersEntry, *sqlgraph.Cr
 // of the `INSERT` statement. For example:
 //
 //	client.IdentifiersEntry.Create().
-//		SetSoftwareIdentifierType(v).
+//		SetNodeID(v).
 //		OnConflict(
 //			// Update the row with the new values
 //			// the was proposed for insertion.
@@ -170,7 +170,7 @@ func (iec *IdentifiersEntryCreate) createSpec() (*IdentifiersEntry, *sqlgraph.Cr
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.IdentifiersEntryUpsert) {
-//			SetSoftwareIdentifierType(v+v).
+//			SetNodeID(v+v).
 //		}).
 //		Exec(ctx)
 func (iec *IdentifiersEntryCreate) OnConflict(opts ...sql.ConflictOption) *IdentifiersEntryUpsertOne {
@@ -205,6 +205,24 @@ type (
 		*sql.UpdateSet
 	}
 )
+
+// SetNodeID sets the "node_id" field.
+func (u *IdentifiersEntryUpsert) SetNodeID(v string) *IdentifiersEntryUpsert {
+	u.Set(identifiersentry.FieldNodeID, v)
+	return u
+}
+
+// UpdateNodeID sets the "node_id" field to the value that was provided on create.
+func (u *IdentifiersEntryUpsert) UpdateNodeID() *IdentifiersEntryUpsert {
+	u.SetExcluded(identifiersentry.FieldNodeID)
+	return u
+}
+
+// ClearNodeID clears the value of the "node_id" field.
+func (u *IdentifiersEntryUpsert) ClearNodeID() *IdentifiersEntryUpsert {
+	u.SetNull(identifiersentry.FieldNodeID)
+	return u
+}
 
 // SetSoftwareIdentifierType sets the "software_identifier_type" field.
 func (u *IdentifiersEntryUpsert) SetSoftwareIdentifierType(v identifiersentry.SoftwareIdentifierType) *IdentifiersEntryUpsert {
@@ -268,6 +286,27 @@ func (u *IdentifiersEntryUpsertOne) Update(set func(*IdentifiersEntryUpsert)) *I
 		set(&IdentifiersEntryUpsert{UpdateSet: update})
 	}))
 	return u
+}
+
+// SetNodeID sets the "node_id" field.
+func (u *IdentifiersEntryUpsertOne) SetNodeID(v string) *IdentifiersEntryUpsertOne {
+	return u.Update(func(s *IdentifiersEntryUpsert) {
+		s.SetNodeID(v)
+	})
+}
+
+// UpdateNodeID sets the "node_id" field to the value that was provided on create.
+func (u *IdentifiersEntryUpsertOne) UpdateNodeID() *IdentifiersEntryUpsertOne {
+	return u.Update(func(s *IdentifiersEntryUpsert) {
+		s.UpdateNodeID()
+	})
+}
+
+// ClearNodeID clears the value of the "node_id" field.
+func (u *IdentifiersEntryUpsertOne) ClearNodeID() *IdentifiersEntryUpsertOne {
+	return u.Update(func(s *IdentifiersEntryUpsert) {
+		s.ClearNodeID()
+	})
 }
 
 // SetSoftwareIdentifierType sets the "software_identifier_type" field.
@@ -432,7 +471,7 @@ func (iecb *IdentifiersEntryCreateBulk) ExecX(ctx context.Context) {
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.IdentifiersEntryUpsert) {
-//			SetSoftwareIdentifierType(v+v).
+//			SetNodeID(v+v).
 //		}).
 //		Exec(ctx)
 func (iecb *IdentifiersEntryCreateBulk) OnConflict(opts ...sql.ConflictOption) *IdentifiersEntryUpsertBulk {
@@ -499,6 +538,27 @@ func (u *IdentifiersEntryUpsertBulk) Update(set func(*IdentifiersEntryUpsert)) *
 		set(&IdentifiersEntryUpsert{UpdateSet: update})
 	}))
 	return u
+}
+
+// SetNodeID sets the "node_id" field.
+func (u *IdentifiersEntryUpsertBulk) SetNodeID(v string) *IdentifiersEntryUpsertBulk {
+	return u.Update(func(s *IdentifiersEntryUpsert) {
+		s.SetNodeID(v)
+	})
+}
+
+// UpdateNodeID sets the "node_id" field to the value that was provided on create.
+func (u *IdentifiersEntryUpsertBulk) UpdateNodeID() *IdentifiersEntryUpsertBulk {
+	return u.Update(func(s *IdentifiersEntryUpsert) {
+		s.UpdateNodeID()
+	})
+}
+
+// ClearNodeID clears the value of the "node_id" field.
+func (u *IdentifiersEntryUpsertBulk) ClearNodeID() *IdentifiersEntryUpsertBulk {
+	return u.Update(func(s *IdentifiersEntryUpsert) {
+		s.ClearNodeID()
+	})
 }
 
 // SetSoftwareIdentifierType sets the "software_identifier_type" field.

--- a/internal/backends/ent/identifiersentry_update.go
+++ b/internal/backends/ent/identifiersentry_update.go
@@ -32,6 +32,26 @@ func (ieu *IdentifiersEntryUpdate) Where(ps ...predicate.IdentifiersEntry) *Iden
 	return ieu
 }
 
+// SetNodeID sets the "node_id" field.
+func (ieu *IdentifiersEntryUpdate) SetNodeID(s string) *IdentifiersEntryUpdate {
+	ieu.mutation.SetNodeID(s)
+	return ieu
+}
+
+// SetNillableNodeID sets the "node_id" field if the given value is not nil.
+func (ieu *IdentifiersEntryUpdate) SetNillableNodeID(s *string) *IdentifiersEntryUpdate {
+	if s != nil {
+		ieu.SetNodeID(*s)
+	}
+	return ieu
+}
+
+// ClearNodeID clears the value of the "node_id" field.
+func (ieu *IdentifiersEntryUpdate) ClearNodeID() *IdentifiersEntryUpdate {
+	ieu.mutation.ClearNodeID()
+	return ieu
+}
+
 // SetSoftwareIdentifierType sets the "software_identifier_type" field.
 func (ieu *IdentifiersEntryUpdate) SetSoftwareIdentifierType(iit identifiersentry.SoftwareIdentifierType) *IdentifiersEntryUpdate {
 	ieu.mutation.SetSoftwareIdentifierType(iit)
@@ -56,20 +76,6 @@ func (ieu *IdentifiersEntryUpdate) SetSoftwareIdentifierValue(s string) *Identif
 func (ieu *IdentifiersEntryUpdate) SetNillableSoftwareIdentifierValue(s *string) *IdentifiersEntryUpdate {
 	if s != nil {
 		ieu.SetSoftwareIdentifierValue(*s)
-	}
-	return ieu
-}
-
-// SetNodeID sets the "node" edge to the Node entity by ID.
-func (ieu *IdentifiersEntryUpdate) SetNodeID(id string) *IdentifiersEntryUpdate {
-	ieu.mutation.SetNodeID(id)
-	return ieu
-}
-
-// SetNillableNodeID sets the "node" edge to the Node entity by ID if the given value is not nil.
-func (ieu *IdentifiersEntryUpdate) SetNillableNodeID(id *string) *IdentifiersEntryUpdate {
-	if id != nil {
-		ieu = ieu.SetNodeID(*id)
 	}
 	return ieu
 }
@@ -194,6 +200,26 @@ type IdentifiersEntryUpdateOne struct {
 	mutation *IdentifiersEntryMutation
 }
 
+// SetNodeID sets the "node_id" field.
+func (ieuo *IdentifiersEntryUpdateOne) SetNodeID(s string) *IdentifiersEntryUpdateOne {
+	ieuo.mutation.SetNodeID(s)
+	return ieuo
+}
+
+// SetNillableNodeID sets the "node_id" field if the given value is not nil.
+func (ieuo *IdentifiersEntryUpdateOne) SetNillableNodeID(s *string) *IdentifiersEntryUpdateOne {
+	if s != nil {
+		ieuo.SetNodeID(*s)
+	}
+	return ieuo
+}
+
+// ClearNodeID clears the value of the "node_id" field.
+func (ieuo *IdentifiersEntryUpdateOne) ClearNodeID() *IdentifiersEntryUpdateOne {
+	ieuo.mutation.ClearNodeID()
+	return ieuo
+}
+
 // SetSoftwareIdentifierType sets the "software_identifier_type" field.
 func (ieuo *IdentifiersEntryUpdateOne) SetSoftwareIdentifierType(iit identifiersentry.SoftwareIdentifierType) *IdentifiersEntryUpdateOne {
 	ieuo.mutation.SetSoftwareIdentifierType(iit)
@@ -218,20 +244,6 @@ func (ieuo *IdentifiersEntryUpdateOne) SetSoftwareIdentifierValue(s string) *Ide
 func (ieuo *IdentifiersEntryUpdateOne) SetNillableSoftwareIdentifierValue(s *string) *IdentifiersEntryUpdateOne {
 	if s != nil {
 		ieuo.SetSoftwareIdentifierValue(*s)
-	}
-	return ieuo
-}
-
-// SetNodeID sets the "node" edge to the Node entity by ID.
-func (ieuo *IdentifiersEntryUpdateOne) SetNodeID(id string) *IdentifiersEntryUpdateOne {
-	ieuo.mutation.SetNodeID(id)
-	return ieuo
-}
-
-// SetNillableNodeID sets the "node" edge to the Node entity by ID if the given value is not nil.
-func (ieuo *IdentifiersEntryUpdateOne) SetNillableNodeID(id *string) *IdentifiersEntryUpdateOne {
-	if id != nil {
-		ieuo = ieuo.SetNodeID(*id)
 	}
 	return ieuo
 }

--- a/internal/backends/ent/migrate/schema.go
+++ b/internal/backends/ent/migrate/schema.go
@@ -47,7 +47,7 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "documenttype_metadata_id_type_name_description",
+				Name:    "idx_document_types",
 				Unique:  true,
 				Columns: []*schema.Column{DocumentTypesColumns[4], DocumentTypesColumns[1], DocumentTypesColumns[2], DocumentTypesColumns[3]},
 			},
@@ -81,7 +81,7 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "edgetype_type_node_id_to_node_id",
+				Name:    "idx_edge_types",
 				Unique:  true,
 				Columns: []*schema.Column{EdgeTypesColumns[1], EdgeTypesColumns[2], EdgeTypesColumns[3]},
 			},
@@ -116,7 +116,7 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "externalreference_node_id_url_type",
+				Name:    "idx_external_references",
 				Unique:  true,
 				Columns: []*schema.Column{ExternalReferencesColumns[5], ExternalReferencesColumns[1], ExternalReferencesColumns[4]},
 			},
@@ -151,7 +151,7 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "hashesentry_external_reference_id_node_id_hash_algorithm_type_hash_data",
+				Name:    "idx_hashes_entries",
 				Unique:  true,
 				Columns: []*schema.Column{HashesEntriesColumns[3], HashesEntriesColumns[4], HashesEntriesColumns[1], HashesEntriesColumns[2]},
 			},
@@ -179,9 +179,9 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "identifiersentry_software_identifier_type_software_identifier_value",
+				Name:    "idx_identifiers_entries",
 				Unique:  true,
-				Columns: []*schema.Column{IdentifiersEntriesColumns[1], IdentifiersEntriesColumns[2]},
+				Columns: []*schema.Column{IdentifiersEntriesColumns[3], IdentifiersEntriesColumns[1], IdentifiersEntriesColumns[2]},
 			},
 		},
 	}
@@ -208,7 +208,7 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "metadata_id_version_name",
+				Name:    "idx_metadata",
 				Unique:  true,
 				Columns: []*schema.Column{MetadataColumns[0], MetadataColumns[1], MetadataColumns[2]},
 			},
@@ -253,7 +253,7 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "node_id_node_list_id",
+				Name:    "idx_nodes",
 				Unique:  true,
 				Columns: []*schema.Column{NodesColumns[0], NodesColumns[20]},
 			},
@@ -325,7 +325,7 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "person_metadata_id_name_is_org_email_url_phone",
+				Name:    "idx_person_metadata_id",
 				Unique:  true,
 				Columns: []*schema.Column{PersonsColumns[6], PersonsColumns[1], PersonsColumns[2], PersonsColumns[3], PersonsColumns[4], PersonsColumns[5]},
 				Annotation: &entsql.IndexAnnotation{
@@ -333,7 +333,7 @@ var (
 				},
 			},
 			{
-				Name:    "person_node_id_name_is_org_email_url_phone",
+				Name:    "idx_person_node_id",
 				Unique:  true,
 				Columns: []*schema.Column{PersonsColumns[8], PersonsColumns[1], PersonsColumns[2], PersonsColumns[3], PersonsColumns[4], PersonsColumns[5]},
 				Annotation: &entsql.IndexAnnotation{
@@ -363,7 +363,7 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "purpose_node_id_primary_purpose",
+				Name:    "idx_purposes",
 				Unique:  true,
 				Columns: []*schema.Column{PurposesColumns[2], PurposesColumns[1]},
 			},
@@ -392,7 +392,7 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "tool_metadata_id_name_version_vendor",
+				Name:    "idx_tools",
 				Unique:  true,
 				Columns: []*schema.Column{ToolsColumns[4], ToolsColumns[1], ToolsColumns[2], ToolsColumns[3]},
 			},

--- a/internal/backends/ent/migrate/schema.go
+++ b/internal/backends/ent/migrate/schema.go
@@ -127,8 +127,8 @@ var (
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "hash_algorithm_type", Type: field.TypeEnum, Enums: []string{"UNKNOWN", "MD5", "SHA1", "SHA256", "SHA384", "SHA512", "SHA3_256", "SHA3_384", "SHA3_512", "BLAKE2B_256", "BLAKE2B_384", "BLAKE2B_512", "BLAKE3", "MD2", "ADLER32", "MD4", "MD6", "SHA224"}},
 		{Name: "hash_data", Type: field.TypeString},
-		{Name: "external_reference_hashes", Type: field.TypeInt, Nullable: true},
-		{Name: "node_hashes", Type: field.TypeString, Nullable: true},
+		{Name: "external_reference_id", Type: field.TypeInt, Nullable: true},
+		{Name: "node_id", Type: field.TypeString, Nullable: true},
 	}
 	// HashesEntriesTable holds the schema information for the "hashes_entries" table.
 	HashesEntriesTable = &schema.Table{
@@ -151,9 +151,9 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "hashesentry_hash_algorithm_type_hash_data",
+				Name:    "hashesentry_external_reference_id_node_id_hash_algorithm_type_hash_data",
 				Unique:  true,
-				Columns: []*schema.Column{HashesEntriesColumns[1], HashesEntriesColumns[2]},
+				Columns: []*schema.Column{HashesEntriesColumns[3], HashesEntriesColumns[4], HashesEntriesColumns[1], HashesEntriesColumns[2]},
 			},
 		},
 	}
@@ -162,7 +162,7 @@ var (
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "software_identifier_type", Type: field.TypeEnum, Enums: []string{"UNKNOWN_IDENTIFIER_TYPE", "PURL", "CPE22", "CPE23", "GITOID"}},
 		{Name: "software_identifier_value", Type: field.TypeString},
-		{Name: "node_identifiers", Type: field.TypeString, Nullable: true},
+		{Name: "node_id", Type: field.TypeString, Nullable: true},
 	}
 	// IdentifiersEntriesTable holds the schema information for the "identifiers_entries" table.
 	IdentifiersEntriesTable = &schema.Table{
@@ -276,16 +276,6 @@ var (
 				Columns:    []*schema.Column{NodeListsColumns[2]},
 				RefColumns: []*schema.Column{DocumentsColumns[0]},
 				OnDelete:   schema.NoAction,
-			},
-		},
-		Indexes: []*schema.Index{
-			{
-				Name:    "nodelist_document_id_root_elements",
-				Unique:  true,
-				Columns: []*schema.Column{NodeListsColumns[2], NodeListsColumns[1]},
-				Annotation: &entsql.IndexAnnotation{
-					Where: "root_elements IS NOT NULL",
-				},
 			},
 		},
 	}

--- a/internal/backends/ent/mutation.go
+++ b/internal/backends/ent/mutation.go
@@ -2468,6 +2468,104 @@ func (m *HashesEntryMutation) IDs(ctx context.Context) ([]int, error) {
 	}
 }
 
+// SetExternalReferenceID sets the "external_reference_id" field.
+func (m *HashesEntryMutation) SetExternalReferenceID(i int) {
+	m.external_reference = &i
+}
+
+// ExternalReferenceID returns the value of the "external_reference_id" field in the mutation.
+func (m *HashesEntryMutation) ExternalReferenceID() (r int, exists bool) {
+	v := m.external_reference
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExternalReferenceID returns the old "external_reference_id" field's value of the HashesEntry entity.
+// If the HashesEntry object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *HashesEntryMutation) OldExternalReferenceID(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExternalReferenceID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExternalReferenceID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExternalReferenceID: %w", err)
+	}
+	return oldValue.ExternalReferenceID, nil
+}
+
+// ClearExternalReferenceID clears the value of the "external_reference_id" field.
+func (m *HashesEntryMutation) ClearExternalReferenceID() {
+	m.external_reference = nil
+	m.clearedFields[hashesentry.FieldExternalReferenceID] = struct{}{}
+}
+
+// ExternalReferenceIDCleared returns if the "external_reference_id" field was cleared in this mutation.
+func (m *HashesEntryMutation) ExternalReferenceIDCleared() bool {
+	_, ok := m.clearedFields[hashesentry.FieldExternalReferenceID]
+	return ok
+}
+
+// ResetExternalReferenceID resets all changes to the "external_reference_id" field.
+func (m *HashesEntryMutation) ResetExternalReferenceID() {
+	m.external_reference = nil
+	delete(m.clearedFields, hashesentry.FieldExternalReferenceID)
+}
+
+// SetNodeID sets the "node_id" field.
+func (m *HashesEntryMutation) SetNodeID(s string) {
+	m.node = &s
+}
+
+// NodeID returns the value of the "node_id" field in the mutation.
+func (m *HashesEntryMutation) NodeID() (r string, exists bool) {
+	v := m.node
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldNodeID returns the old "node_id" field's value of the HashesEntry entity.
+// If the HashesEntry object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *HashesEntryMutation) OldNodeID(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldNodeID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldNodeID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldNodeID: %w", err)
+	}
+	return oldValue.NodeID, nil
+}
+
+// ClearNodeID clears the value of the "node_id" field.
+func (m *HashesEntryMutation) ClearNodeID() {
+	m.node = nil
+	m.clearedFields[hashesentry.FieldNodeID] = struct{}{}
+}
+
+// NodeIDCleared returns if the "node_id" field was cleared in this mutation.
+func (m *HashesEntryMutation) NodeIDCleared() bool {
+	_, ok := m.clearedFields[hashesentry.FieldNodeID]
+	return ok
+}
+
+// ResetNodeID resets all changes to the "node_id" field.
+func (m *HashesEntryMutation) ResetNodeID() {
+	m.node = nil
+	delete(m.clearedFields, hashesentry.FieldNodeID)
+}
+
 // SetHashAlgorithmType sets the "hash_algorithm_type" field.
 func (m *HashesEntryMutation) SetHashAlgorithmType(hat hashesentry.HashAlgorithmType) {
 	m.hash_algorithm_type = &hat
@@ -2540,27 +2638,15 @@ func (m *HashesEntryMutation) ResetHashData() {
 	m.hash_data = nil
 }
 
-// SetExternalReferenceID sets the "external_reference" edge to the ExternalReference entity by id.
-func (m *HashesEntryMutation) SetExternalReferenceID(id int) {
-	m.external_reference = &id
-}
-
 // ClearExternalReference clears the "external_reference" edge to the ExternalReference entity.
 func (m *HashesEntryMutation) ClearExternalReference() {
 	m.clearedexternal_reference = true
+	m.clearedFields[hashesentry.FieldExternalReferenceID] = struct{}{}
 }
 
 // ExternalReferenceCleared reports if the "external_reference" edge to the ExternalReference entity was cleared.
 func (m *HashesEntryMutation) ExternalReferenceCleared() bool {
-	return m.clearedexternal_reference
-}
-
-// ExternalReferenceID returns the "external_reference" edge ID in the mutation.
-func (m *HashesEntryMutation) ExternalReferenceID() (id int, exists bool) {
-	if m.external_reference != nil {
-		return *m.external_reference, true
-	}
-	return
+	return m.ExternalReferenceIDCleared() || m.clearedexternal_reference
 }
 
 // ExternalReferenceIDs returns the "external_reference" edge IDs in the mutation.
@@ -2579,27 +2665,15 @@ func (m *HashesEntryMutation) ResetExternalReference() {
 	m.clearedexternal_reference = false
 }
 
-// SetNodeID sets the "node" edge to the Node entity by id.
-func (m *HashesEntryMutation) SetNodeID(id string) {
-	m.node = &id
-}
-
 // ClearNode clears the "node" edge to the Node entity.
 func (m *HashesEntryMutation) ClearNode() {
 	m.clearednode = true
+	m.clearedFields[hashesentry.FieldNodeID] = struct{}{}
 }
 
 // NodeCleared reports if the "node" edge to the Node entity was cleared.
 func (m *HashesEntryMutation) NodeCleared() bool {
-	return m.clearednode
-}
-
-// NodeID returns the "node" edge ID in the mutation.
-func (m *HashesEntryMutation) NodeID() (id string, exists bool) {
-	if m.node != nil {
-		return *m.node, true
-	}
-	return
+	return m.NodeIDCleared() || m.clearednode
 }
 
 // NodeIDs returns the "node" edge IDs in the mutation.
@@ -2652,7 +2726,13 @@ func (m *HashesEntryMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *HashesEntryMutation) Fields() []string {
-	fields := make([]string, 0, 2)
+	fields := make([]string, 0, 4)
+	if m.external_reference != nil {
+		fields = append(fields, hashesentry.FieldExternalReferenceID)
+	}
+	if m.node != nil {
+		fields = append(fields, hashesentry.FieldNodeID)
+	}
 	if m.hash_algorithm_type != nil {
 		fields = append(fields, hashesentry.FieldHashAlgorithmType)
 	}
@@ -2667,6 +2747,10 @@ func (m *HashesEntryMutation) Fields() []string {
 // schema.
 func (m *HashesEntryMutation) Field(name string) (ent.Value, bool) {
 	switch name {
+	case hashesentry.FieldExternalReferenceID:
+		return m.ExternalReferenceID()
+	case hashesentry.FieldNodeID:
+		return m.NodeID()
 	case hashesentry.FieldHashAlgorithmType:
 		return m.HashAlgorithmType()
 	case hashesentry.FieldHashData:
@@ -2680,6 +2764,10 @@ func (m *HashesEntryMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *HashesEntryMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
+	case hashesentry.FieldExternalReferenceID:
+		return m.OldExternalReferenceID(ctx)
+	case hashesentry.FieldNodeID:
+		return m.OldNodeID(ctx)
 	case hashesentry.FieldHashAlgorithmType:
 		return m.OldHashAlgorithmType(ctx)
 	case hashesentry.FieldHashData:
@@ -2693,6 +2781,20 @@ func (m *HashesEntryMutation) OldField(ctx context.Context, name string) (ent.Va
 // type.
 func (m *HashesEntryMutation) SetField(name string, value ent.Value) error {
 	switch name {
+	case hashesentry.FieldExternalReferenceID:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExternalReferenceID(v)
+		return nil
+	case hashesentry.FieldNodeID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetNodeID(v)
+		return nil
 	case hashesentry.FieldHashAlgorithmType:
 		v, ok := value.(hashesentry.HashAlgorithmType)
 		if !ok {
@@ -2714,13 +2816,16 @@ func (m *HashesEntryMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *HashesEntryMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *HashesEntryMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	}
 	return nil, false
 }
 
@@ -2736,7 +2841,14 @@ func (m *HashesEntryMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *HashesEntryMutation) ClearedFields() []string {
-	return nil
+	var fields []string
+	if m.FieldCleared(hashesentry.FieldExternalReferenceID) {
+		fields = append(fields, hashesentry.FieldExternalReferenceID)
+	}
+	if m.FieldCleared(hashesentry.FieldNodeID) {
+		fields = append(fields, hashesentry.FieldNodeID)
+	}
+	return fields
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -2749,6 +2861,14 @@ func (m *HashesEntryMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *HashesEntryMutation) ClearField(name string) error {
+	switch name {
+	case hashesentry.FieldExternalReferenceID:
+		m.ClearExternalReferenceID()
+		return nil
+	case hashesentry.FieldNodeID:
+		m.ClearNodeID()
+		return nil
+	}
 	return fmt.Errorf("unknown HashesEntry nullable field %s", name)
 }
 
@@ -2756,6 +2876,12 @@ func (m *HashesEntryMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *HashesEntryMutation) ResetField(name string) error {
 	switch name {
+	case hashesentry.FieldExternalReferenceID:
+		m.ResetExternalReferenceID()
+		return nil
+	case hashesentry.FieldNodeID:
+		m.ResetNodeID()
+		return nil
 	case hashesentry.FieldHashAlgorithmType:
 		m.ResetHashAlgorithmType()
 		return nil
@@ -2972,6 +3098,55 @@ func (m *IdentifiersEntryMutation) IDs(ctx context.Context) ([]int, error) {
 	}
 }
 
+// SetNodeID sets the "node_id" field.
+func (m *IdentifiersEntryMutation) SetNodeID(s string) {
+	m.node = &s
+}
+
+// NodeID returns the value of the "node_id" field in the mutation.
+func (m *IdentifiersEntryMutation) NodeID() (r string, exists bool) {
+	v := m.node
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldNodeID returns the old "node_id" field's value of the IdentifiersEntry entity.
+// If the IdentifiersEntry object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *IdentifiersEntryMutation) OldNodeID(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldNodeID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldNodeID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldNodeID: %w", err)
+	}
+	return oldValue.NodeID, nil
+}
+
+// ClearNodeID clears the value of the "node_id" field.
+func (m *IdentifiersEntryMutation) ClearNodeID() {
+	m.node = nil
+	m.clearedFields[identifiersentry.FieldNodeID] = struct{}{}
+}
+
+// NodeIDCleared returns if the "node_id" field was cleared in this mutation.
+func (m *IdentifiersEntryMutation) NodeIDCleared() bool {
+	_, ok := m.clearedFields[identifiersentry.FieldNodeID]
+	return ok
+}
+
+// ResetNodeID resets all changes to the "node_id" field.
+func (m *IdentifiersEntryMutation) ResetNodeID() {
+	m.node = nil
+	delete(m.clearedFields, identifiersentry.FieldNodeID)
+}
+
 // SetSoftwareIdentifierType sets the "software_identifier_type" field.
 func (m *IdentifiersEntryMutation) SetSoftwareIdentifierType(iit identifiersentry.SoftwareIdentifierType) {
 	m.software_identifier_type = &iit
@@ -3044,27 +3219,15 @@ func (m *IdentifiersEntryMutation) ResetSoftwareIdentifierValue() {
 	m.software_identifier_value = nil
 }
 
-// SetNodeID sets the "node" edge to the Node entity by id.
-func (m *IdentifiersEntryMutation) SetNodeID(id string) {
-	m.node = &id
-}
-
 // ClearNode clears the "node" edge to the Node entity.
 func (m *IdentifiersEntryMutation) ClearNode() {
 	m.clearednode = true
+	m.clearedFields[identifiersentry.FieldNodeID] = struct{}{}
 }
 
 // NodeCleared reports if the "node" edge to the Node entity was cleared.
 func (m *IdentifiersEntryMutation) NodeCleared() bool {
-	return m.clearednode
-}
-
-// NodeID returns the "node" edge ID in the mutation.
-func (m *IdentifiersEntryMutation) NodeID() (id string, exists bool) {
-	if m.node != nil {
-		return *m.node, true
-	}
-	return
+	return m.NodeIDCleared() || m.clearednode
 }
 
 // NodeIDs returns the "node" edge IDs in the mutation.
@@ -3117,7 +3280,10 @@ func (m *IdentifiersEntryMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *IdentifiersEntryMutation) Fields() []string {
-	fields := make([]string, 0, 2)
+	fields := make([]string, 0, 3)
+	if m.node != nil {
+		fields = append(fields, identifiersentry.FieldNodeID)
+	}
 	if m.software_identifier_type != nil {
 		fields = append(fields, identifiersentry.FieldSoftwareIdentifierType)
 	}
@@ -3132,6 +3298,8 @@ func (m *IdentifiersEntryMutation) Fields() []string {
 // schema.
 func (m *IdentifiersEntryMutation) Field(name string) (ent.Value, bool) {
 	switch name {
+	case identifiersentry.FieldNodeID:
+		return m.NodeID()
 	case identifiersentry.FieldSoftwareIdentifierType:
 		return m.SoftwareIdentifierType()
 	case identifiersentry.FieldSoftwareIdentifierValue:
@@ -3145,6 +3313,8 @@ func (m *IdentifiersEntryMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *IdentifiersEntryMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
+	case identifiersentry.FieldNodeID:
+		return m.OldNodeID(ctx)
 	case identifiersentry.FieldSoftwareIdentifierType:
 		return m.OldSoftwareIdentifierType(ctx)
 	case identifiersentry.FieldSoftwareIdentifierValue:
@@ -3158,6 +3328,13 @@ func (m *IdentifiersEntryMutation) OldField(ctx context.Context, name string) (e
 // type.
 func (m *IdentifiersEntryMutation) SetField(name string, value ent.Value) error {
 	switch name {
+	case identifiersentry.FieldNodeID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetNodeID(v)
+		return nil
 	case identifiersentry.FieldSoftwareIdentifierType:
 		v, ok := value.(identifiersentry.SoftwareIdentifierType)
 		if !ok {
@@ -3201,7 +3378,11 @@ func (m *IdentifiersEntryMutation) AddField(name string, value ent.Value) error 
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *IdentifiersEntryMutation) ClearedFields() []string {
-	return nil
+	var fields []string
+	if m.FieldCleared(identifiersentry.FieldNodeID) {
+		fields = append(fields, identifiersentry.FieldNodeID)
+	}
+	return fields
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -3214,6 +3395,11 @@ func (m *IdentifiersEntryMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *IdentifiersEntryMutation) ClearField(name string) error {
+	switch name {
+	case identifiersentry.FieldNodeID:
+		m.ClearNodeID()
+		return nil
+	}
 	return fmt.Errorf("unknown IdentifiersEntry nullable field %s", name)
 }
 
@@ -3221,6 +3407,9 @@ func (m *IdentifiersEntryMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *IdentifiersEntryMutation) ResetField(name string) error {
 	switch name {
+	case identifiersentry.FieldNodeID:
+		m.ResetNodeID()
+		return nil
 	case identifiersentry.FieldSoftwareIdentifierType:
 		m.ResetSoftwareIdentifierType()
 		return nil

--- a/internal/backends/ent/node/node.go
+++ b/internal/backends/ent/node/node.go
@@ -108,14 +108,14 @@ const (
 	// It exists in this package in order to avoid circular dependency with the "identifiersentry" package.
 	IdentifiersInverseTable = "identifiers_entries"
 	// IdentifiersColumn is the table column denoting the identifiers relation/edge.
-	IdentifiersColumn = "node_identifiers"
+	IdentifiersColumn = "node_id"
 	// HashesTable is the table that holds the hashes relation/edge.
 	HashesTable = "hashes_entries"
 	// HashesInverseTable is the table name for the HashesEntry entity.
 	// It exists in this package in order to avoid circular dependency with the "hashesentry" package.
 	HashesInverseTable = "hashes_entries"
 	// HashesColumn is the table column denoting the hashes relation/edge.
-	HashesColumn = "node_hashes"
+	HashesColumn = "node_id"
 	// PrimaryPurposeTable is the table that holds the primary_purpose relation/edge.
 	PrimaryPurposeTable = "purposes"
 	// PrimaryPurposeInverseTable is the table name for the Purpose entity.

--- a/internal/backends/ent/node_query.go
+++ b/internal/backends/ent/node_query.go
@@ -902,7 +902,9 @@ func (nq *NodeQuery) loadIdentifiers(ctx context.Context, query *IdentifiersEntr
 			init(nodes[i])
 		}
 	}
-	query.withFKs = true
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(identifiersentry.FieldNodeID)
+	}
 	query.Where(predicate.IdentifiersEntry(func(s *sql.Selector) {
 		s.Where(sql.InValues(s.C(node.IdentifiersColumn), fks...))
 	}))
@@ -911,13 +913,10 @@ func (nq *NodeQuery) loadIdentifiers(ctx context.Context, query *IdentifiersEntr
 		return err
 	}
 	for _, n := range neighbors {
-		fk := n.node_identifiers
-		if fk == nil {
-			return fmt.Errorf(`foreign-key "node_identifiers" is nil for node %v`, n.ID)
-		}
-		node, ok := nodeids[*fk]
+		fk := n.NodeID
+		node, ok := nodeids[fk]
 		if !ok {
-			return fmt.Errorf(`unexpected referenced foreign-key "node_identifiers" returned %v for node %v`, *fk, n.ID)
+			return fmt.Errorf(`unexpected referenced foreign-key "node_id" returned %v for node %v`, fk, n.ID)
 		}
 		assign(node, n)
 	}
@@ -933,7 +932,9 @@ func (nq *NodeQuery) loadHashes(ctx context.Context, query *HashesEntryQuery, no
 			init(nodes[i])
 		}
 	}
-	query.withFKs = true
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(hashesentry.FieldNodeID)
+	}
 	query.Where(predicate.HashesEntry(func(s *sql.Selector) {
 		s.Where(sql.InValues(s.C(node.HashesColumn), fks...))
 	}))
@@ -942,13 +943,10 @@ func (nq *NodeQuery) loadHashes(ctx context.Context, query *HashesEntryQuery, no
 		return err
 	}
 	for _, n := range neighbors {
-		fk := n.node_hashes
-		if fk == nil {
-			return fmt.Errorf(`foreign-key "node_hashes" is nil for node %v`, n.ID)
-		}
-		node, ok := nodeids[*fk]
+		fk := n.NodeID
+		node, ok := nodeids[fk]
 		if !ok {
-			return fmt.Errorf(`unexpected referenced foreign-key "node_hashes" returned %v for node %v`, *fk, n.ID)
+			return fmt.Errorf(`unexpected referenced foreign-key "node_id" returned %v for node %v`, fk, n.ID)
 		}
 		assign(node, n)
 	}

--- a/internal/backends/ent/nodelist_create.go
+++ b/internal/backends/ent/nodelist_create.go
@@ -218,18 +218,6 @@ type (
 	}
 )
 
-// SetDocumentID sets the "document_id" field.
-func (u *NodeListUpsert) SetDocumentID(v string) *NodeListUpsert {
-	u.Set(nodelist.FieldDocumentID, v)
-	return u
-}
-
-// UpdateDocumentID sets the "document_id" field to the value that was provided on create.
-func (u *NodeListUpsert) UpdateDocumentID() *NodeListUpsert {
-	u.SetExcluded(nodelist.FieldDocumentID)
-	return u
-}
-
 // SetRootElements sets the "root_elements" field.
 func (u *NodeListUpsert) SetRootElements(v []string) *NodeListUpsert {
 	u.Set(nodelist.FieldRootElements, v)
@@ -252,6 +240,11 @@ func (u *NodeListUpsert) UpdateRootElements() *NodeListUpsert {
 //		Exec(ctx)
 func (u *NodeListUpsertOne) UpdateNewValues() *NodeListUpsertOne {
 	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		if _, exists := u.create.mutation.DocumentID(); exists {
+			s.SetIgnore(nodelist.FieldDocumentID)
+		}
+	}))
 	return u
 }
 
@@ -280,20 +273,6 @@ func (u *NodeListUpsertOne) Update(set func(*NodeListUpsert)) *NodeListUpsertOne
 		set(&NodeListUpsert{UpdateSet: update})
 	}))
 	return u
-}
-
-// SetDocumentID sets the "document_id" field.
-func (u *NodeListUpsertOne) SetDocumentID(v string) *NodeListUpsertOne {
-	return u.Update(func(s *NodeListUpsert) {
-		s.SetDocumentID(v)
-	})
-}
-
-// UpdateDocumentID sets the "document_id" field to the value that was provided on create.
-func (u *NodeListUpsertOne) UpdateDocumentID() *NodeListUpsertOne {
-	return u.Update(func(s *NodeListUpsert) {
-		s.UpdateDocumentID()
-	})
 }
 
 // SetRootElements sets the "root_elements" field.
@@ -483,6 +462,13 @@ type NodeListUpsertBulk struct {
 //		Exec(ctx)
 func (u *NodeListUpsertBulk) UpdateNewValues() *NodeListUpsertBulk {
 	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		for _, b := range u.create.builders {
+			if _, exists := b.mutation.DocumentID(); exists {
+				s.SetIgnore(nodelist.FieldDocumentID)
+			}
+		}
+	}))
 	return u
 }
 
@@ -511,20 +497,6 @@ func (u *NodeListUpsertBulk) Update(set func(*NodeListUpsert)) *NodeListUpsertBu
 		set(&NodeListUpsert{UpdateSet: update})
 	}))
 	return u
-}
-
-// SetDocumentID sets the "document_id" field.
-func (u *NodeListUpsertBulk) SetDocumentID(v string) *NodeListUpsertBulk {
-	return u.Update(func(s *NodeListUpsert) {
-		s.SetDocumentID(v)
-	})
-}
-
-// UpdateDocumentID sets the "document_id" field to the value that was provided on create.
-func (u *NodeListUpsertBulk) UpdateDocumentID() *NodeListUpsertBulk {
-	return u.Update(func(s *NodeListUpsert) {
-		s.UpdateDocumentID()
-	})
 }
 
 // SetRootElements sets the "root_elements" field.

--- a/internal/backends/ent/nodelist_update.go
+++ b/internal/backends/ent/nodelist_update.go
@@ -15,7 +15,6 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
-	"github.com/protobom/storage/internal/backends/ent/document"
 	"github.com/protobom/storage/internal/backends/ent/node"
 	"github.com/protobom/storage/internal/backends/ent/nodelist"
 	"github.com/protobom/storage/internal/backends/ent/predicate"
@@ -31,20 +30,6 @@ type NodeListUpdate struct {
 // Where appends a list predicates to the NodeListUpdate builder.
 func (nlu *NodeListUpdate) Where(ps ...predicate.NodeList) *NodeListUpdate {
 	nlu.mutation.Where(ps...)
-	return nlu
-}
-
-// SetDocumentID sets the "document_id" field.
-func (nlu *NodeListUpdate) SetDocumentID(s string) *NodeListUpdate {
-	nlu.mutation.SetDocumentID(s)
-	return nlu
-}
-
-// SetNillableDocumentID sets the "document_id" field if the given value is not nil.
-func (nlu *NodeListUpdate) SetNillableDocumentID(s *string) *NodeListUpdate {
-	if s != nil {
-		nlu.SetDocumentID(*s)
-	}
 	return nlu
 }
 
@@ -75,11 +60,6 @@ func (nlu *NodeListUpdate) AddNodes(n ...*Node) *NodeListUpdate {
 	return nlu.AddNodeIDs(ids...)
 }
 
-// SetDocument sets the "document" edge to the Document entity.
-func (nlu *NodeListUpdate) SetDocument(d *Document) *NodeListUpdate {
-	return nlu.SetDocumentID(d.ID)
-}
-
 // Mutation returns the NodeListMutation object of the builder.
 func (nlu *NodeListUpdate) Mutation() *NodeListMutation {
 	return nlu.mutation
@@ -104,12 +84,6 @@ func (nlu *NodeListUpdate) RemoveNodes(n ...*Node) *NodeListUpdate {
 		ids[i] = n[i].ID
 	}
 	return nlu.RemoveNodeIDs(ids...)
-}
-
-// ClearDocument clears the "document" edge to the Document entity.
-func (nlu *NodeListUpdate) ClearDocument() *NodeListUpdate {
-	nlu.mutation.ClearDocument()
-	return nlu
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -212,35 +186,6 @@ func (nlu *NodeListUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if nlu.mutation.DocumentCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2O,
-			Inverse: true,
-			Table:   nodelist.DocumentTable,
-			Columns: []string{nodelist.DocumentColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeString),
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := nlu.mutation.DocumentIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2O,
-			Inverse: true,
-			Table:   nodelist.DocumentTable,
-			Columns: []string{nodelist.DocumentColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
 	if n, err = sqlgraph.UpdateNodes(ctx, nlu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{nodelist.Label}
@@ -259,20 +204,6 @@ type NodeListUpdateOne struct {
 	fields   []string
 	hooks    []Hook
 	mutation *NodeListMutation
-}
-
-// SetDocumentID sets the "document_id" field.
-func (nluo *NodeListUpdateOne) SetDocumentID(s string) *NodeListUpdateOne {
-	nluo.mutation.SetDocumentID(s)
-	return nluo
-}
-
-// SetNillableDocumentID sets the "document_id" field if the given value is not nil.
-func (nluo *NodeListUpdateOne) SetNillableDocumentID(s *string) *NodeListUpdateOne {
-	if s != nil {
-		nluo.SetDocumentID(*s)
-	}
-	return nluo
 }
 
 // SetRootElements sets the "root_elements" field.
@@ -302,11 +233,6 @@ func (nluo *NodeListUpdateOne) AddNodes(n ...*Node) *NodeListUpdateOne {
 	return nluo.AddNodeIDs(ids...)
 }
 
-// SetDocument sets the "document" edge to the Document entity.
-func (nluo *NodeListUpdateOne) SetDocument(d *Document) *NodeListUpdateOne {
-	return nluo.SetDocumentID(d.ID)
-}
-
 // Mutation returns the NodeListMutation object of the builder.
 func (nluo *NodeListUpdateOne) Mutation() *NodeListMutation {
 	return nluo.mutation
@@ -331,12 +257,6 @@ func (nluo *NodeListUpdateOne) RemoveNodes(n ...*Node) *NodeListUpdateOne {
 		ids[i] = n[i].ID
 	}
 	return nluo.RemoveNodeIDs(ids...)
-}
-
-// ClearDocument clears the "document" edge to the Document entity.
-func (nluo *NodeListUpdateOne) ClearDocument() *NodeListUpdateOne {
-	nluo.mutation.ClearDocument()
-	return nluo
 }
 
 // Where appends a list predicates to the NodeListUpdate builder.
@@ -462,35 +382,6 @@ func (nluo *NodeListUpdateOne) sqlSave(ctx context.Context) (_node *NodeList, er
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if nluo.mutation.DocumentCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2O,
-			Inverse: true,
-			Table:   nodelist.DocumentTable,
-			Columns: []string{nodelist.DocumentColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeString),
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := nluo.mutation.DocumentIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2O,
-			Inverse: true,
-			Table:   nodelist.DocumentTable,
-			Columns: []string{nodelist.DocumentColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/internal/backends/ent/schema/document_type.go
+++ b/internal/backends/ent/schema/document_type.go
@@ -43,6 +43,8 @@ func (DocumentType) Edges() []ent.Edge {
 
 func (DocumentType) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("metadata_id", "type", "name", "description").Unique(),
+		index.Fields("metadata_id", "type", "name", "description").
+			Unique().
+			StorageKey("idx_document_types"),
 	}
 }

--- a/internal/backends/ent/schema/edge_type.go
+++ b/internal/backends/ent/schema/edge_type.go
@@ -79,6 +79,8 @@ func (EdgeType) Edges() []ent.Edge {
 
 func (EdgeType) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("type", "node_id", "to_node_id").Unique(),
+		index.Fields("type", "node_id", "to_node_id").
+			Unique().
+			StorageKey("idx_edge_types"),
 	}
 }

--- a/internal/backends/ent/schema/external_reference.go
+++ b/internal/backends/ent/schema/external_reference.go
@@ -97,6 +97,8 @@ func (ExternalReference) Edges() []ent.Edge {
 
 func (ExternalReference) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("node_id", "url", "type").Unique(),
+		index.Fields("node_id", "url", "type").
+			Unique().
+			StorageKey("idx_external_references"),
 	}
 }

--- a/internal/backends/ent/schema/hashes_entry.go
+++ b/internal/backends/ent/schema/hashes_entry.go
@@ -18,6 +18,8 @@ type HashesEntry struct {
 
 func (HashesEntry) Fields() []ent.Field {
 	return []ent.Field{
+		field.Int("external_reference_id").Optional(),
+		field.String("node_id").Optional(),
 		field.Enum("hash_algorithm_type").Values(
 			"UNKNOWN",
 			"MD5",
@@ -44,13 +46,19 @@ func (HashesEntry) Fields() []ent.Field {
 
 func (HashesEntry) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("external_reference", ExternalReference.Type).Ref("hashes").Unique(),
-		edge.From("node", Node.Type).Ref("hashes").Unique(),
+		edge.From("external_reference", ExternalReference.Type).
+			Ref("hashes").
+			Unique().
+			Field("external_reference_id"),
+		edge.From("node", Node.Type).
+			Ref("hashes").
+			Unique().
+			Field("node_id"),
 	}
 }
 
 func (HashesEntry) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("hash_algorithm_type", "hash_data").Unique(),
+		index.Fields("external_reference_id", "node_id", "hash_algorithm_type", "hash_data").Unique(),
 	}
 }

--- a/internal/backends/ent/schema/hashes_entry.go
+++ b/internal/backends/ent/schema/hashes_entry.go
@@ -59,6 +59,8 @@ func (HashesEntry) Edges() []ent.Edge {
 
 func (HashesEntry) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("external_reference_id", "node_id", "hash_algorithm_type", "hash_data").Unique(),
+		index.Fields("external_reference_id", "node_id", "hash_algorithm_type", "hash_data").
+			Unique().
+			StorageKey("idx_hashes_entries"),
 	}
 }

--- a/internal/backends/ent/schema/identifiers_entry.go
+++ b/internal/backends/ent/schema/identifiers_entry.go
@@ -41,6 +41,8 @@ func (IdentifiersEntry) Edges() []ent.Edge {
 
 func (IdentifiersEntry) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("software_identifier_type", "software_identifier_value").Unique(),
+		index.Fields("node_id", "software_identifier_type", "software_identifier_value").
+			Unique().
+			StorageKey("idx_identifiers_entries"),
 	}
 }

--- a/internal/backends/ent/schema/identifiers_entry.go
+++ b/internal/backends/ent/schema/identifiers_entry.go
@@ -18,6 +18,7 @@ type IdentifiersEntry struct {
 
 func (IdentifiersEntry) Fields() []ent.Field {
 	return []ent.Field{
+		field.String("node_id").Optional(),
 		field.Enum("software_identifier_type").Values(
 			"UNKNOWN_IDENTIFIER_TYPE",
 			"PURL",
@@ -31,7 +32,10 @@ func (IdentifiersEntry) Fields() []ent.Field {
 
 func (IdentifiersEntry) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("node", Node.Type).Ref("identifiers").Unique(),
+		edge.From("node", Node.Type).
+			Ref("identifiers").
+			Unique().
+			Field("node_id"),
 	}
 }
 

--- a/internal/backends/ent/schema/metadata.go
+++ b/internal/backends/ent/schema/metadata.go
@@ -31,7 +31,11 @@ func (Metadata) Edges() []ent.Edge {
 		edge.To("tools", Tool.Type),
 		edge.To("authors", Person.Type),
 		edge.To("document_types", DocumentType.Type),
-		edge.From("document", Document.Type).Ref("metadata").Required().Unique().Immutable(),
+		edge.From("document", Document.Type).
+			Ref("metadata").
+			Required().
+			Unique().
+			Immutable(),
 	}
 }
 

--- a/internal/backends/ent/schema/metadata.go
+++ b/internal/backends/ent/schema/metadata.go
@@ -41,6 +41,8 @@ func (Metadata) Edges() []ent.Edge {
 
 func (Metadata) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("id", "version", "name").Unique(),
+		index.Fields("id", "version", "name").
+			Unique().
+			StorageKey("idx_metadata"),
 	}
 }

--- a/internal/backends/ent/schema/node.go
+++ b/internal/backends/ent/schema/node.go
@@ -57,6 +57,8 @@ func (Node) Edges() []ent.Edge {
 
 func (Node) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("id", "node_list_id").Unique(),
+		index.Fields("id", "node_list_id").
+			Unique().
+			StorageKey("idx_nodes"),
 	}
 }

--- a/internal/backends/ent/schema/node_list.go
+++ b/internal/backends/ent/schema/node_list.go
@@ -7,10 +7,8 @@ package schema
 
 import (
 	"entgo.io/ent"
-	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
-	"entgo.io/ent/schema/index"
 )
 
 type NodeList struct {
@@ -19,7 +17,7 @@ type NodeList struct {
 
 func (NodeList) Fields() []ent.Field {
 	return []ent.Field{
-		field.String("document_id"),
+		field.String("document_id").Unique().Immutable(),
 		field.Strings("root_elements"),
 	}
 }
@@ -27,16 +25,11 @@ func (NodeList) Fields() []ent.Field {
 func (NodeList) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("nodes", Node.Type),
-		edge.From("document", Document.Type).Ref("node_list").Required().Unique().Field("document_id"),
-	}
-}
-
-func (NodeList) Indexes() []ent.Index {
-	return []ent.Index{
-		index.Fields("document_id", "root_elements").
+		edge.From("document", Document.Type).
+			Ref("node_list").
+			Required().
 			Unique().
-			Annotations(
-				entsql.IndexWhere("root_elements IS NOT NULL"),
-			),
+			Immutable().
+			Field("document_id"),
 	}
 }

--- a/internal/backends/ent/schema/person.go
+++ b/internal/backends/ent/schema/person.go
@@ -41,13 +41,11 @@ func (Person) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("metadata_id", "name", "is_org", "email", "url", "phone").
 			Unique().
-			Annotations(
-				entsql.IndexWhere("metadata_id IS NOT NULL AND node_id IS NULL"),
-			),
+			Annotations(entsql.IndexWhere("metadata_id IS NOT NULL AND node_id IS NULL")).
+			StorageKey("idx_person_metadata_id"),
 		index.Fields("node_id", "name", "is_org", "email", "url", "phone").
 			Unique().
-			Annotations(
-				entsql.IndexWhere("metadata_id IS NULL AND node_id IS NOT NULL"),
-			),
+			Annotations(entsql.IndexWhere("metadata_id IS NULL AND node_id IS NOT NULL")).
+			StorageKey("idx_person_node_id"),
 	}
 }

--- a/internal/backends/ent/schema/purpose.go
+++ b/internal/backends/ent/schema/purpose.go
@@ -61,6 +61,8 @@ func (Purpose) Edges() []ent.Edge {
 
 func (Purpose) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("node_id", "primary_purpose").Unique(),
+		index.Fields("node_id", "primary_purpose").
+			Unique().
+			StorageKey("idx_purposes"),
 	}
 }

--- a/internal/backends/ent/schema/tool.go
+++ b/internal/backends/ent/schema/tool.go
@@ -33,6 +33,8 @@ func (Tool) Edges() []ent.Edge {
 
 func (Tool) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("metadata_id", "name", "version", "vendor").Unique(),
+		index.Fields("metadata_id", "name", "version", "vendor").
+			Unique().
+			StorageKey("idx_tools"),
 	}
 }


### PR DESCRIPTION
This PR adds the following enhancements to the ent backend:

- Add utility methods 
  - `GetDocumentsByID`: return protobom Documents from database for variable number of input IDs, or all documents if no IDs are specified
  - `GetExternalReferencesByDocumentID`: return all external references associated with document nodes, with optional external reference type(s) parameter
- Set Store* methods to internal since they might create orphaned data
  - e.g. inserting `Node`s with no associated `NodeList`, or inserting a `NodeList` with no associated `Document`
- Store foreign key IDs for hashes and identifiers (the ID of the `Node` or `ExternalReference` that owns the relationship)
- Assign custom names with `idx_` prefix for unique indexes