### PR TITLE
refactor: redefine annotation document ID as nillable/pointer type

### DIFF
--- a/backends/ent/annotations_test.go
+++ b/backends/ent/annotations_test.go
@@ -587,7 +587,7 @@ func (as *annotationsSuite) TestBackend_SetDocumentUniqueAnnotation() { //nolint
 			annotations := as.getTestResult(annotationName)
 
 			as.Require().Len(annotations, subtest.expectedLen)
-			as.Equal(uniqueID, annotations[subtest.documentIdx].DocumentID)
+			as.Equal(&uniqueID, annotations[subtest.documentIdx].DocumentID)
 			as.Equal(annotationName, annotations[subtest.documentIdx].Name)
 			as.Equal(subtest.value, annotations[subtest.documentIdx].Value)
 		})
@@ -622,7 +622,7 @@ func (as *annotationsSuite) TestBackend_SetNodeUniqueAnnotation() { //nolint:dup
 			annotations := as.getTestResult(annotationName)
 
 			as.Require().Len(annotations, subtest.expectedLen)
-			as.Equal(uniqueID, annotations[subtest.nodeIdx].DocumentID)
+			as.Equal(&uniqueID, annotations[subtest.nodeIdx].DocumentID)
 			as.Equal(annotationName, annotations[subtest.nodeIdx].Name)
 			as.Equal(subtest.value, annotations[subtest.nodeIdx].Value)
 		})

--- a/backends/ent/store.go
+++ b/backends/ent/store.go
@@ -71,8 +71,8 @@ func (backend *Backend) Store(doc *sbom.Document, opts *storage.StoreOptions) er
 
 	// Set each annotation's document ID if not specified.
 	for _, a := range annotations {
-		if a.DocumentID == uuid.Nil {
-			a.DocumentID = id
+		if a.DocumentID == nil || a.DocumentID == &uuid.Nil {
+			a.DocumentID = &id
 		}
 	}
 
@@ -96,7 +96,7 @@ func (backend *Backend) saveAnnotations(annotations ...*ent.Annotation) TxFunc {
 
 		for idx := range annotations {
 			builder := tx.Annotation.Create().
-				SetDocumentID(annotations[idx].DocumentID).
+				SetNillableDocumentID(annotations[idx].DocumentID).
 				SetNillableNodeID(annotations[idx].NodeID).
 				SetName(annotations[idx].Name).
 				SetValue(annotations[idx].Value).

--- a/internal/backends/ent/annotation/annotation.go
+++ b/internal/backends/ent/annotation/annotation.go
@@ -10,7 +10,6 @@ package annotation
 import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
-	"github.com/google/uuid"
 )
 
 const (
@@ -71,8 +70,6 @@ func ValidColumn(column string) bool {
 }
 
 var (
-	// DefaultDocumentID holds the default value on creation for the "document_id" field.
-	DefaultDocumentID func() uuid.UUID
 	// DefaultIsUnique holds the default value on creation for the "is_unique" field.
 	DefaultIsUnique bool
 )
@@ -127,7 +124,7 @@ func newDocumentStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(DocumentInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
+		sqlgraph.Edge(sqlgraph.M2O, true, DocumentTable, DocumentColumn),
 	)
 }
 func newNodeStep() *sqlgraph.Step {

--- a/internal/backends/ent/annotation/where.go
+++ b/internal/backends/ent/annotation/where.go
@@ -289,7 +289,7 @@ func HasDocument() predicate.Annotation {
 	return predicate.Annotation(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2O, true, DocumentTable, DocumentColumn),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})

--- a/internal/backends/ent/annotation_create.go
+++ b/internal/backends/ent/annotation_create.go
@@ -128,10 +128,6 @@ func (ac *AnnotationCreate) ExecX(ctx context.Context) {
 
 // defaults sets the default values of the builder before save.
 func (ac *AnnotationCreate) defaults() {
-	if _, ok := ac.mutation.DocumentID(); !ok {
-		v := annotation.DefaultDocumentID()
-		ac.mutation.SetDocumentID(v)
-	}
 	if _, ok := ac.mutation.IsUnique(); !ok {
 		v := annotation.DefaultIsUnique
 		ac.mutation.SetIsUnique(v)
@@ -191,7 +187,7 @@ func (ac *AnnotationCreate) createSpec() (*Annotation, *sqlgraph.CreateSpec) {
 	if nodes := ac.mutation.DocumentIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
-			Inverse: false,
+			Inverse: true,
 			Table:   annotation.DocumentTable,
 			Columns: []string{annotation.DocumentColumn},
 			Bidi:    false,
@@ -202,7 +198,7 @@ func (ac *AnnotationCreate) createSpec() (*Annotation, *sqlgraph.CreateSpec) {
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.DocumentID = nodes[0]
+		_node.DocumentID = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ac.mutation.NodeIDs(); len(nodes) > 0 {
@@ -274,6 +270,24 @@ type (
 	}
 )
 
+// SetDocumentID sets the "document_id" field.
+func (u *AnnotationUpsert) SetDocumentID(v uuid.UUID) *AnnotationUpsert {
+	u.Set(annotation.FieldDocumentID, v)
+	return u
+}
+
+// UpdateDocumentID sets the "document_id" field to the value that was provided on create.
+func (u *AnnotationUpsert) UpdateDocumentID() *AnnotationUpsert {
+	u.SetExcluded(annotation.FieldDocumentID)
+	return u
+}
+
+// ClearDocumentID clears the value of the "document_id" field.
+func (u *AnnotationUpsert) ClearDocumentID() *AnnotationUpsert {
+	u.SetNull(annotation.FieldDocumentID)
+	return u
+}
+
 // SetNodeID sets the "node_id" field.
 func (u *AnnotationUpsert) SetNodeID(v uuid.UUID) *AnnotationUpsert {
 	u.Set(annotation.FieldNodeID, v)
@@ -338,11 +352,6 @@ func (u *AnnotationUpsert) UpdateIsUnique() *AnnotationUpsert {
 //		Exec(ctx)
 func (u *AnnotationUpsertOne) UpdateNewValues() *AnnotationUpsertOne {
 	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
-	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
-		if _, exists := u.create.mutation.DocumentID(); exists {
-			s.SetIgnore(annotation.FieldDocumentID)
-		}
-	}))
 	return u
 }
 
@@ -371,6 +380,27 @@ func (u *AnnotationUpsertOne) Update(set func(*AnnotationUpsert)) *AnnotationUps
 		set(&AnnotationUpsert{UpdateSet: update})
 	}))
 	return u
+}
+
+// SetDocumentID sets the "document_id" field.
+func (u *AnnotationUpsertOne) SetDocumentID(v uuid.UUID) *AnnotationUpsertOne {
+	return u.Update(func(s *AnnotationUpsert) {
+		s.SetDocumentID(v)
+	})
+}
+
+// UpdateDocumentID sets the "document_id" field to the value that was provided on create.
+func (u *AnnotationUpsertOne) UpdateDocumentID() *AnnotationUpsertOne {
+	return u.Update(func(s *AnnotationUpsert) {
+		s.UpdateDocumentID()
+	})
+}
+
+// ClearDocumentID clears the value of the "document_id" field.
+func (u *AnnotationUpsertOne) ClearDocumentID() *AnnotationUpsertOne {
+	return u.Update(func(s *AnnotationUpsert) {
+		s.ClearDocumentID()
+	})
 }
 
 // SetNodeID sets the "node_id" field.
@@ -610,13 +640,6 @@ type AnnotationUpsertBulk struct {
 //		Exec(ctx)
 func (u *AnnotationUpsertBulk) UpdateNewValues() *AnnotationUpsertBulk {
 	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
-	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
-		for _, b := range u.create.builders {
-			if _, exists := b.mutation.DocumentID(); exists {
-				s.SetIgnore(annotation.FieldDocumentID)
-			}
-		}
-	}))
 	return u
 }
 
@@ -645,6 +668,27 @@ func (u *AnnotationUpsertBulk) Update(set func(*AnnotationUpsert)) *AnnotationUp
 		set(&AnnotationUpsert{UpdateSet: update})
 	}))
 	return u
+}
+
+// SetDocumentID sets the "document_id" field.
+func (u *AnnotationUpsertBulk) SetDocumentID(v uuid.UUID) *AnnotationUpsertBulk {
+	return u.Update(func(s *AnnotationUpsert) {
+		s.SetDocumentID(v)
+	})
+}
+
+// UpdateDocumentID sets the "document_id" field to the value that was provided on create.
+func (u *AnnotationUpsertBulk) UpdateDocumentID() *AnnotationUpsertBulk {
+	return u.Update(func(s *AnnotationUpsert) {
+		s.UpdateDocumentID()
+	})
+}
+
+// ClearDocumentID clears the value of the "document_id" field.
+func (u *AnnotationUpsertBulk) ClearDocumentID() *AnnotationUpsertBulk {
+	return u.Update(func(s *AnnotationUpsert) {
+		s.ClearDocumentID()
+	})
 }
 
 // SetNodeID sets the "node_id" field.

--- a/internal/backends/ent/annotation_query.go
+++ b/internal/backends/ent/annotation_query.go
@@ -82,7 +82,7 @@ func (aq *AnnotationQuery) QueryDocument() *DocumentQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(annotation.Table, annotation.FieldID, selector),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, annotation.DocumentTable, annotation.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2O, true, annotation.DocumentTable, annotation.DocumentColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(aq.driver.Dialect(), step)
 		return fromU, nil
@@ -454,7 +454,10 @@ func (aq *AnnotationQuery) loadDocument(ctx context.Context, query *DocumentQuer
 	ids := make([]uuid.UUID, 0, len(nodes))
 	nodeids := make(map[uuid.UUID][]*Annotation)
 	for i := range nodes {
-		fk := nodes[i].DocumentID
+		if nodes[i].DocumentID == nil {
+			continue
+		}
+		fk := *nodes[i].DocumentID
 		if _, ok := nodeids[fk]; !ok {
 			ids = append(ids, fk)
 		}

--- a/internal/backends/ent/annotation_update.go
+++ b/internal/backends/ent/annotation_update.go
@@ -17,6 +17,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/google/uuid"
 	"github.com/protobom/storage/internal/backends/ent/annotation"
+	"github.com/protobom/storage/internal/backends/ent/document"
 	"github.com/protobom/storage/internal/backends/ent/node"
 	"github.com/protobom/storage/internal/backends/ent/predicate"
 )
@@ -31,6 +32,26 @@ type AnnotationUpdate struct {
 // Where appends a list predicates to the AnnotationUpdate builder.
 func (au *AnnotationUpdate) Where(ps ...predicate.Annotation) *AnnotationUpdate {
 	au.mutation.Where(ps...)
+	return au
+}
+
+// SetDocumentID sets the "document_id" field.
+func (au *AnnotationUpdate) SetDocumentID(u uuid.UUID) *AnnotationUpdate {
+	au.mutation.SetDocumentID(u)
+	return au
+}
+
+// SetNillableDocumentID sets the "document_id" field if the given value is not nil.
+func (au *AnnotationUpdate) SetNillableDocumentID(u *uuid.UUID) *AnnotationUpdate {
+	if u != nil {
+		au.SetDocumentID(*u)
+	}
+	return au
+}
+
+// ClearDocumentID clears the value of the "document_id" field.
+func (au *AnnotationUpdate) ClearDocumentID() *AnnotationUpdate {
+	au.mutation.ClearDocumentID()
 	return au
 }
 
@@ -96,6 +117,11 @@ func (au *AnnotationUpdate) SetNillableIsUnique(b *bool) *AnnotationUpdate {
 	return au
 }
 
+// SetDocument sets the "document" edge to the Document entity.
+func (au *AnnotationUpdate) SetDocument(d *Document) *AnnotationUpdate {
+	return au.SetDocumentID(d.ID)
+}
+
 // SetNode sets the "node" edge to the Node entity.
 func (au *AnnotationUpdate) SetNode(n *Node) *AnnotationUpdate {
 	return au.SetNodeID(n.ID)
@@ -104,6 +130,12 @@ func (au *AnnotationUpdate) SetNode(n *Node) *AnnotationUpdate {
 // Mutation returns the AnnotationMutation object of the builder.
 func (au *AnnotationUpdate) Mutation() *AnnotationMutation {
 	return au.mutation
+}
+
+// ClearDocument clears the "document" edge to the Document entity.
+func (au *AnnotationUpdate) ClearDocument() *AnnotationUpdate {
+	au.mutation.ClearDocument()
+	return au
 }
 
 // ClearNode clears the "node" edge to the Node entity.
@@ -157,6 +189,35 @@ func (au *AnnotationUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if value, ok := au.mutation.IsUnique(); ok {
 		_spec.SetField(annotation.FieldIsUnique, field.TypeBool, value)
 	}
+	if au.mutation.DocumentCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   annotation.DocumentTable,
+			Columns: []string{annotation.DocumentColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := au.mutation.DocumentIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   annotation.DocumentTable,
+			Columns: []string{annotation.DocumentColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if au.mutation.NodeCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -204,6 +265,26 @@ type AnnotationUpdateOne struct {
 	fields   []string
 	hooks    []Hook
 	mutation *AnnotationMutation
+}
+
+// SetDocumentID sets the "document_id" field.
+func (auo *AnnotationUpdateOne) SetDocumentID(u uuid.UUID) *AnnotationUpdateOne {
+	auo.mutation.SetDocumentID(u)
+	return auo
+}
+
+// SetNillableDocumentID sets the "document_id" field if the given value is not nil.
+func (auo *AnnotationUpdateOne) SetNillableDocumentID(u *uuid.UUID) *AnnotationUpdateOne {
+	if u != nil {
+		auo.SetDocumentID(*u)
+	}
+	return auo
+}
+
+// ClearDocumentID clears the value of the "document_id" field.
+func (auo *AnnotationUpdateOne) ClearDocumentID() *AnnotationUpdateOne {
+	auo.mutation.ClearDocumentID()
+	return auo
 }
 
 // SetNodeID sets the "node_id" field.
@@ -268,6 +349,11 @@ func (auo *AnnotationUpdateOne) SetNillableIsUnique(b *bool) *AnnotationUpdateOn
 	return auo
 }
 
+// SetDocument sets the "document" edge to the Document entity.
+func (auo *AnnotationUpdateOne) SetDocument(d *Document) *AnnotationUpdateOne {
+	return auo.SetDocumentID(d.ID)
+}
+
 // SetNode sets the "node" edge to the Node entity.
 func (auo *AnnotationUpdateOne) SetNode(n *Node) *AnnotationUpdateOne {
 	return auo.SetNodeID(n.ID)
@@ -276,6 +362,12 @@ func (auo *AnnotationUpdateOne) SetNode(n *Node) *AnnotationUpdateOne {
 // Mutation returns the AnnotationMutation object of the builder.
 func (auo *AnnotationUpdateOne) Mutation() *AnnotationMutation {
 	return auo.mutation
+}
+
+// ClearDocument clears the "document" edge to the Document entity.
+func (auo *AnnotationUpdateOne) ClearDocument() *AnnotationUpdateOne {
+	auo.mutation.ClearDocument()
+	return auo
 }
 
 // ClearNode clears the "node" edge to the Node entity.
@@ -358,6 +450,35 @@ func (auo *AnnotationUpdateOne) sqlSave(ctx context.Context) (_node *Annotation,
 	}
 	if value, ok := auo.mutation.IsUnique(); ok {
 		_spec.SetField(annotation.FieldIsUnique, field.TypeBool, value)
+	}
+	if auo.mutation.DocumentCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   annotation.DocumentTable,
+			Columns: []string{annotation.DocumentColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := auo.mutation.DocumentIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   annotation.DocumentTable,
+			Columns: []string{annotation.DocumentColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if auo.mutation.NodeCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/backends/ent/client.go
+++ b/internal/backends/ent/client.go
@@ -445,7 +445,7 @@ func (c *AnnotationClient) QueryDocument(a *Annotation) *DocumentQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(annotation.Table, annotation.FieldID, id),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, annotation.DocumentTable, annotation.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2O, true, annotation.DocumentTable, annotation.DocumentColumn),
 		)
 		fromV = sqlgraph.Neighbors(a.driver.Dialect(), step)
 		return fromV, nil
@@ -602,6 +602,22 @@ func (c *DocumentClient) GetX(ctx context.Context, id uuid.UUID) *Document {
 	return obj
 }
 
+// QueryAnnotations queries the annotations edge of a Document.
+func (c *DocumentClient) QueryAnnotations(d *Document) *AnnotationQuery {
+	query := (&AnnotationClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := d.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(document.Table, document.FieldID, id),
+			sqlgraph.To(annotation.Table, annotation.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, document.AnnotationsTable, document.AnnotationsColumn),
+		)
+		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryMetadata queries the metadata edge of a Document.
 func (c *DocumentClient) QueryMetadata(d *Document) *MetadataQuery {
 	query := (&MetadataClient{config: c.config}).Query()
@@ -610,7 +626,7 @@ func (c *DocumentClient) QueryMetadata(d *Document) *MetadataQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(document.Table, document.FieldID, id),
 			sqlgraph.To(metadata.Table, metadata.FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, document.MetadataTable, document.MetadataColumn),
+			sqlgraph.Edge(sqlgraph.O2O, true, document.MetadataTable, document.MetadataColumn),
 		)
 		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
 		return fromV, nil
@@ -626,7 +642,7 @@ func (c *DocumentClient) QueryNodeList(d *Document) *NodeListQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(document.Table, document.FieldID, id),
 			sqlgraph.To(nodelist.Table, nodelist.FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, document.NodeListTable, document.NodeListColumn),
+			sqlgraph.Edge(sqlgraph.O2O, true, document.NodeListTable, document.NodeListColumn),
 		)
 		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
 		return fromV, nil
@@ -1656,6 +1672,22 @@ func (c *MetadataClient) GetX(ctx context.Context, id uuid.UUID) *Metadata {
 	return obj
 }
 
+// QueryDocument queries the document edge of a Metadata.
+func (c *MetadataClient) QueryDocument(m *Metadata) *DocumentQuery {
+	query := (&DocumentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(metadata.Table, metadata.FieldID, id),
+			sqlgraph.To(document.Table, document.FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, false, metadata.DocumentTable, metadata.DocumentColumn),
+		)
+		fromV = sqlgraph.Neighbors(m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryTools queries the tools edge of a Metadata.
 func (c *MetadataClient) QueryTools(m *Metadata) *ToolQuery {
 	query := (&ToolClient{config: c.config}).Query()
@@ -1713,22 +1745,6 @@ func (c *MetadataClient) QuerySourceData(m *Metadata) *SourceDataQuery {
 			sqlgraph.From(metadata.Table, metadata.FieldID, id),
 			sqlgraph.To(sourcedata.Table, sourcedata.FieldID),
 			sqlgraph.Edge(sqlgraph.O2M, false, metadata.SourceDataTable, metadata.SourceDataColumn),
-		)
-		fromV = sqlgraph.Neighbors(m.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryDocument queries the document edge of a Metadata.
-func (c *MetadataClient) QueryDocument(m *Metadata) *DocumentQuery {
-	query := (&DocumentClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := m.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(metadata.Table, metadata.FieldID, id),
-			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, metadata.DocumentTable, metadata.DocumentColumn),
 		)
 		fromV = sqlgraph.Neighbors(m.driver.Dialect(), step)
 		return fromV, nil
@@ -2210,6 +2226,22 @@ func (c *NodeListClient) GetX(ctx context.Context, id uuid.UUID) *NodeList {
 	return obj
 }
 
+// QueryDocument queries the document edge of a NodeList.
+func (c *NodeListClient) QueryDocument(nl *NodeList) *DocumentQuery {
+	query := (&DocumentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := nl.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(nodelist.Table, nodelist.FieldID, id),
+			sqlgraph.To(document.Table, document.FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, false, nodelist.DocumentTable, nodelist.DocumentColumn),
+		)
+		fromV = sqlgraph.Neighbors(nl.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryEdgeTypes queries the edge_types edge of a NodeList.
 func (c *NodeListClient) QueryEdgeTypes(nl *NodeList) *EdgeTypeQuery {
 	query := (&EdgeTypeClient{config: c.config}).Query()
@@ -2235,22 +2267,6 @@ func (c *NodeListClient) QueryNodes(nl *NodeList) *NodeQuery {
 			sqlgraph.From(nodelist.Table, nodelist.FieldID, id),
 			sqlgraph.To(node.Table, node.FieldID),
 			sqlgraph.Edge(sqlgraph.M2M, false, nodelist.NodesTable, nodelist.NodesPrimaryKey...),
-		)
-		fromV = sqlgraph.Neighbors(nl.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryDocument queries the document edge of a NodeList.
-func (c *NodeListClient) QueryDocument(nl *NodeList) *DocumentQuery {
-	query := (&DocumentClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := nl.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(nodelist.Table, nodelist.FieldID, id),
-			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, nodelist.DocumentTable, nodelist.DocumentColumn),
 		)
 		fromV = sqlgraph.Neighbors(nl.driver.Dialect(), step)
 		return fromV, nil

--- a/internal/backends/ent/document/document.go
+++ b/internal/backends/ent/document/document.go
@@ -18,31 +18,46 @@ const (
 	Label = "document"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
+	// FieldMetadataID holds the string denoting the metadata_id field in the database.
+	FieldMetadataID = "metadata_id"
+	// FieldNodeListID holds the string denoting the node_list_id field in the database.
+	FieldNodeListID = "node_list_id"
+	// EdgeAnnotations holds the string denoting the annotations edge name in mutations.
+	EdgeAnnotations = "annotations"
 	// EdgeMetadata holds the string denoting the metadata edge name in mutations.
 	EdgeMetadata = "metadata"
 	// EdgeNodeList holds the string denoting the node_list edge name in mutations.
 	EdgeNodeList = "node_list"
 	// Table holds the table name of the document in the database.
 	Table = "documents"
+	// AnnotationsTable is the table that holds the annotations relation/edge.
+	AnnotationsTable = "annotations"
+	// AnnotationsInverseTable is the table name for the Annotation entity.
+	// It exists in this package in order to avoid circular dependency with the "annotation" package.
+	AnnotationsInverseTable = "annotations"
+	// AnnotationsColumn is the table column denoting the annotations relation/edge.
+	AnnotationsColumn = "document_id"
 	// MetadataTable is the table that holds the metadata relation/edge.
-	MetadataTable = "metadata"
+	MetadataTable = "documents"
 	// MetadataInverseTable is the table name for the Metadata entity.
 	// It exists in this package in order to avoid circular dependency with the "metadata" package.
 	MetadataInverseTable = "metadata"
 	// MetadataColumn is the table column denoting the metadata relation/edge.
-	MetadataColumn = "document_id"
+	MetadataColumn = "metadata_id"
 	// NodeListTable is the table that holds the node_list relation/edge.
-	NodeListTable = "node_lists"
+	NodeListTable = "documents"
 	// NodeListInverseTable is the table name for the NodeList entity.
 	// It exists in this package in order to avoid circular dependency with the "nodelist" package.
 	NodeListInverseTable = "node_lists"
 	// NodeListColumn is the table column denoting the node_list relation/edge.
-	NodeListColumn = "document_id"
+	NodeListColumn = "node_list_id"
 )
 
 // Columns holds all SQL columns for document fields.
 var Columns = []string{
 	FieldID,
+	FieldMetadataID,
+	FieldNodeListID,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -68,6 +83,30 @@ func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
+// ByMetadataID orders the results by the metadata_id field.
+func ByMetadataID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldMetadataID, opts...).ToFunc()
+}
+
+// ByNodeListID orders the results by the node_list_id field.
+func ByNodeListID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldNodeListID, opts...).ToFunc()
+}
+
+// ByAnnotationsCount orders the results by annotations count.
+func ByAnnotationsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newAnnotationsStep(), opts...)
+	}
+}
+
+// ByAnnotations orders the results by annotations terms.
+func ByAnnotations(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newAnnotationsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
 // ByMetadataField orders the results by metadata field.
 func ByMetadataField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -81,17 +120,24 @@ func ByNodeListField(field string, opts ...sql.OrderTermOption) OrderOption {
 		sqlgraph.OrderByNeighborTerms(s, newNodeListStep(), sql.OrderByField(field, opts...))
 	}
 }
+func newAnnotationsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(AnnotationsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, AnnotationsTable, AnnotationsColumn),
+	)
+}
 func newMetadataStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(MetadataInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2O, false, MetadataTable, MetadataColumn),
+		sqlgraph.Edge(sqlgraph.O2O, true, MetadataTable, MetadataColumn),
 	)
 }
 func newNodeListStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(NodeListInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2O, false, NodeListTable, NodeListColumn),
+		sqlgraph.Edge(sqlgraph.O2O, true, NodeListTable, NodeListColumn),
 	)
 }

--- a/internal/backends/ent/document/where.go
+++ b/internal/backends/ent/document/where.go
@@ -59,12 +59,105 @@ func IDLTE(id uuid.UUID) predicate.Document {
 	return predicate.Document(sql.FieldLTE(FieldID, id))
 }
 
+// MetadataID applies equality check predicate on the "metadata_id" field. It's identical to MetadataIDEQ.
+func MetadataID(v uuid.UUID) predicate.Document {
+	return predicate.Document(sql.FieldEQ(FieldMetadataID, v))
+}
+
+// NodeListID applies equality check predicate on the "node_list_id" field. It's identical to NodeListIDEQ.
+func NodeListID(v uuid.UUID) predicate.Document {
+	return predicate.Document(sql.FieldEQ(FieldNodeListID, v))
+}
+
+// MetadataIDEQ applies the EQ predicate on the "metadata_id" field.
+func MetadataIDEQ(v uuid.UUID) predicate.Document {
+	return predicate.Document(sql.FieldEQ(FieldMetadataID, v))
+}
+
+// MetadataIDNEQ applies the NEQ predicate on the "metadata_id" field.
+func MetadataIDNEQ(v uuid.UUID) predicate.Document {
+	return predicate.Document(sql.FieldNEQ(FieldMetadataID, v))
+}
+
+// MetadataIDIn applies the In predicate on the "metadata_id" field.
+func MetadataIDIn(vs ...uuid.UUID) predicate.Document {
+	return predicate.Document(sql.FieldIn(FieldMetadataID, vs...))
+}
+
+// MetadataIDNotIn applies the NotIn predicate on the "metadata_id" field.
+func MetadataIDNotIn(vs ...uuid.UUID) predicate.Document {
+	return predicate.Document(sql.FieldNotIn(FieldMetadataID, vs...))
+}
+
+// MetadataIDIsNil applies the IsNil predicate on the "metadata_id" field.
+func MetadataIDIsNil() predicate.Document {
+	return predicate.Document(sql.FieldIsNull(FieldMetadataID))
+}
+
+// MetadataIDNotNil applies the NotNil predicate on the "metadata_id" field.
+func MetadataIDNotNil() predicate.Document {
+	return predicate.Document(sql.FieldNotNull(FieldMetadataID))
+}
+
+// NodeListIDEQ applies the EQ predicate on the "node_list_id" field.
+func NodeListIDEQ(v uuid.UUID) predicate.Document {
+	return predicate.Document(sql.FieldEQ(FieldNodeListID, v))
+}
+
+// NodeListIDNEQ applies the NEQ predicate on the "node_list_id" field.
+func NodeListIDNEQ(v uuid.UUID) predicate.Document {
+	return predicate.Document(sql.FieldNEQ(FieldNodeListID, v))
+}
+
+// NodeListIDIn applies the In predicate on the "node_list_id" field.
+func NodeListIDIn(vs ...uuid.UUID) predicate.Document {
+	return predicate.Document(sql.FieldIn(FieldNodeListID, vs...))
+}
+
+// NodeListIDNotIn applies the NotIn predicate on the "node_list_id" field.
+func NodeListIDNotIn(vs ...uuid.UUID) predicate.Document {
+	return predicate.Document(sql.FieldNotIn(FieldNodeListID, vs...))
+}
+
+// NodeListIDIsNil applies the IsNil predicate on the "node_list_id" field.
+func NodeListIDIsNil() predicate.Document {
+	return predicate.Document(sql.FieldIsNull(FieldNodeListID))
+}
+
+// NodeListIDNotNil applies the NotNil predicate on the "node_list_id" field.
+func NodeListIDNotNil() predicate.Document {
+	return predicate.Document(sql.FieldNotNull(FieldNodeListID))
+}
+
+// HasAnnotations applies the HasEdge predicate on the "annotations" edge.
+func HasAnnotations() predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, AnnotationsTable, AnnotationsColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasAnnotationsWith applies the HasEdge predicate on the "annotations" edge with a given conditions (other predicates).
+func HasAnnotationsWith(preds ...predicate.Annotation) predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := newAnnotationsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasMetadata applies the HasEdge predicate on the "metadata" edge.
 func HasMetadata() predicate.Document {
 	return predicate.Document(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, MetadataTable, MetadataColumn),
+			sqlgraph.Edge(sqlgraph.O2O, true, MetadataTable, MetadataColumn),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -87,7 +180,7 @@ func HasNodeList() predicate.Document {
 	return predicate.Document(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, NodeListTable, NodeListColumn),
+			sqlgraph.Edge(sqlgraph.O2O, true, NodeListTable, NodeListColumn),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})

--- a/internal/backends/ent/document_update.go
+++ b/internal/backends/ent/document_update.go
@@ -15,6 +15,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/protobom/storage/internal/backends/ent/annotation"
 	"github.com/protobom/storage/internal/backends/ent/document"
 	"github.com/protobom/storage/internal/backends/ent/predicate"
 )
@@ -32,9 +33,45 @@ func (du *DocumentUpdate) Where(ps ...predicate.Document) *DocumentUpdate {
 	return du
 }
 
+// AddAnnotationIDs adds the "annotations" edge to the Annotation entity by IDs.
+func (du *DocumentUpdate) AddAnnotationIDs(ids ...int) *DocumentUpdate {
+	du.mutation.AddAnnotationIDs(ids...)
+	return du
+}
+
+// AddAnnotations adds the "annotations" edges to the Annotation entity.
+func (du *DocumentUpdate) AddAnnotations(a ...*Annotation) *DocumentUpdate {
+	ids := make([]int, len(a))
+	for i := range a {
+		ids[i] = a[i].ID
+	}
+	return du.AddAnnotationIDs(ids...)
+}
+
 // Mutation returns the DocumentMutation object of the builder.
 func (du *DocumentUpdate) Mutation() *DocumentMutation {
 	return du.mutation
+}
+
+// ClearAnnotations clears all "annotations" edges to the Annotation entity.
+func (du *DocumentUpdate) ClearAnnotations() *DocumentUpdate {
+	du.mutation.ClearAnnotations()
+	return du
+}
+
+// RemoveAnnotationIDs removes the "annotations" edge to Annotation entities by IDs.
+func (du *DocumentUpdate) RemoveAnnotationIDs(ids ...int) *DocumentUpdate {
+	du.mutation.RemoveAnnotationIDs(ids...)
+	return du
+}
+
+// RemoveAnnotations removes "annotations" edges to Annotation entities.
+func (du *DocumentUpdate) RemoveAnnotations(a ...*Annotation) *DocumentUpdate {
+	ids := make([]int, len(a))
+	for i := range a {
+		ids[i] = a[i].ID
+	}
+	return du.RemoveAnnotationIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -73,6 +110,51 @@ func (du *DocumentUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			}
 		}
 	}
+	if du.mutation.AnnotationsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   document.AnnotationsTable,
+			Columns: []string{document.AnnotationsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(annotation.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.RemovedAnnotationsIDs(); len(nodes) > 0 && !du.mutation.AnnotationsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   document.AnnotationsTable,
+			Columns: []string{document.AnnotationsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(annotation.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.AnnotationsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   document.AnnotationsTable,
+			Columns: []string{document.AnnotationsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(annotation.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, du.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{document.Label}
@@ -93,9 +175,45 @@ type DocumentUpdateOne struct {
 	mutation *DocumentMutation
 }
 
+// AddAnnotationIDs adds the "annotations" edge to the Annotation entity by IDs.
+func (duo *DocumentUpdateOne) AddAnnotationIDs(ids ...int) *DocumentUpdateOne {
+	duo.mutation.AddAnnotationIDs(ids...)
+	return duo
+}
+
+// AddAnnotations adds the "annotations" edges to the Annotation entity.
+func (duo *DocumentUpdateOne) AddAnnotations(a ...*Annotation) *DocumentUpdateOne {
+	ids := make([]int, len(a))
+	for i := range a {
+		ids[i] = a[i].ID
+	}
+	return duo.AddAnnotationIDs(ids...)
+}
+
 // Mutation returns the DocumentMutation object of the builder.
 func (duo *DocumentUpdateOne) Mutation() *DocumentMutation {
 	return duo.mutation
+}
+
+// ClearAnnotations clears all "annotations" edges to the Annotation entity.
+func (duo *DocumentUpdateOne) ClearAnnotations() *DocumentUpdateOne {
+	duo.mutation.ClearAnnotations()
+	return duo
+}
+
+// RemoveAnnotationIDs removes the "annotations" edge to Annotation entities by IDs.
+func (duo *DocumentUpdateOne) RemoveAnnotationIDs(ids ...int) *DocumentUpdateOne {
+	duo.mutation.RemoveAnnotationIDs(ids...)
+	return duo
+}
+
+// RemoveAnnotations removes "annotations" edges to Annotation entities.
+func (duo *DocumentUpdateOne) RemoveAnnotations(a ...*Annotation) *DocumentUpdateOne {
+	ids := make([]int, len(a))
+	for i := range a {
+		ids[i] = a[i].ID
+	}
+	return duo.RemoveAnnotationIDs(ids...)
 }
 
 // Where appends a list predicates to the DocumentUpdate builder.
@@ -163,6 +281,51 @@ func (duo *DocumentUpdateOne) sqlSave(ctx context.Context) (_node *Document, err
 				ps[i](selector)
 			}
 		}
+	}
+	if duo.mutation.AnnotationsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   document.AnnotationsTable,
+			Columns: []string{document.AnnotationsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(annotation.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.RemovedAnnotationsIDs(); len(nodes) > 0 && !duo.mutation.AnnotationsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   document.AnnotationsTable,
+			Columns: []string{document.AnnotationsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(annotation.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.AnnotationsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   document.AnnotationsTable,
+			Columns: []string{document.AnnotationsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(annotation.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	_node = &Document{config: duo.config}
 	_spec.Assign = _node.assignValues

--- a/internal/backends/ent/metadata/where.go
+++ b/internal/backends/ent/metadata/where.go
@@ -67,11 +67,6 @@ func ProtoMessage(v *sbom.Metadata) predicate.Metadata {
 	return predicate.Metadata(sql.FieldEQ(FieldProtoMessage, v))
 }
 
-// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
-func DocumentID(v uuid.UUID) predicate.Metadata {
-	return predicate.Metadata(sql.FieldEQ(FieldDocumentID, v))
-}
-
 // NativeID applies equality check predicate on the "native_id" field. It's identical to NativeIDEQ.
 func NativeID(v string) predicate.Metadata {
 	return predicate.Metadata(sql.FieldEQ(FieldNativeID, v))
@@ -135,26 +130,6 @@ func ProtoMessageLT(v *sbom.Metadata) predicate.Metadata {
 // ProtoMessageLTE applies the LTE predicate on the "proto_message" field.
 func ProtoMessageLTE(v *sbom.Metadata) predicate.Metadata {
 	return predicate.Metadata(sql.FieldLTE(FieldProtoMessage, v))
-}
-
-// DocumentIDEQ applies the EQ predicate on the "document_id" field.
-func DocumentIDEQ(v uuid.UUID) predicate.Metadata {
-	return predicate.Metadata(sql.FieldEQ(FieldDocumentID, v))
-}
-
-// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
-func DocumentIDNEQ(v uuid.UUID) predicate.Metadata {
-	return predicate.Metadata(sql.FieldNEQ(FieldDocumentID, v))
-}
-
-// DocumentIDIn applies the In predicate on the "document_id" field.
-func DocumentIDIn(vs ...uuid.UUID) predicate.Metadata {
-	return predicate.Metadata(sql.FieldIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
-func DocumentIDNotIn(vs ...uuid.UUID) predicate.Metadata {
-	return predicate.Metadata(sql.FieldNotIn(FieldDocumentID, vs...))
 }
 
 // NativeIDEQ applies the EQ predicate on the "native_id" field.
@@ -457,6 +432,29 @@ func CommentContainsFold(v string) predicate.Metadata {
 	return predicate.Metadata(sql.FieldContainsFold(FieldComment, v))
 }
 
+// HasDocument applies the HasEdge predicate on the "document" edge.
+func HasDocument() predicate.Metadata {
+	return predicate.Metadata(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, false, DocumentTable, DocumentColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
+func HasDocumentWith(preds ...predicate.Document) predicate.Metadata {
+	return predicate.Metadata(func(s *sql.Selector) {
+		step := newDocumentStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasTools applies the HasEdge predicate on the "tools" edge.
 func HasTools() predicate.Metadata {
 	return predicate.Metadata(func(s *sql.Selector) {
@@ -541,29 +539,6 @@ func HasSourceData() predicate.Metadata {
 func HasSourceDataWith(preds ...predicate.SourceData) predicate.Metadata {
 	return predicate.Metadata(func(s *sql.Selector) {
 		step := newSourceDataStep()
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.Metadata {
-	return predicate.Metadata(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, DocumentTable, DocumentColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.Metadata {
-	return predicate.Metadata(func(s *sql.Selector) {
-		step := newDocumentStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/backends/ent/metadata_create.go
+++ b/internal/backends/ent/metadata_create.go
@@ -41,12 +41,6 @@ func (mc *MetadataCreate) SetProtoMessage(s *sbom.Metadata) *MetadataCreate {
 	return mc
 }
 
-// SetDocumentID sets the "document_id" field.
-func (mc *MetadataCreate) SetDocumentID(u uuid.UUID) *MetadataCreate {
-	mc.mutation.SetDocumentID(u)
-	return mc
-}
-
 // SetNativeID sets the "native_id" field.
 func (mc *MetadataCreate) SetNativeID(s string) *MetadataCreate {
 	mc.mutation.SetNativeID(s)
@@ -89,6 +83,17 @@ func (mc *MetadataCreate) SetNillableID(u *uuid.UUID) *MetadataCreate {
 		mc.SetID(*u)
 	}
 	return mc
+}
+
+// SetDocumentID sets the "document" edge to the Document entity by ID.
+func (mc *MetadataCreate) SetDocumentID(id uuid.UUID) *MetadataCreate {
+	mc.mutation.SetDocumentID(id)
+	return mc
+}
+
+// SetDocument sets the "document" edge to the Document entity.
+func (mc *MetadataCreate) SetDocument(d *Document) *MetadataCreate {
+	return mc.SetDocumentID(d.ID)
 }
 
 // AddToolIDs adds the "tools" edge to the Tool entity by IDs.
@@ -151,11 +156,6 @@ func (mc *MetadataCreate) AddSourceData(s ...*SourceData) *MetadataCreate {
 	return mc.AddSourceDatumIDs(ids...)
 }
 
-// SetDocument sets the "document" edge to the Document entity.
-func (mc *MetadataCreate) SetDocument(d *Document) *MetadataCreate {
-	return mc.SetDocumentID(d.ID)
-}
-
 // Mutation returns the MetadataMutation object of the builder.
 func (mc *MetadataCreate) Mutation() *MetadataMutation {
 	return mc.mutation
@@ -201,9 +201,6 @@ func (mc *MetadataCreate) defaults() {
 func (mc *MetadataCreate) check() error {
 	if _, ok := mc.mutation.ProtoMessage(); !ok {
 		return &ValidationError{Name: "proto_message", err: errors.New(`ent: missing required field "Metadata.proto_message"`)}
-	}
-	if _, ok := mc.mutation.DocumentID(); !ok {
-		return &ValidationError{Name: "document_id", err: errors.New(`ent: missing required field "Metadata.document_id"`)}
 	}
 	if _, ok := mc.mutation.NativeID(); !ok {
 		return &ValidationError{Name: "native_id", err: errors.New(`ent: missing required field "Metadata.native_id"`)}
@@ -288,6 +285,22 @@ func (mc *MetadataCreate) createSpec() (*Metadata, *sqlgraph.CreateSpec) {
 		_spec.SetField(metadata.FieldComment, field.TypeString, value)
 		_node.Comment = value
 	}
+	if nodes := mc.mutation.DocumentIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: false,
+			Table:   metadata.DocumentTable,
+			Columns: []string{metadata.DocumentColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
 	if nodes := mc.mutation.ToolsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2M,
@@ -350,23 +363,6 @@ func (mc *MetadataCreate) createSpec() (*Metadata, *sqlgraph.CreateSpec) {
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := mc.mutation.DocumentIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2O,
-			Inverse: true,
-			Table:   metadata.DocumentTable,
-			Columns: []string{metadata.DocumentColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeUUID),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_node.DocumentID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec
@@ -488,9 +484,6 @@ func (u *MetadataUpsertOne) UpdateNewValues() *MetadataUpsertOne {
 		}
 		if _, exists := u.create.mutation.ProtoMessage(); exists {
 			s.SetIgnore(metadata.FieldProtoMessage)
-		}
-		if _, exists := u.create.mutation.DocumentID(); exists {
-			s.SetIgnore(metadata.FieldDocumentID)
 		}
 		if _, exists := u.create.mutation.NativeID(); exists {
 			s.SetIgnore(metadata.FieldNativeID)
@@ -767,9 +760,6 @@ func (u *MetadataUpsertBulk) UpdateNewValues() *MetadataUpsertBulk {
 			}
 			if _, exists := b.mutation.ProtoMessage(); exists {
 				s.SetIgnore(metadata.FieldProtoMessage)
-			}
-			if _, exists := b.mutation.DocumentID(); exists {
-				s.SetIgnore(metadata.FieldDocumentID)
 			}
 			if _, exists := b.mutation.NativeID(); exists {
 				s.SetIgnore(metadata.FieldNativeID)

--- a/internal/backends/ent/migrate/migrations/20250116171940_annotations_nillable_document_id.sql
+++ b/internal/backends/ent/migrate/migrations/20250116171940_annotations_nillable_document_id.sql
@@ -1,0 +1,59 @@
+-- Disable the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = off;
+-- Create "new_metadata" table
+CREATE TABLE `new_metadata` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `native_id` text NOT NULL,
+  `version` text NOT NULL,
+  `name` text NOT NULL,
+  `date` datetime NOT NULL,
+  `comment` text NOT NULL,
+  PRIMARY KEY (`id`)
+);
+-- Copy rows from old table "metadata" to new temporary table "new_metadata"
+INSERT INTO `new_metadata` (`id`, `proto_message`, `native_id`, `version`, `name`, `date`, `comment`) SELECT `id`, `proto_message`, `native_id`, `version`, `name`, `date`, `comment` FROM `metadata`;
+-- Drop "metadata" table after copying rows
+DROP TABLE `metadata`;
+-- Rename temporary table "new_metadata" to "metadata"
+ALTER TABLE `new_metadata` RENAME TO `metadata`;
+-- Create index "idx_metadata" to table: "metadata"
+CREATE UNIQUE INDEX `idx_metadata` ON `metadata` (`native_id`, `version`, `name`);
+-- Create "new_node_lists" table
+CREATE TABLE `new_node_lists` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `root_elements` json NOT NULL,
+  PRIMARY KEY (`id`)
+);
+-- Copy rows from old table "node_lists" to new temporary table "new_node_lists"
+INSERT INTO `new_node_lists` (`id`, `proto_message`, `root_elements`) SELECT `id`, `proto_message`, `root_elements` FROM `node_lists`;
+-- Drop "node_lists" table after copying rows
+DROP TABLE `node_lists`;
+-- Rename temporary table "new_node_lists" to "node_lists"
+ALTER TABLE `new_node_lists` RENAME TO `node_lists`;
+-- Create "new_documents" table
+CREATE TABLE `new_documents` (
+  `id` uuid NOT NULL,
+  `metadata_id` uuid NULL,
+  `node_list_id` uuid NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `documents_metadata_document` FOREIGN KEY (`metadata_id`) REFERENCES `metadata` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `documents_node_lists_document` FOREIGN KEY (`node_list_id`) REFERENCES `node_lists` (`id`) ON DELETE SET NULL
+);
+-- Copy rows from old table "documents" to new temporary table "new_documents"
+INSERT INTO `new_documents` (`id`) SELECT `id` FROM `documents`;
+-- Drop "documents" table after copying rows
+DROP TABLE `documents`;
+-- Rename temporary table "new_documents" to "documents"
+ALTER TABLE `new_documents` RENAME TO `documents`;
+-- Create index "documents_metadata_id_key" to table: "documents"
+CREATE UNIQUE INDEX `documents_metadata_id_key` ON `documents` (`metadata_id`);
+-- Create index "documents_node_list_id_key" to table: "documents"
+CREATE UNIQUE INDEX `documents_node_list_id_key` ON `documents` (`node_list_id`);
+-- Create index "idx_annotations_node_id" to table: "annotations"
+CREATE INDEX `idx_annotations_node_id` ON `annotations` (`node_id`);
+-- Create index "idx_annotations_document_id" to table: "annotations"
+CREATE INDEX `idx_annotations_document_id` ON `annotations` (`document_id`);
+-- Enable back the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = on;

--- a/internal/backends/ent/migrate/migrations/atlas.sum
+++ b/internal/backends/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:LsrssYsdcm8jjYaT6GHzhPlZ7soWyhOvqryWvUOkngA=
+h1:lIrfcCk+LYFBqsFjGSqZ9QnvvS8jecCevrYZdG6GdDk=
 20241016141529_initial.sql h1:cZ5Nr+1kj075buwWNz8SHKlRSFaV3L0dzpT9htnXQY4=
 20241101155047_store_protos.sql h1:ALraUjMTZaPGDf+y7IXSLp/LRVWXP3rG6kKQb3ZJf5I=
 20241109194036_ext_ref_type_fix.sql h1:hvLOKWxV23ea20Po7TLLx0VVfevihIQmR2Ft9nX2Nis=
@@ -8,3 +8,4 @@ h1:LsrssYsdcm8jjYaT6GHzhPlZ7soWyhOvqryWvUOkngA=
 20250111185420_nodelist_edges_fix.sql h1:3N2FWm6V4ynDShFdVCvMDegJDCrRTul2DrT6hcoaqqk=
 20250111195106_hashes_entries.sql h1:xjufIpuHDOznA58+Uk7sIDgtA7lDHTynVtui/iXYFJk=
 20250111195831_identifiers_entries.sql h1:t+6QoPwVYJFuXnS8zPiFeL3F/NvQorfgi5sAxGcEn6c=
+20250116171940_annotations_nillable_document_id.sql h1:m7rHNc6tZKrgqTH2QWYJ6x7cZheeS1r3pihYyHATV8U=

--- a/internal/backends/ent/migrate/schema.go
+++ b/internal/backends/ent/migrate/schema.go
@@ -30,7 +30,7 @@ var (
 		PrimaryKey: []*schema.Column{AnnotationsColumns[0]},
 		ForeignKeys: []*schema.ForeignKey{
 			{
-				Symbol:     "annotations_documents_document",
+				Symbol:     "annotations_documents_annotations",
 				Columns:    []*schema.Column{AnnotationsColumns[4]},
 				RefColumns: []*schema.Column{DocumentsColumns[0]},
 				OnDelete:   schema.Cascade,
@@ -43,6 +43,16 @@ var (
 			},
 		},
 		Indexes: []*schema.Index{
+			{
+				Name:    "idx_annotations_node_id",
+				Unique:  false,
+				Columns: []*schema.Column{AnnotationsColumns[5]},
+			},
+			{
+				Name:    "idx_annotations_document_id",
+				Unique:  false,
+				Columns: []*schema.Column{AnnotationsColumns[4]},
+			},
 			{
 				Name:    "idx_node_annotations",
 				Unique:  true,
@@ -80,12 +90,28 @@ var (
 	// DocumentsColumns holds the columns for the "documents" table.
 	DocumentsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeUUID, Unique: true},
+		{Name: "metadata_id", Type: field.TypeUUID, Unique: true, Nullable: true},
+		{Name: "node_list_id", Type: field.TypeUUID, Unique: true, Nullable: true},
 	}
 	// DocumentsTable holds the schema information for the "documents" table.
 	DocumentsTable = &schema.Table{
 		Name:       "documents",
 		Columns:    DocumentsColumns,
 		PrimaryKey: []*schema.Column{DocumentsColumns[0]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "documents_metadata_document",
+				Columns:    []*schema.Column{DocumentsColumns[1]},
+				RefColumns: []*schema.Column{MetadataColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+			{
+				Symbol:     "documents_node_lists_document",
+				Columns:    []*schema.Column{DocumentsColumns[2]},
+				RefColumns: []*schema.Column{NodeListsColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+		},
 	}
 	// DocumentTypesColumns holds the columns for the "document_types" table.
 	DocumentTypesColumns = []*schema.Column{
@@ -260,21 +286,12 @@ var (
 		{Name: "name", Type: field.TypeString},
 		{Name: "date", Type: field.TypeTime},
 		{Name: "comment", Type: field.TypeString},
-		{Name: "document_id", Type: field.TypeUUID, Unique: true},
 	}
 	// MetadataTable holds the schema information for the "metadata" table.
 	MetadataTable = &schema.Table{
 		Name:       "metadata",
 		Columns:    MetadataColumns,
 		PrimaryKey: []*schema.Column{MetadataColumns[0]},
-		ForeignKeys: []*schema.ForeignKey{
-			{
-				Symbol:     "metadata_documents_metadata",
-				Columns:    []*schema.Column{MetadataColumns[7]},
-				RefColumns: []*schema.Column{DocumentsColumns[0]},
-				OnDelete:   schema.NoAction,
-			},
-		},
 		Indexes: []*schema.Index{
 			{
 				Name:    "idx_metadata",
@@ -336,21 +353,12 @@ var (
 		{Name: "id", Type: field.TypeUUID, Unique: true},
 		{Name: "proto_message", Type: field.TypeBytes},
 		{Name: "root_elements", Type: field.TypeJSON},
-		{Name: "document_id", Type: field.TypeUUID, Unique: true},
 	}
 	// NodeListsTable holds the schema information for the "node_lists" table.
 	NodeListsTable = &schema.Table{
 		Name:       "node_lists",
 		Columns:    NodeListsColumns,
 		PrimaryKey: []*schema.Column{NodeListsColumns[0]},
-		ForeignKeys: []*schema.ForeignKey{
-			{
-				Symbol:     "node_lists_documents_node_list",
-				Columns:    []*schema.Column{NodeListsColumns[3]},
-				RefColumns: []*schema.Column{DocumentsColumns[0]},
-				OnDelete:   schema.NoAction,
-			},
-		},
 	}
 	// PersonsColumns holds the columns for the "persons" table.
 	PersonsColumns = []*schema.Column{
@@ -747,7 +755,8 @@ var (
 func init() {
 	AnnotationsTable.ForeignKeys[0].RefTable = DocumentsTable
 	AnnotationsTable.ForeignKeys[1].RefTable = NodesTable
-	AnnotationsTable.Annotation = &entsql.Annotation{}
+	DocumentsTable.ForeignKeys[0].RefTable = MetadataTable
+	DocumentsTable.ForeignKeys[1].RefTable = NodeListsTable
 	DocumentTypesTable.ForeignKeys[0].RefTable = DocumentsTable
 	DocumentTypesTable.ForeignKeys[1].RefTable = MetadataTable
 	DocumentTypesTable.Annotation = &entsql.Annotation{}
@@ -761,10 +770,8 @@ func init() {
 	HashesEntriesTable.Annotation = &entsql.Annotation{}
 	IdentifiersEntriesTable.ForeignKeys[0].RefTable = DocumentsTable
 	IdentifiersEntriesTable.Annotation = &entsql.Annotation{}
-	MetadataTable.ForeignKeys[0].RefTable = DocumentsTable
 	NodesTable.ForeignKeys[0].RefTable = DocumentsTable
 	NodesTable.Annotation = &entsql.Annotation{}
-	NodeListsTable.ForeignKeys[0].RefTable = DocumentsTable
 	PersonsTable.ForeignKeys[0].RefTable = MetadataTable
 	PersonsTable.ForeignKeys[1].RefTable = NodesTable
 	PersonsTable.ForeignKeys[2].RefTable = NodesTable

--- a/internal/backends/ent/mutation.go
+++ b/internal/backends/ent/mutation.go
@@ -196,7 +196,7 @@ func (m *AnnotationMutation) DocumentID() (r uuid.UUID, exists bool) {
 // OldDocumentID returns the old "document_id" field's value of the Annotation entity.
 // If the Annotation object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *AnnotationMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
+func (m *AnnotationMutation) OldDocumentID(ctx context.Context) (v *uuid.UUID, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
 	}
@@ -748,17 +748,20 @@ func (m *AnnotationMutation) ResetEdge(name string) error {
 // DocumentMutation represents an operation that mutates the Document nodes in the graph.
 type DocumentMutation struct {
 	config
-	op               Op
-	typ              string
-	id               *uuid.UUID
-	clearedFields    map[string]struct{}
-	metadata         *uuid.UUID
-	clearedmetadata  bool
-	node_list        *uuid.UUID
-	clearednode_list bool
-	done             bool
-	oldValue         func(context.Context) (*Document, error)
-	predicates       []predicate.Document
+	op                 Op
+	typ                string
+	id                 *uuid.UUID
+	clearedFields      map[string]struct{}
+	annotations        map[int]struct{}
+	removedannotations map[int]struct{}
+	clearedannotations bool
+	metadata           *uuid.UUID
+	clearedmetadata    bool
+	node_list          *uuid.UUID
+	clearednode_list   bool
+	done               bool
+	oldValue           func(context.Context) (*Document, error)
+	predicates         []predicate.Document
 }
 
 var _ ent.Mutation = (*DocumentMutation)(nil)
@@ -865,27 +868,167 @@ func (m *DocumentMutation) IDs(ctx context.Context) ([]uuid.UUID, error) {
 	}
 }
 
-// SetMetadataID sets the "metadata" edge to the Metadata entity by id.
-func (m *DocumentMutation) SetMetadataID(id uuid.UUID) {
-	m.metadata = &id
+// SetMetadataID sets the "metadata_id" field.
+func (m *DocumentMutation) SetMetadataID(u uuid.UUID) {
+	m.metadata = &u
+}
+
+// MetadataID returns the value of the "metadata_id" field in the mutation.
+func (m *DocumentMutation) MetadataID() (r uuid.UUID, exists bool) {
+	v := m.metadata
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldMetadataID returns the old "metadata_id" field's value of the Document entity.
+// If the Document object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *DocumentMutation) OldMetadataID(ctx context.Context) (v uuid.UUID, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldMetadataID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldMetadataID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldMetadataID: %w", err)
+	}
+	return oldValue.MetadataID, nil
+}
+
+// ClearMetadataID clears the value of the "metadata_id" field.
+func (m *DocumentMutation) ClearMetadataID() {
+	m.metadata = nil
+	m.clearedFields[document.FieldMetadataID] = struct{}{}
+}
+
+// MetadataIDCleared returns if the "metadata_id" field was cleared in this mutation.
+func (m *DocumentMutation) MetadataIDCleared() bool {
+	_, ok := m.clearedFields[document.FieldMetadataID]
+	return ok
+}
+
+// ResetMetadataID resets all changes to the "metadata_id" field.
+func (m *DocumentMutation) ResetMetadataID() {
+	m.metadata = nil
+	delete(m.clearedFields, document.FieldMetadataID)
+}
+
+// SetNodeListID sets the "node_list_id" field.
+func (m *DocumentMutation) SetNodeListID(u uuid.UUID) {
+	m.node_list = &u
+}
+
+// NodeListID returns the value of the "node_list_id" field in the mutation.
+func (m *DocumentMutation) NodeListID() (r uuid.UUID, exists bool) {
+	v := m.node_list
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldNodeListID returns the old "node_list_id" field's value of the Document entity.
+// If the Document object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *DocumentMutation) OldNodeListID(ctx context.Context) (v uuid.UUID, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldNodeListID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldNodeListID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldNodeListID: %w", err)
+	}
+	return oldValue.NodeListID, nil
+}
+
+// ClearNodeListID clears the value of the "node_list_id" field.
+func (m *DocumentMutation) ClearNodeListID() {
+	m.node_list = nil
+	m.clearedFields[document.FieldNodeListID] = struct{}{}
+}
+
+// NodeListIDCleared returns if the "node_list_id" field was cleared in this mutation.
+func (m *DocumentMutation) NodeListIDCleared() bool {
+	_, ok := m.clearedFields[document.FieldNodeListID]
+	return ok
+}
+
+// ResetNodeListID resets all changes to the "node_list_id" field.
+func (m *DocumentMutation) ResetNodeListID() {
+	m.node_list = nil
+	delete(m.clearedFields, document.FieldNodeListID)
+}
+
+// AddAnnotationIDs adds the "annotations" edge to the Annotation entity by ids.
+func (m *DocumentMutation) AddAnnotationIDs(ids ...int) {
+	if m.annotations == nil {
+		m.annotations = make(map[int]struct{})
+	}
+	for i := range ids {
+		m.annotations[ids[i]] = struct{}{}
+	}
+}
+
+// ClearAnnotations clears the "annotations" edge to the Annotation entity.
+func (m *DocumentMutation) ClearAnnotations() {
+	m.clearedannotations = true
+}
+
+// AnnotationsCleared reports if the "annotations" edge to the Annotation entity was cleared.
+func (m *DocumentMutation) AnnotationsCleared() bool {
+	return m.clearedannotations
+}
+
+// RemoveAnnotationIDs removes the "annotations" edge to the Annotation entity by IDs.
+func (m *DocumentMutation) RemoveAnnotationIDs(ids ...int) {
+	if m.removedannotations == nil {
+		m.removedannotations = make(map[int]struct{})
+	}
+	for i := range ids {
+		delete(m.annotations, ids[i])
+		m.removedannotations[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedAnnotations returns the removed IDs of the "annotations" edge to the Annotation entity.
+func (m *DocumentMutation) RemovedAnnotationsIDs() (ids []int) {
+	for id := range m.removedannotations {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// AnnotationsIDs returns the "annotations" edge IDs in the mutation.
+func (m *DocumentMutation) AnnotationsIDs() (ids []int) {
+	for id := range m.annotations {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetAnnotations resets all changes to the "annotations" edge.
+func (m *DocumentMutation) ResetAnnotations() {
+	m.annotations = nil
+	m.clearedannotations = false
+	m.removedannotations = nil
 }
 
 // ClearMetadata clears the "metadata" edge to the Metadata entity.
 func (m *DocumentMutation) ClearMetadata() {
 	m.clearedmetadata = true
+	m.clearedFields[document.FieldMetadataID] = struct{}{}
 }
 
 // MetadataCleared reports if the "metadata" edge to the Metadata entity was cleared.
 func (m *DocumentMutation) MetadataCleared() bool {
-	return m.clearedmetadata
-}
-
-// MetadataID returns the "metadata" edge ID in the mutation.
-func (m *DocumentMutation) MetadataID() (id uuid.UUID, exists bool) {
-	if m.metadata != nil {
-		return *m.metadata, true
-	}
-	return
+	return m.MetadataIDCleared() || m.clearedmetadata
 }
 
 // MetadataIDs returns the "metadata" edge IDs in the mutation.
@@ -904,27 +1047,15 @@ func (m *DocumentMutation) ResetMetadata() {
 	m.clearedmetadata = false
 }
 
-// SetNodeListID sets the "node_list" edge to the NodeList entity by id.
-func (m *DocumentMutation) SetNodeListID(id uuid.UUID) {
-	m.node_list = &id
-}
-
 // ClearNodeList clears the "node_list" edge to the NodeList entity.
 func (m *DocumentMutation) ClearNodeList() {
 	m.clearednode_list = true
+	m.clearedFields[document.FieldNodeListID] = struct{}{}
 }
 
 // NodeListCleared reports if the "node_list" edge to the NodeList entity was cleared.
 func (m *DocumentMutation) NodeListCleared() bool {
-	return m.clearednode_list
-}
-
-// NodeListID returns the "node_list" edge ID in the mutation.
-func (m *DocumentMutation) NodeListID() (id uuid.UUID, exists bool) {
-	if m.node_list != nil {
-		return *m.node_list, true
-	}
-	return
+	return m.NodeListIDCleared() || m.clearednode_list
 }
 
 // NodeListIDs returns the "node_list" edge IDs in the mutation.
@@ -977,7 +1108,13 @@ func (m *DocumentMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *DocumentMutation) Fields() []string {
-	fields := make([]string, 0, 0)
+	fields := make([]string, 0, 2)
+	if m.metadata != nil {
+		fields = append(fields, document.FieldMetadataID)
+	}
+	if m.node_list != nil {
+		fields = append(fields, document.FieldNodeListID)
+	}
 	return fields
 }
 
@@ -985,6 +1122,12 @@ func (m *DocumentMutation) Fields() []string {
 // return value indicates that this field was not set, or was not defined in the
 // schema.
 func (m *DocumentMutation) Field(name string) (ent.Value, bool) {
+	switch name {
+	case document.FieldMetadataID:
+		return m.MetadataID()
+	case document.FieldNodeListID:
+		return m.NodeListID()
+	}
 	return nil, false
 }
 
@@ -992,6 +1135,12 @@ func (m *DocumentMutation) Field(name string) (ent.Value, bool) {
 // returned if the mutation operation is not UpdateOne, or the query to the
 // database failed.
 func (m *DocumentMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
+	switch name {
+	case document.FieldMetadataID:
+		return m.OldMetadataID(ctx)
+	case document.FieldNodeListID:
+		return m.OldNodeListID(ctx)
+	}
 	return nil, fmt.Errorf("unknown Document field %s", name)
 }
 
@@ -1000,6 +1149,20 @@ func (m *DocumentMutation) OldField(ctx context.Context, name string) (ent.Value
 // type.
 func (m *DocumentMutation) SetField(name string, value ent.Value) error {
 	switch name {
+	case document.FieldMetadataID:
+		v, ok := value.(uuid.UUID)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetMetadataID(v)
+		return nil
+	case document.FieldNodeListID:
+		v, ok := value.(uuid.UUID)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetNodeListID(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Document field %s", name)
 }
@@ -1021,13 +1184,22 @@ func (m *DocumentMutation) AddedField(name string) (ent.Value, bool) {
 // the field is not defined in the schema, or if the type mismatched the field
 // type.
 func (m *DocumentMutation) AddField(name string, value ent.Value) error {
+	switch name {
+	}
 	return fmt.Errorf("unknown Document numeric field %s", name)
 }
 
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *DocumentMutation) ClearedFields() []string {
-	return nil
+	var fields []string
+	if m.FieldCleared(document.FieldMetadataID) {
+		fields = append(fields, document.FieldMetadataID)
+	}
+	if m.FieldCleared(document.FieldNodeListID) {
+		fields = append(fields, document.FieldNodeListID)
+	}
+	return fields
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -1040,18 +1212,37 @@ func (m *DocumentMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *DocumentMutation) ClearField(name string) error {
+	switch name {
+	case document.FieldMetadataID:
+		m.ClearMetadataID()
+		return nil
+	case document.FieldNodeListID:
+		m.ClearNodeListID()
+		return nil
+	}
 	return fmt.Errorf("unknown Document nullable field %s", name)
 }
 
 // ResetField resets all changes in the mutation for the field with the given name.
 // It returns an error if the field is not defined in the schema.
 func (m *DocumentMutation) ResetField(name string) error {
+	switch name {
+	case document.FieldMetadataID:
+		m.ResetMetadataID()
+		return nil
+	case document.FieldNodeListID:
+		m.ResetNodeListID()
+		return nil
+	}
 	return fmt.Errorf("unknown Document field %s", name)
 }
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *DocumentMutation) AddedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
+	if m.annotations != nil {
+		edges = append(edges, document.EdgeAnnotations)
+	}
 	if m.metadata != nil {
 		edges = append(edges, document.EdgeMetadata)
 	}
@@ -1065,6 +1256,12 @@ func (m *DocumentMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *DocumentMutation) AddedIDs(name string) []ent.Value {
 	switch name {
+	case document.EdgeAnnotations:
+		ids := make([]ent.Value, 0, len(m.annotations))
+		for id := range m.annotations {
+			ids = append(ids, id)
+		}
+		return ids
 	case document.EdgeMetadata:
 		if id := m.metadata; id != nil {
 			return []ent.Value{*id}
@@ -1079,19 +1276,33 @@ func (m *DocumentMutation) AddedIDs(name string) []ent.Value {
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *DocumentMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
+	if m.removedannotations != nil {
+		edges = append(edges, document.EdgeAnnotations)
+	}
 	return edges
 }
 
 // RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
 // the given name in this mutation.
 func (m *DocumentMutation) RemovedIDs(name string) []ent.Value {
+	switch name {
+	case document.EdgeAnnotations:
+		ids := make([]ent.Value, 0, len(m.removedannotations))
+		for id := range m.removedannotations {
+			ids = append(ids, id)
+		}
+		return ids
+	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *DocumentMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
+	if m.clearedannotations {
+		edges = append(edges, document.EdgeAnnotations)
+	}
 	if m.clearedmetadata {
 		edges = append(edges, document.EdgeMetadata)
 	}
@@ -1105,6 +1316,8 @@ func (m *DocumentMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *DocumentMutation) EdgeCleared(name string) bool {
 	switch name {
+	case document.EdgeAnnotations:
+		return m.clearedannotations
 	case document.EdgeMetadata:
 		return m.clearedmetadata
 	case document.EdgeNodeList:
@@ -1131,6 +1344,9 @@ func (m *DocumentMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *DocumentMutation) ResetEdge(name string) error {
 	switch name {
+	case document.EdgeAnnotations:
+		m.ResetAnnotations()
+		return nil
 	case document.EdgeMetadata:
 		m.ResetMetadata()
 		return nil
@@ -4931,6 +5147,8 @@ type MetadataMutation struct {
 	date                  *time.Time
 	comment               *string
 	clearedFields         map[string]struct{}
+	document              *uuid.UUID
+	cleareddocument       bool
 	tools                 map[uuid.UUID]struct{}
 	removedtools          map[uuid.UUID]struct{}
 	clearedtools          bool
@@ -4943,8 +5161,6 @@ type MetadataMutation struct {
 	source_data           map[uuid.UUID]struct{}
 	removedsource_data    map[uuid.UUID]struct{}
 	clearedsource_data    bool
-	document              *uuid.UUID
-	cleareddocument       bool
 	done                  bool
 	oldValue              func(context.Context) (*Metadata, error)
 	predicates            []predicate.Metadata
@@ -5088,42 +5304,6 @@ func (m *MetadataMutation) OldProtoMessage(ctx context.Context) (v *sbom.Metadat
 // ResetProtoMessage resets all changes to the "proto_message" field.
 func (m *MetadataMutation) ResetProtoMessage() {
 	m.proto_message = nil
-}
-
-// SetDocumentID sets the "document_id" field.
-func (m *MetadataMutation) SetDocumentID(u uuid.UUID) {
-	m.document = &u
-}
-
-// DocumentID returns the value of the "document_id" field in the mutation.
-func (m *MetadataMutation) DocumentID() (r uuid.UUID, exists bool) {
-	v := m.document
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDocumentID returns the old "document_id" field's value of the Metadata entity.
-// If the Metadata object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *MetadataMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDocumentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
-	}
-	return oldValue.DocumentID, nil
-}
-
-// ResetDocumentID resets all changes to the "document_id" field.
-func (m *MetadataMutation) ResetDocumentID() {
-	m.document = nil
 }
 
 // SetNativeID sets the "native_id" field.
@@ -5304,6 +5484,45 @@ func (m *MetadataMutation) OldComment(ctx context.Context) (v string, err error)
 // ResetComment resets all changes to the "comment" field.
 func (m *MetadataMutation) ResetComment() {
 	m.comment = nil
+}
+
+// SetDocumentID sets the "document" edge to the Document entity by id.
+func (m *MetadataMutation) SetDocumentID(id uuid.UUID) {
+	m.document = &id
+}
+
+// ClearDocument clears the "document" edge to the Document entity.
+func (m *MetadataMutation) ClearDocument() {
+	m.cleareddocument = true
+}
+
+// DocumentCleared reports if the "document" edge to the Document entity was cleared.
+func (m *MetadataMutation) DocumentCleared() bool {
+	return m.cleareddocument
+}
+
+// DocumentID returns the "document" edge ID in the mutation.
+func (m *MetadataMutation) DocumentID() (id uuid.UUID, exists bool) {
+	if m.document != nil {
+		return *m.document, true
+	}
+	return
+}
+
+// DocumentIDs returns the "document" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// DocumentID instead. It exists only for internal usage by the builders.
+func (m *MetadataMutation) DocumentIDs() (ids []uuid.UUID) {
+	if id := m.document; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetDocument resets all changes to the "document" edge.
+func (m *MetadataMutation) ResetDocument() {
+	m.document = nil
+	m.cleareddocument = false
 }
 
 // AddToolIDs adds the "tools" edge to the Tool entity by ids.
@@ -5522,33 +5741,6 @@ func (m *MetadataMutation) ResetSourceData() {
 	m.removedsource_data = nil
 }
 
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *MetadataMutation) ClearDocument() {
-	m.cleareddocument = true
-	m.clearedFields[metadata.FieldDocumentID] = struct{}{}
-}
-
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *MetadataMutation) DocumentCleared() bool {
-	return m.cleareddocument
-}
-
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *MetadataMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
-	}
-	return
-}
-
-// ResetDocument resets all changes to the "document" edge.
-func (m *MetadataMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
-}
-
 // Where appends a list predicates to the MetadataMutation builder.
 func (m *MetadataMutation) Where(ps ...predicate.Metadata) {
 	m.predicates = append(m.predicates, ps...)
@@ -5583,12 +5775,9 @@ func (m *MetadataMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *MetadataMutation) Fields() []string {
-	fields := make([]string, 0, 7)
+	fields := make([]string, 0, 6)
 	if m.proto_message != nil {
 		fields = append(fields, metadata.FieldProtoMessage)
-	}
-	if m.document != nil {
-		fields = append(fields, metadata.FieldDocumentID)
 	}
 	if m.native_id != nil {
 		fields = append(fields, metadata.FieldNativeID)
@@ -5615,8 +5804,6 @@ func (m *MetadataMutation) Field(name string) (ent.Value, bool) {
 	switch name {
 	case metadata.FieldProtoMessage:
 		return m.ProtoMessage()
-	case metadata.FieldDocumentID:
-		return m.DocumentID()
 	case metadata.FieldNativeID:
 		return m.NativeID()
 	case metadata.FieldVersion:
@@ -5638,8 +5825,6 @@ func (m *MetadataMutation) OldField(ctx context.Context, name string) (ent.Value
 	switch name {
 	case metadata.FieldProtoMessage:
 		return m.OldProtoMessage(ctx)
-	case metadata.FieldDocumentID:
-		return m.OldDocumentID(ctx)
 	case metadata.FieldNativeID:
 		return m.OldNativeID(ctx)
 	case metadata.FieldVersion:
@@ -5665,13 +5850,6 @@ func (m *MetadataMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetProtoMessage(v)
-		return nil
-	case metadata.FieldDocumentID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDocumentID(v)
 		return nil
 	case metadata.FieldNativeID:
 		v, ok := value.(string)
@@ -5760,9 +5938,6 @@ func (m *MetadataMutation) ResetField(name string) error {
 	case metadata.FieldProtoMessage:
 		m.ResetProtoMessage()
 		return nil
-	case metadata.FieldDocumentID:
-		m.ResetDocumentID()
-		return nil
 	case metadata.FieldNativeID:
 		m.ResetNativeID()
 		return nil
@@ -5785,6 +5960,9 @@ func (m *MetadataMutation) ResetField(name string) error {
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *MetadataMutation) AddedEdges() []string {
 	edges := make([]string, 0, 5)
+	if m.document != nil {
+		edges = append(edges, metadata.EdgeDocument)
+	}
 	if m.tools != nil {
 		edges = append(edges, metadata.EdgeTools)
 	}
@@ -5797,9 +5975,6 @@ func (m *MetadataMutation) AddedEdges() []string {
 	if m.source_data != nil {
 		edges = append(edges, metadata.EdgeSourceData)
 	}
-	if m.document != nil {
-		edges = append(edges, metadata.EdgeDocument)
-	}
 	return edges
 }
 
@@ -5807,6 +5982,10 @@ func (m *MetadataMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *MetadataMutation) AddedIDs(name string) []ent.Value {
 	switch name {
+	case metadata.EdgeDocument:
+		if id := m.document; id != nil {
+			return []ent.Value{*id}
+		}
 	case metadata.EdgeTools:
 		ids := make([]ent.Value, 0, len(m.tools))
 		for id := range m.tools {
@@ -5831,10 +6010,6 @@ func (m *MetadataMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
-	case metadata.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
-		}
 	}
 	return nil
 }
@@ -5892,6 +6067,9 @@ func (m *MetadataMutation) RemovedIDs(name string) []ent.Value {
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *MetadataMutation) ClearedEdges() []string {
 	edges := make([]string, 0, 5)
+	if m.cleareddocument {
+		edges = append(edges, metadata.EdgeDocument)
+	}
 	if m.clearedtools {
 		edges = append(edges, metadata.EdgeTools)
 	}
@@ -5904,9 +6082,6 @@ func (m *MetadataMutation) ClearedEdges() []string {
 	if m.clearedsource_data {
 		edges = append(edges, metadata.EdgeSourceData)
 	}
-	if m.cleareddocument {
-		edges = append(edges, metadata.EdgeDocument)
-	}
 	return edges
 }
 
@@ -5914,6 +6089,8 @@ func (m *MetadataMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *MetadataMutation) EdgeCleared(name string) bool {
 	switch name {
+	case metadata.EdgeDocument:
+		return m.cleareddocument
 	case metadata.EdgeTools:
 		return m.clearedtools
 	case metadata.EdgeAuthors:
@@ -5922,8 +6099,6 @@ func (m *MetadataMutation) EdgeCleared(name string) bool {
 		return m.cleareddocument_types
 	case metadata.EdgeSourceData:
 		return m.clearedsource_data
-	case metadata.EdgeDocument:
-		return m.cleareddocument
 	}
 	return false
 }
@@ -5943,6 +6118,9 @@ func (m *MetadataMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *MetadataMutation) ResetEdge(name string) error {
 	switch name {
+	case metadata.EdgeDocument:
+		m.ResetDocument()
+		return nil
 	case metadata.EdgeTools:
 		m.ResetTools()
 		return nil
@@ -5954,9 +6132,6 @@ func (m *MetadataMutation) ResetEdge(name string) error {
 		return nil
 	case metadata.EdgeSourceData:
 		m.ResetSourceData()
-		return nil
-	case metadata.EdgeDocument:
-		m.ResetDocument()
 		return nil
 	}
 	return fmt.Errorf("unknown Metadata edge %s", name)
@@ -8633,14 +8808,14 @@ type NodeListMutation struct {
 	root_elements       *[]string
 	appendroot_elements []string
 	clearedFields       map[string]struct{}
+	document            *uuid.UUID
+	cleareddocument     bool
 	edge_types          map[uuid.UUID]struct{}
 	removededge_types   map[uuid.UUID]struct{}
 	clearededge_types   bool
 	nodes               map[uuid.UUID]struct{}
 	removednodes        map[uuid.UUID]struct{}
 	clearednodes        bool
-	document            *uuid.UUID
-	cleareddocument     bool
 	done                bool
 	oldValue            func(context.Context) (*NodeList, error)
 	predicates          []predicate.NodeList
@@ -8786,42 +8961,6 @@ func (m *NodeListMutation) ResetProtoMessage() {
 	m.proto_message = nil
 }
 
-// SetDocumentID sets the "document_id" field.
-func (m *NodeListMutation) SetDocumentID(u uuid.UUID) {
-	m.document = &u
-}
-
-// DocumentID returns the value of the "document_id" field in the mutation.
-func (m *NodeListMutation) DocumentID() (r uuid.UUID, exists bool) {
-	v := m.document
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDocumentID returns the old "document_id" field's value of the NodeList entity.
-// If the NodeList object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *NodeListMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDocumentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
-	}
-	return oldValue.DocumentID, nil
-}
-
-// ResetDocumentID resets all changes to the "document_id" field.
-func (m *NodeListMutation) ResetDocumentID() {
-	m.document = nil
-}
-
 // SetRootElements sets the "root_elements" field.
 func (m *NodeListMutation) SetRootElements(s []string) {
 	m.root_elements = &s
@@ -8871,6 +9010,45 @@ func (m *NodeListMutation) AppendedRootElements() ([]string, bool) {
 func (m *NodeListMutation) ResetRootElements() {
 	m.root_elements = nil
 	m.appendroot_elements = nil
+}
+
+// SetDocumentID sets the "document" edge to the Document entity by id.
+func (m *NodeListMutation) SetDocumentID(id uuid.UUID) {
+	m.document = &id
+}
+
+// ClearDocument clears the "document" edge to the Document entity.
+func (m *NodeListMutation) ClearDocument() {
+	m.cleareddocument = true
+}
+
+// DocumentCleared reports if the "document" edge to the Document entity was cleared.
+func (m *NodeListMutation) DocumentCleared() bool {
+	return m.cleareddocument
+}
+
+// DocumentID returns the "document" edge ID in the mutation.
+func (m *NodeListMutation) DocumentID() (id uuid.UUID, exists bool) {
+	if m.document != nil {
+		return *m.document, true
+	}
+	return
+}
+
+// DocumentIDs returns the "document" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// DocumentID instead. It exists only for internal usage by the builders.
+func (m *NodeListMutation) DocumentIDs() (ids []uuid.UUID) {
+	if id := m.document; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetDocument resets all changes to the "document" edge.
+func (m *NodeListMutation) ResetDocument() {
+	m.document = nil
+	m.cleareddocument = false
 }
 
 // AddEdgeTypeIDs adds the "edge_types" edge to the EdgeType entity by ids.
@@ -8981,33 +9159,6 @@ func (m *NodeListMutation) ResetNodes() {
 	m.removednodes = nil
 }
 
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *NodeListMutation) ClearDocument() {
-	m.cleareddocument = true
-	m.clearedFields[nodelist.FieldDocumentID] = struct{}{}
-}
-
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *NodeListMutation) DocumentCleared() bool {
-	return m.cleareddocument
-}
-
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *NodeListMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
-	}
-	return
-}
-
-// ResetDocument resets all changes to the "document" edge.
-func (m *NodeListMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
-}
-
 // Where appends a list predicates to the NodeListMutation builder.
 func (m *NodeListMutation) Where(ps ...predicate.NodeList) {
 	m.predicates = append(m.predicates, ps...)
@@ -9042,12 +9193,9 @@ func (m *NodeListMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *NodeListMutation) Fields() []string {
-	fields := make([]string, 0, 3)
+	fields := make([]string, 0, 2)
 	if m.proto_message != nil {
 		fields = append(fields, nodelist.FieldProtoMessage)
-	}
-	if m.document != nil {
-		fields = append(fields, nodelist.FieldDocumentID)
 	}
 	if m.root_elements != nil {
 		fields = append(fields, nodelist.FieldRootElements)
@@ -9062,8 +9210,6 @@ func (m *NodeListMutation) Field(name string) (ent.Value, bool) {
 	switch name {
 	case nodelist.FieldProtoMessage:
 		return m.ProtoMessage()
-	case nodelist.FieldDocumentID:
-		return m.DocumentID()
 	case nodelist.FieldRootElements:
 		return m.RootElements()
 	}
@@ -9077,8 +9223,6 @@ func (m *NodeListMutation) OldField(ctx context.Context, name string) (ent.Value
 	switch name {
 	case nodelist.FieldProtoMessage:
 		return m.OldProtoMessage(ctx)
-	case nodelist.FieldDocumentID:
-		return m.OldDocumentID(ctx)
 	case nodelist.FieldRootElements:
 		return m.OldRootElements(ctx)
 	}
@@ -9096,13 +9240,6 @@ func (m *NodeListMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetProtoMessage(v)
-		return nil
-	case nodelist.FieldDocumentID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDocumentID(v)
 		return nil
 	case nodelist.FieldRootElements:
 		v, ok := value.([]string)
@@ -9163,9 +9300,6 @@ func (m *NodeListMutation) ResetField(name string) error {
 	case nodelist.FieldProtoMessage:
 		m.ResetProtoMessage()
 		return nil
-	case nodelist.FieldDocumentID:
-		m.ResetDocumentID()
-		return nil
 	case nodelist.FieldRootElements:
 		m.ResetRootElements()
 		return nil
@@ -9176,14 +9310,14 @@ func (m *NodeListMutation) ResetField(name string) error {
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *NodeListMutation) AddedEdges() []string {
 	edges := make([]string, 0, 3)
+	if m.document != nil {
+		edges = append(edges, nodelist.EdgeDocument)
+	}
 	if m.edge_types != nil {
 		edges = append(edges, nodelist.EdgeEdgeTypes)
 	}
 	if m.nodes != nil {
 		edges = append(edges, nodelist.EdgeNodes)
-	}
-	if m.document != nil {
-		edges = append(edges, nodelist.EdgeDocument)
 	}
 	return edges
 }
@@ -9192,6 +9326,10 @@ func (m *NodeListMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *NodeListMutation) AddedIDs(name string) []ent.Value {
 	switch name {
+	case nodelist.EdgeDocument:
+		if id := m.document; id != nil {
+			return []ent.Value{*id}
+		}
 	case nodelist.EdgeEdgeTypes:
 		ids := make([]ent.Value, 0, len(m.edge_types))
 		for id := range m.edge_types {
@@ -9204,10 +9342,6 @@ func (m *NodeListMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
-	case nodelist.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
-		}
 	}
 	return nil
 }
@@ -9247,14 +9381,14 @@ func (m *NodeListMutation) RemovedIDs(name string) []ent.Value {
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *NodeListMutation) ClearedEdges() []string {
 	edges := make([]string, 0, 3)
+	if m.cleareddocument {
+		edges = append(edges, nodelist.EdgeDocument)
+	}
 	if m.clearededge_types {
 		edges = append(edges, nodelist.EdgeEdgeTypes)
 	}
 	if m.clearednodes {
 		edges = append(edges, nodelist.EdgeNodes)
-	}
-	if m.cleareddocument {
-		edges = append(edges, nodelist.EdgeDocument)
 	}
 	return edges
 }
@@ -9263,12 +9397,12 @@ func (m *NodeListMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *NodeListMutation) EdgeCleared(name string) bool {
 	switch name {
+	case nodelist.EdgeDocument:
+		return m.cleareddocument
 	case nodelist.EdgeEdgeTypes:
 		return m.clearededge_types
 	case nodelist.EdgeNodes:
 		return m.clearednodes
-	case nodelist.EdgeDocument:
-		return m.cleareddocument
 	}
 	return false
 }
@@ -9288,14 +9422,14 @@ func (m *NodeListMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *NodeListMutation) ResetEdge(name string) error {
 	switch name {
+	case nodelist.EdgeDocument:
+		m.ResetDocument()
+		return nil
 	case nodelist.EdgeEdgeTypes:
 		m.ResetEdgeTypes()
 		return nil
 	case nodelist.EdgeNodes:
 		m.ResetNodes()
-		return nil
-	case nodelist.EdgeDocument:
-		m.ResetDocument()
 		return nil
 	}
 	return fmt.Errorf("unknown NodeList edge %s", name)

--- a/internal/backends/ent/nodelist/where.go
+++ b/internal/backends/ent/nodelist/where.go
@@ -65,11 +65,6 @@ func ProtoMessage(v *sbom.NodeList) predicate.NodeList {
 	return predicate.NodeList(sql.FieldEQ(FieldProtoMessage, v))
 }
 
-// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
-func DocumentID(v uuid.UUID) predicate.NodeList {
-	return predicate.NodeList(sql.FieldEQ(FieldDocumentID, v))
-}
-
 // ProtoMessageEQ applies the EQ predicate on the "proto_message" field.
 func ProtoMessageEQ(v *sbom.NodeList) predicate.NodeList {
 	return predicate.NodeList(sql.FieldEQ(FieldProtoMessage, v))
@@ -110,24 +105,27 @@ func ProtoMessageLTE(v *sbom.NodeList) predicate.NodeList {
 	return predicate.NodeList(sql.FieldLTE(FieldProtoMessage, v))
 }
 
-// DocumentIDEQ applies the EQ predicate on the "document_id" field.
-func DocumentIDEQ(v uuid.UUID) predicate.NodeList {
-	return predicate.NodeList(sql.FieldEQ(FieldDocumentID, v))
+// HasDocument applies the HasEdge predicate on the "document" edge.
+func HasDocument() predicate.NodeList {
+	return predicate.NodeList(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, false, DocumentTable, DocumentColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
 }
 
-// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
-func DocumentIDNEQ(v uuid.UUID) predicate.NodeList {
-	return predicate.NodeList(sql.FieldNEQ(FieldDocumentID, v))
-}
-
-// DocumentIDIn applies the In predicate on the "document_id" field.
-func DocumentIDIn(vs ...uuid.UUID) predicate.NodeList {
-	return predicate.NodeList(sql.FieldIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
-func DocumentIDNotIn(vs ...uuid.UUID) predicate.NodeList {
-	return predicate.NodeList(sql.FieldNotIn(FieldDocumentID, vs...))
+// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
+func HasDocumentWith(preds ...predicate.Document) predicate.NodeList {
+	return predicate.NodeList(func(s *sql.Selector) {
+		step := newDocumentStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
 }
 
 // HasEdgeTypes applies the HasEdge predicate on the "edge_types" edge.
@@ -168,29 +166,6 @@ func HasNodes() predicate.NodeList {
 func HasNodesWith(preds ...predicate.Node) predicate.NodeList {
 	return predicate.NodeList(func(s *sql.Selector) {
 		step := newNodesStep()
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.NodeList {
-	return predicate.NodeList(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, DocumentTable, DocumentColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.NodeList {
-	return predicate.NodeList(func(s *sql.Selector) {
-		step := newDocumentStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/backends/ent/runtime.go
+++ b/internal/backends/ent/runtime.go
@@ -31,17 +31,10 @@ import (
 // (default values, validators, hooks and policies) and stitches it
 // to their package variables.
 func init() {
-	annotationMixin := schema.Annotation{}.Mixin()
-	annotationMixinFields0 := annotationMixin[0].Fields()
-	_ = annotationMixinFields0
 	annotationFields := schema.Annotation{}.Fields()
 	_ = annotationFields
-	// annotationDescDocumentID is the schema descriptor for document_id field.
-	annotationDescDocumentID := annotationMixinFields0[0].Descriptor()
-	// annotation.DefaultDocumentID holds the default value on creation for the document_id field.
-	annotation.DefaultDocumentID = annotationDescDocumentID.Default.(func() uuid.UUID)
 	// annotationDescIsUnique is the schema descriptor for is_unique field.
-	annotationDescIsUnique := annotationFields[3].Descriptor()
+	annotationDescIsUnique := annotationFields[4].Descriptor()
 	// annotation.DefaultIsUnique holds the default value on creation for the is_unique field.
 	annotation.DefaultIsUnique = annotationDescIsUnique.Default.(bool)
 	documentMixin := schema.Document{}.Mixin()
@@ -134,7 +127,7 @@ func init() {
 	metadataFields := schema.Metadata{}.Fields()
 	_ = metadataFields
 	// metadataDescNativeID is the schema descriptor for native_id field.
-	metadataDescNativeID := metadataFields[1].Descriptor()
+	metadataDescNativeID := metadataFields[0].Descriptor()
 	// metadata.NativeIDValidator is a validator for the "native_id" field. It is called by the builders before save.
 	metadata.NativeIDValidator = metadataDescNativeID.Validators[0].(func(string) error)
 	// metadataDescID is the schema descriptor for id field.

--- a/internal/backends/ent/schema/annotation.go
+++ b/internal/backends/ent/schema/annotation.go
@@ -19,15 +19,14 @@ type Annotation struct {
 	ent.Schema
 }
 
-func (Annotation) Mixin() []ent.Mixin {
-	return []ent.Mixin{
-		DocumentMixin{},
-	}
-}
-
 func (Annotation) Fields() []ent.Field {
 	return []ent.Field{
-		field.UUID("node_id", uuid.UUID{}).Optional().Nillable(),
+		field.UUID("document_id", uuid.UUID{}).
+			Optional().
+			Nillable(),
+		field.UUID("node_id", uuid.UUID{}).
+			Optional().
+			Nillable(),
 		field.String("name"),
 		field.String("value"),
 		field.Bool("is_unique").Default(false),
@@ -36,6 +35,10 @@ func (Annotation) Fields() []ent.Field {
 
 func (Annotation) Edges() []ent.Edge {
 	return []ent.Edge{
+		edge.From("document", Document.Type).
+			Ref("annotations").
+			Unique().
+			Field("document_id"),
 		edge.From("node", Node.Type).
 			Ref("annotations").
 			Unique().
@@ -45,6 +48,10 @@ func (Annotation) Edges() []ent.Edge {
 
 func (Annotation) Indexes() []ent.Index {
 	return []ent.Index{
+		index.Fields("node_id").
+			StorageKey("idx_annotations_node_id"),
+		index.Fields("document_id").
+			StorageKey("idx_annotations_document_id"),
 		index.Fields("node_id", "name", "value").
 			Unique().
 			Annotations(entsql.IndexWhere("node_id IS NOT NULL AND TRIM(node_id) != ''")).

--- a/internal/backends/ent/schema/document.go
+++ b/internal/backends/ent/schema/document.go
@@ -8,7 +8,10 @@ package schema
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
+	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 )
 
 type Document struct {
@@ -21,13 +24,36 @@ func (Document) Mixin() []ent.Mixin {
 	}
 }
 
+func (Document) Fields() []ent.Field {
+	return []ent.Field{
+		field.UUID("metadata_id", uuid.UUID{}).
+			Unique().
+			Immutable().
+			Optional(),
+		field.UUID("node_list_id", uuid.UUID{}).
+			Unique().
+			Immutable().
+			Optional(),
+	}
+}
+
 func (Document) Edges() []ent.Edge {
+	const edgeRef = "document"
+
 	return []ent.Edge{
-		edge.To("metadata", Metadata.Type).
+		edge.To("annotations", Annotation.Type).
+			Annotations(entsql.OnDelete(entsql.Cascade)),
+		edge.From("metadata", Metadata.Type).
+			Ref(edgeRef).
 			Unique().
-			Immutable(),
-		edge.To("node_list", NodeList.Type).
+			Immutable().
+			Annotations(entsql.OnDelete(entsql.Cascade)).
+			Field("metadata_id"),
+		edge.From("node_list", NodeList.Type).
+			Ref(edgeRef).
 			Unique().
-			Immutable(),
+			Immutable().
+			Annotations(entsql.OnDelete(entsql.Cascade)).
+			Field("node_list_id"),
 	}
 }

--- a/internal/backends/ent/schema/metadata.go
+++ b/internal/backends/ent/schema/metadata.go
@@ -12,7 +12,6 @@ import (
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
-	"github.com/google/uuid"
 	"github.com/protobom/protobom/pkg/sbom"
 )
 
@@ -29,7 +28,6 @@ func (Metadata) Mixin() []ent.Mixin {
 
 func (Metadata) Fields() []ent.Field {
 	return []ent.Field{
-		field.UUID("document_id", uuid.UUID{}).Unique().Immutable(),
 		field.String("native_id").NotEmpty().Immutable(),
 		field.String("version"),
 		field.String("name"),
@@ -40,6 +38,10 @@ func (Metadata) Fields() []ent.Field {
 
 func (Metadata) Edges() []ent.Edge {
 	return []ent.Edge{
+		edge.To("document", Document.Type).
+			Required().
+			Unique().
+			Immutable(),
 		edge.To("tools", Tool.Type).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
 		edge.To("authors", Person.Type).
@@ -48,13 +50,6 @@ func (Metadata) Edges() []ent.Edge {
 			Annotations(entsql.OnDelete(entsql.Cascade)),
 		edge.To("source_data", SourceData.Type).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
-		edge.From("document", Document.Type).
-			Ref("metadata").
-			Required().
-			Unique().
-			Immutable().
-			Annotations(entsql.OnDelete(entsql.Cascade)).
-			Field("document_id"),
 	}
 }
 

--- a/internal/backends/ent/schema/node_list.go
+++ b/internal/backends/ent/schema/node_list.go
@@ -11,7 +11,6 @@ import (
 	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
-	"github.com/google/uuid"
 	"github.com/protobom/protobom/pkg/sbom"
 )
 
@@ -28,25 +27,21 @@ func (NodeList) Mixin() []ent.Mixin {
 
 func (NodeList) Fields() []ent.Field {
 	return []ent.Field{
-		field.UUID("document_id", uuid.UUID{}).Unique().Immutable(),
 		field.Strings("root_elements"),
 	}
 }
 
 func (NodeList) Edges() []ent.Edge {
 	return []ent.Edge{
+		edge.To("document", Document.Type).
+			Required().
+			Unique().
+			Immutable(),
 		edge.To("edge_types", EdgeType.Type).
 			StorageKey(edge.Table("node_list_edges"), edge.Columns("node_list_id", "edge_type_id")).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
 		edge.To("nodes", Node.Type).
 			StorageKey(edge.Table("node_list_nodes"), edge.Columns("node_list_id", "node_id")).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
-		edge.From("document", Document.Type).
-			Ref("node_list").
-			Required().
-			Unique().
-			Immutable().
-			Annotations(entsql.OnDelete(entsql.Cascade)).
-			Field("document_id"),
 	}
 }


### PR DESCRIPTION
This PR redefines the `Annotation` schema's `document_id` as nillable. This allows clearer delineation between document-specific and node-specific annotations, and the intent is to enable future enhancements (utilize edge-schema to truly separate node/document annotations).

Diff against previous branch in the PR series: [link](https://github.com/jhoward-lm/protobom-storage/compare/identifiers-entries...annotations-nillable-document-id)

Depends on #56

> [!NOTE]
> Only the following files are manually modified; the rest are auto-generated
>
> - `backends/ent/*.go`
> - `internal/backends/ent/schema/*.go`

/cc @ashearin @lmphil