### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,34 +2,38 @@
 # SPDX-FileCopyrightText: Copyright © 2024 The Protobom Authors
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
-
+# ------------------------------------------------------------------------
+---
 name: Release
 
 on:
   push:
     tags: v*
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write # needed to write releases 
+      contents: write # needed to write releases
 
     steps:
       - name: Set tag name
         shell: bash
         run: echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-        
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v3
-        with:
-          go-version-file: go.mod
-          cache: false
-  
+
       - name: Check out code
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           fetch-depth: 1
+
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v3
+        with:
+          go-version-file: go.mod
+          cache: false
 
       - name: Install bom
         uses: kubernetes-sigs/release-actions/setup-bom@2f8b9ec22aedc9ce15039b6c7716aa6c2907df1c # v0.2.0


### PR DESCRIPTION
This PR adds a fix to run the `checkout` action prior to `setup-go` since it needs to pull the desired Go version from the committed `go.mod` file.