### PR TITLE
fix: external reference type predicate

### DIFF
--- a/backends/ent/example_test.go
+++ b/backends/ent/example_test.go
@@ -73,7 +73,9 @@ func Example() {
 	//     "source_data": {
 	//       "format": "application/vnd.cyclonedx+json;version=1.5",
 	//       "hashes": {
-	//         "3": "71a3948e45c0bcd83a617ed94674079778d10a0578932e6e536533339b1bbea5"
+	//         "2": "1ecc17c081f9a0b452b1d8a0d846901bcc40508f",
+	//         "3": "71a3948e45c0bcd83a617ed94674079778d10a0578932e6e536533339b1bbea5",
+	//         "5": "2cc9ac5ab13a8074463e85996e91aa96916a08d33fc3aff9129dd44b24b850884f6176898a21d48dabd9f3824a2dd6bcc1f350e8f13d4be1c564211d1108e43c"
 	//       },
 	//       "size": 5263
 	//     }

--- a/backends/ent/retrieve_test.go
+++ b/backends/ent/retrieve_test.go
@@ -1,0 +1,106 @@
+// --------------------------------------------------------------
+// SPDX-FileCopyrightText: Copyright © 2024 The Protobom Authors
+// SPDX-FileType: SOURCE
+// SPDX-License-Identifier: Apache-2.0
+// --------------------------------------------------------------
+
+package ent_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/protobom/protobom/pkg/reader"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/protobom/storage/backends/ent"
+)
+
+type retrieveSuite struct {
+	suite.Suite
+	*ent.Backend
+}
+
+// SetupSuite runs before the tests in the suite are run.
+func (rs *retrieveSuite) SetupSuite() {
+	rs.Backend = ent.NewBackend(ent.WithDatabaseFile(":memory:"))
+	rs.Require().NoError(rs.Backend.InitClient())
+
+	cwd, err := os.Getwd()
+	rs.Require().NoError(err)
+
+	rdr := reader.New()
+	testdataDir := filepath.Join(cwd, "testdata")
+
+	entries, err := os.ReadDir(testdataDir)
+	rs.Require().NoError(err)
+
+	for idx := range entries {
+		document, err := rdr.ParseFile(filepath.Join(testdataDir, entries[idx].Name()))
+		rs.Require().NoError(err)
+
+		rs.Require().NoError(rs.Backend.Store(document, nil))
+	}
+}
+
+// TearDownSuite runs after all the tests in the suite have been run.
+func (rs *retrieveSuite) TearDownSuite() {
+	rs.Backend.CloseClient()
+}
+
+func (rs *retrieveSuite) TestBackend_GetExternalReferencesByDocumentID() {
+	// juice-shop-11.1.2.cdx.json serial number
+	id := "urn:uuid:1f860713-54b9-4253-ba5a-9554851904af"
+
+	for _, data := range []struct {
+		name     string
+		errorMsg string
+		types    []string
+		expected int
+	}{
+		{
+			name:     "issue-tracker",
+			types:    []string{"ISSUE_TRACKER"},
+			expected: 711,
+		},
+		{
+			name:     "vcs",
+			types:    []string{"VCS"},
+			expected: 730,
+		},
+		{
+			name:     "website",
+			types:    []string{"WEBSITE"},
+			expected: 714,
+		},
+		{
+			name:     "all types",
+			types:    []string{},
+			expected: 2155,
+		},
+		{
+			name:     "invalid-type",
+			types:    []string{"INVALID"},
+			errorMsg: `externalreference: invalid enum value for type field: "INVALID"`,
+		},
+	} {
+		rs.Run(data.name, func() {
+			extRefs, err := rs.GetExternalReferencesByDocumentID(id, data.types...)
+
+			if data.errorMsg != "" {
+				rs.Require().Error(err)
+				rs.Require().Equal(data.errorMsg, err.Error())
+			} else {
+				rs.Require().NoError(err)
+			}
+
+			rs.Len(extRefs, data.expected)
+		})
+	}
+}
+
+func TestRetrieveSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(retrieveSuite))
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	entgo.io/ent v0.14.1
 	github.com/glebarez/go-sqlite v1.22.0
 	github.com/google/uuid v1.6.0
-	github.com/protobom/protobom v0.4.5-0.20241031170812-4c8262ccbd8a
+	github.com/protobom/protobom v0.5.0
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/protobuf v1.35.1
 )

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 h1:DpOJ2HYzC
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/protobom/protobom v0.4.5-0.20241031170812-4c8262ccbd8a h1:Vt9Bc4RoEcV4QpWUMiAyLUw+dXa6XpT9nvLK/XJxpko=
-github.com/protobom/protobom v0.4.5-0.20241031170812-4c8262ccbd8a/go.mod h1:HL47tggz7SXYXgNm3WjQQrWB6iOirYnrATsXAEyTUkI=
+github.com/protobom/protobom v0.5.0 h1:jJYqGpdHq99zwh0/n1SOPl1aickCBZdA8pHS9V/f+XQ=
+github.com/protobom/protobom v0.5.0/go.mod h1:HL47tggz7SXYXgNm3WjQQrWB6iOirYnrATsXAEyTUkI=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=


### PR DESCRIPTION
This PR fixes the `backend.GetExternalReferencesByDocumentID` method and adds test cases to test the fix.