### PR TITLE
refactor: skip foreign keys and inverse edges when marshaling JSON

### DIFF
--- a/internal/backends/ent/annotation_query.go
+++ b/internal/backends/ent/annotation_query.go
@@ -340,7 +340,7 @@ func (aq *AnnotationQuery) WithNode(opts ...func(*NodeQuery)) *AnnotationQuery {
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -363,7 +363,7 @@ func (aq *AnnotationQuery) GroupBy(field string, fields ...string) *AnnotationGr
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //	}
 //
 //	client.Annotation.Query().

--- a/internal/backends/ent/document_query.go
+++ b/internal/backends/ent/document_query.go
@@ -377,7 +377,7 @@ func (dq *DocumentQuery) WithNodeList(opts ...func(*NodeListQuery)) *DocumentQue
 // Example:
 //
 //	var v []struct {
-//		MetadataID uuid.UUID `json:"metadata_id,omitempty"`
+//		MetadataID uuid.UUID `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -400,7 +400,7 @@ func (dq *DocumentQuery) GroupBy(field string, fields ...string) *DocumentGroupB
 // Example:
 //
 //	var v []struct {
-//		MetadataID uuid.UUID `json:"metadata_id,omitempty"`
+//		MetadataID uuid.UUID `json:"-"`
 //	}
 //
 //	client.Document.Query().

--- a/internal/backends/ent/documenttype.go
+++ b/internal/backends/ent/documenttype.go
@@ -8,6 +8,7 @@
 package ent
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -24,13 +25,13 @@ import (
 type DocumentType struct {
 	config `json:"-"`
 	// ID of the ent.
-	ID uuid.UUID `json:"id,omitempty"`
+	ID uuid.UUID `json:"-"`
 	// DocumentID holds the value of the "document_id" field.
-	DocumentID uuid.UUID `json:"document_id,omitempty"`
+	DocumentID uuid.UUID `json:"-"`
 	// ProtoMessage holds the value of the "proto_message" field.
-	ProtoMessage *sbom.DocumentType `json:"proto_message,omitempty"`
+	ProtoMessage *sbom.DocumentType `json:"-"`
 	// MetadataID holds the value of the "metadata_id" field.
-	MetadataID uuid.UUID `json:"metadata_id,omitempty"`
+	MetadataID uuid.UUID `json:"-"`
 	// Type holds the value of the "type" field.
 	Type *documenttype.Type `json:"type,omitempty"`
 	// Name holds the value of the "name" field.
@@ -39,7 +40,7 @@ type DocumentType struct {
 	Description *string `json:"description,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the DocumentTypeQuery when eager-loading is set.
-	Edges        DocumentTypeEdges `json:"edges"`
+	Edges        DocumentTypeEdges `json:"-"`
 	selectValues sql.SelectValues
 }
 
@@ -48,7 +49,7 @@ type DocumentTypeEdges struct {
 	// Document holds the value of the document edge.
 	Document *Document `json:"document,omitempty"`
 	// Metadata holds the value of the metadata edge.
-	Metadata *Metadata `json:"metadata,omitempty"`
+	Metadata *Metadata `json:"-"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
 	loadedTypes [2]bool
@@ -220,6 +221,18 @@ func (dt *DocumentType) String() string {
 	}
 	builder.WriteByte(')')
 	return builder.String()
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (dt *DocumentType) MarshalJSON() ([]byte, error) {
+	type Alias DocumentType
+	return json.Marshal(&struct {
+		*Alias
+		DocumentTypeEdges
+	}{
+		Alias:             (*Alias)(dt),
+		DocumentTypeEdges: dt.Edges,
+	})
 }
 
 // DocumentTypes is a parsable slice of DocumentType.

--- a/internal/backends/ent/documenttype_query.go
+++ b/internal/backends/ent/documenttype_query.go
@@ -340,7 +340,7 @@ func (dtq *DocumentTypeQuery) WithMetadata(opts ...func(*MetadataQuery)) *Docume
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -363,7 +363,7 @@ func (dtq *DocumentTypeQuery) GroupBy(field string, fields ...string) *DocumentT
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //	}
 //
 //	client.DocumentType.Query().

--- a/internal/backends/ent/edgetype_query.go
+++ b/internal/backends/ent/edgetype_query.go
@@ -412,7 +412,7 @@ func (etq *EdgeTypeQuery) WithNodeLists(opts ...func(*NodeListQuery)) *EdgeTypeQ
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -435,7 +435,7 @@ func (etq *EdgeTypeQuery) GroupBy(field string, fields ...string) *EdgeTypeGroup
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //	}
 //
 //	client.EdgeType.Query().

--- a/internal/backends/ent/entc.go
+++ b/internal/backends/ent/entc.go
@@ -14,21 +14,62 @@ import (
 
 	"entgo.io/ent/entc"
 	"entgo.io/ent/entc/gen"
+	"entgo.io/ent/schema/edge"
 )
 
 func main() {
-	// Parse the template file.
-	tmpl := gen.MustParse(gen.NewTemplate("header").ParseFiles("template/header.tmpl"))
-
-	if err := entc.Generate("./schema", &gen.Config{
+	config := &gen.Config{
 		Features: []gen.Feature{
 			gen.FeatureExecQuery,
 			gen.FeatureIntercept,
 			gen.FeatureUpsert,
 			gen.FeatureVersionedMigration,
 		},
-		Templates: []*gen.Template{tmpl},
-	}); err != nil {
+		Hooks:     []gen.Hook{marshalEdgesHook},
+		Templates: []*gen.Template{gen.MustParse(gen.NewTemplate("").ParseDir("template"))},
+	}
+
+	// Ensure the generated directory (environment) avoids cyclic imports.
+	if undo, err := gen.PrepareEnv(config); err != nil {
+		defer undo()
+		log.Fatalf("preparing ent environment: %v", err)
+	}
+
+	if err := entc.Generate("./schema", config); err != nil {
 		log.Fatalf("running ent codegen: %v", err)
+	}
+}
+
+// marshalEdgesHook is a generator hook to set the struct tag
+// for the generated types' Edges field to `json:"-"`.
+func marshalEdgesHook(next gen.Generator) gen.Generator {
+	return gen.GenerateFunc(func(graph *gen.Graph) error {
+		tag := edge.Annotation{StructTag: `json:"-"`}
+
+		for _, node := range graph.Nodes {
+			setFieldStructTag(node.Fields...)
+			setInverseEdgeStructTag(node.Edges...)
+			node.Annotations.Set(tag.Name(), tag)
+		}
+
+		return next.Generate(graph)
+	})
+}
+
+// setFieldStructTag sets the struct tag for generated types' edge-fields to `json:"-"`.
+func setFieldStructTag(fields ...*gen.Field) {
+	for idx := range fields {
+		if fields[idx].IsEdgeField() {
+			fields[idx].StructTag = `json:"-"`
+		}
+	}
+}
+
+// setInverseEdgeStructTag sets the struct tag for generated types' inverse edges to `json:"-"`.
+func setInverseEdgeStructTag(edges ...*gen.Edge) {
+	for idx := range edges {
+		if edges[idx].IsInverse() {
+			edges[idx].StructTag = `json:"-"`
+		}
 	}
 }

--- a/internal/backends/ent/externalreference_query.go
+++ b/internal/backends/ent/externalreference_query.go
@@ -377,7 +377,7 @@ func (erq *ExternalReferenceQuery) WithNodes(opts ...func(*NodeQuery)) *External
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -400,7 +400,7 @@ func (erq *ExternalReferenceQuery) GroupBy(field string, fields ...string) *Exte
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //	}
 //
 //	client.ExternalReference.Query().

--- a/internal/backends/ent/hashesentry.go
+++ b/internal/backends/ent/hashesentry.go
@@ -8,6 +8,7 @@
 package ent
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -22,16 +23,16 @@ import (
 type HashesEntry struct {
 	config `json:"-"`
 	// ID of the ent.
-	ID uuid.UUID `json:"id,omitempty"`
+	ID uuid.UUID `json:"-"`
 	// DocumentID holds the value of the "document_id" field.
-	DocumentID uuid.UUID `json:"document_id,omitempty"`
+	DocumentID uuid.UUID `json:"-"`
 	// HashAlgorithm holds the value of the "hash_algorithm" field.
 	HashAlgorithm hashesentry.HashAlgorithm `json:"hash_algorithm,omitempty"`
 	// HashData holds the value of the "hash_data" field.
 	HashData string `json:"hash_data,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the HashesEntryQuery when eager-loading is set.
-	Edges        HashesEntryEdges `json:"edges"`
+	Edges        HashesEntryEdges `json:"-"`
 	selectValues sql.SelectValues
 }
 
@@ -40,9 +41,9 @@ type HashesEntryEdges struct {
 	// Document holds the value of the document edge.
 	Document *Document `json:"document,omitempty"`
 	// ExternalReferences holds the value of the external_references edge.
-	ExternalReferences []*ExternalReference `json:"external_references,omitempty"`
+	ExternalReferences []*ExternalReference `json:"-"`
 	// Nodes holds the value of the nodes edge.
-	Nodes []*Node `json:"nodes,omitempty"`
+	Nodes []*Node `json:"-"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
 	loadedTypes [3]bool
@@ -186,6 +187,18 @@ func (he *HashesEntry) String() string {
 	builder.WriteString(he.HashData)
 	builder.WriteByte(')')
 	return builder.String()
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (he *HashesEntry) MarshalJSON() ([]byte, error) {
+	type Alias HashesEntry
+	return json.Marshal(&struct {
+		*Alias
+		HashesEntryEdges
+	}{
+		Alias:            (*Alias)(he),
+		HashesEntryEdges: he.Edges,
+	})
 }
 
 // HashesEntries is a parsable slice of HashesEntry.

--- a/internal/backends/ent/hashesentry_query.go
+++ b/internal/backends/ent/hashesentry_query.go
@@ -377,7 +377,7 @@ func (heq *HashesEntryQuery) WithNodes(opts ...func(*NodeQuery)) *HashesEntryQue
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -400,7 +400,7 @@ func (heq *HashesEntryQuery) GroupBy(field string, fields ...string) *HashesEntr
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //	}
 //
 //	client.HashesEntry.Query().

--- a/internal/backends/ent/identifiersentry.go
+++ b/internal/backends/ent/identifiersentry.go
@@ -8,6 +8,7 @@
 package ent
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -22,16 +23,16 @@ import (
 type IdentifiersEntry struct {
 	config `json:"-"`
 	// ID of the ent.
-	ID uuid.UUID `json:"id,omitempty"`
+	ID uuid.UUID `json:"-"`
 	// DocumentID holds the value of the "document_id" field.
-	DocumentID uuid.UUID `json:"document_id,omitempty"`
+	DocumentID uuid.UUID `json:"-"`
 	// Type holds the value of the "type" field.
 	Type identifiersentry.Type `json:"type,omitempty"`
 	// Value holds the value of the "value" field.
 	Value string `json:"value,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the IdentifiersEntryQuery when eager-loading is set.
-	Edges        IdentifiersEntryEdges `json:"edges"`
+	Edges        IdentifiersEntryEdges `json:"-"`
 	selectValues sql.SelectValues
 }
 
@@ -40,7 +41,7 @@ type IdentifiersEntryEdges struct {
 	// Document holds the value of the document edge.
 	Document *Document `json:"document,omitempty"`
 	// Nodes holds the value of the nodes edge.
-	Nodes []*Node `json:"nodes,omitempty"`
+	Nodes []*Node `json:"-"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
 	loadedTypes [2]bool
@@ -170,6 +171,18 @@ func (ie *IdentifiersEntry) String() string {
 	builder.WriteString(ie.Value)
 	builder.WriteByte(')')
 	return builder.String()
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (ie *IdentifiersEntry) MarshalJSON() ([]byte, error) {
+	type Alias IdentifiersEntry
+	return json.Marshal(&struct {
+		*Alias
+		IdentifiersEntryEdges
+	}{
+		Alias:                 (*Alias)(ie),
+		IdentifiersEntryEdges: ie.Edges,
+	})
 }
 
 // IdentifiersEntries is a parsable slice of IdentifiersEntry.

--- a/internal/backends/ent/identifiersentry_query.go
+++ b/internal/backends/ent/identifiersentry_query.go
@@ -341,7 +341,7 @@ func (ieq *IdentifiersEntryQuery) WithNodes(opts ...func(*NodeQuery)) *Identifie
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -364,7 +364,7 @@ func (ieq *IdentifiersEntryQuery) GroupBy(field string, fields ...string) *Ident
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //	}
 //
 //	client.IdentifiersEntry.Query().

--- a/internal/backends/ent/metadata.go
+++ b/internal/backends/ent/metadata.go
@@ -8,6 +8,7 @@
 package ent
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -24,9 +25,9 @@ import (
 type Metadata struct {
 	config `json:"-"`
 	// ID of the ent.
-	ID uuid.UUID `json:"id,omitempty"`
+	ID uuid.UUID `json:"-"`
 	// ProtoMessage holds the value of the "proto_message" field.
-	ProtoMessage *sbom.Metadata `json:"proto_message,omitempty"`
+	ProtoMessage *sbom.Metadata `json:"-"`
 	// NativeID holds the value of the "native_id" field.
 	NativeID string `json:"native_id,omitempty"`
 	// Version holds the value of the "version" field.
@@ -39,7 +40,7 @@ type Metadata struct {
 	Comment string `json:"comment,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the MetadataQuery when eager-loading is set.
-	Edges        MetadataEdges `json:"edges"`
+	Edges        MetadataEdges `json:"-"`
 	selectValues sql.SelectValues
 }
 
@@ -259,6 +260,18 @@ func (m *Metadata) String() string {
 	builder.WriteString(m.Comment)
 	builder.WriteByte(')')
 	return builder.String()
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type Alias Metadata
+	return json.Marshal(&struct {
+		*Alias
+		MetadataEdges
+	}{
+		Alias:         (*Alias)(m),
+		MetadataEdges: m.Edges,
+	})
 }
 
 // MetadataSlice is a parsable slice of Metadata.

--- a/internal/backends/ent/metadata_query.go
+++ b/internal/backends/ent/metadata_query.go
@@ -449,7 +449,7 @@ func (mq *MetadataQuery) WithSourceData(opts ...func(*SourceDataQuery)) *Metadat
 // Example:
 //
 //	var v []struct {
-//		ProtoMessage *sbom.Metadata `json:"proto_message,omitempty"`
+//		ProtoMessage *sbom.Metadata `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -472,7 +472,7 @@ func (mq *MetadataQuery) GroupBy(field string, fields ...string) *MetadataGroupB
 // Example:
 //
 //	var v []struct {
-//		ProtoMessage *sbom.Metadata `json:"proto_message,omitempty"`
+//		ProtoMessage *sbom.Metadata `json:"-"`
 //	}
 //
 //	client.Metadata.Query().

--- a/internal/backends/ent/node.go
+++ b/internal/backends/ent/node.go
@@ -25,11 +25,11 @@ import (
 type Node struct {
 	config `json:"-"`
 	// ID of the ent.
-	ID uuid.UUID `json:"id,omitempty"`
+	ID uuid.UUID `json:"-"`
 	// DocumentID holds the value of the "document_id" field.
-	DocumentID uuid.UUID `json:"document_id,omitempty"`
+	DocumentID uuid.UUID `json:"-"`
 	// ProtoMessage holds the value of the "proto_message" field.
-	ProtoMessage *sbom.Node `json:"proto_message,omitempty"`
+	ProtoMessage *sbom.Node `json:"-"`
 	// NativeID holds the value of the "native_id" field.
 	NativeID string `json:"native_id,omitempty"`
 	// NodeListID holds the value of the "node_list_id" field.
@@ -74,7 +74,7 @@ type Node struct {
 	FileTypes []string `json:"file_types,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the NodeQuery when eager-loading is set.
-	Edges        NodeEdges `json:"edges"`
+	Edges        NodeEdges `json:"-"`
 	selectValues sql.SelectValues
 }
 
@@ -93,7 +93,7 @@ type NodeEdges struct {
 	// PrimaryPurpose holds the value of the primary_purpose edge.
 	PrimaryPurpose []*Purpose `json:"primary_purpose,omitempty"`
 	// ToNodes holds the value of the to_nodes edge.
-	ToNodes []*Node `json:"to_nodes,omitempty"`
+	ToNodes []*Node `json:"-"`
 	// Nodes holds the value of the nodes edge.
 	Nodes []*Node `json:"nodes,omitempty"`
 	// Hashes holds the value of the hashes edge.
@@ -103,9 +103,9 @@ type NodeEdges struct {
 	// Properties holds the value of the properties edge.
 	Properties []*Property `json:"properties,omitempty"`
 	// NodeLists holds the value of the node_lists edge.
-	NodeLists []*NodeList `json:"node_lists,omitempty"`
+	NodeLists []*NodeList `json:"-"`
 	// EdgeTypes holds the value of the edge_types edge.
-	EdgeTypes []*EdgeType `json:"edge_types,omitempty"`
+	EdgeTypes []*EdgeType `json:"-"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
 	loadedTypes [13]bool
@@ -583,6 +583,18 @@ func (n *Node) String() string {
 	builder.WriteString(fmt.Sprintf("%v", n.FileTypes))
 	builder.WriteByte(')')
 	return builder.String()
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (n *Node) MarshalJSON() ([]byte, error) {
+	type Alias Node
+	return json.Marshal(&struct {
+		*Alias
+		NodeEdges
+	}{
+		Alias:     (*Alias)(n),
+		NodeEdges: n.Edges,
+	})
 }
 
 // Nodes is a parsable slice of Node.

--- a/internal/backends/ent/node_query.go
+++ b/internal/backends/ent/node_query.go
@@ -734,7 +734,7 @@ func (nq *NodeQuery) WithEdgeTypes(opts ...func(*EdgeTypeQuery)) *NodeQuery {
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -757,7 +757,7 @@ func (nq *NodeQuery) GroupBy(field string, fields ...string) *NodeGroupBy {
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //	}
 //
 //	client.Node.Query().

--- a/internal/backends/ent/nodelist.go
+++ b/internal/backends/ent/nodelist.go
@@ -24,14 +24,14 @@ import (
 type NodeList struct {
 	config `json:"-"`
 	// ID of the ent.
-	ID uuid.UUID `json:"id,omitempty"`
+	ID uuid.UUID `json:"-"`
 	// ProtoMessage holds the value of the "proto_message" field.
-	ProtoMessage *sbom.NodeList `json:"proto_message,omitempty"`
+	ProtoMessage *sbom.NodeList `json:"-"`
 	// RootElements holds the value of the "root_elements" field.
 	RootElements []string `json:"root_elements,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the NodeListQuery when eager-loading is set.
-	Edges        NodeListEdges `json:"edges"`
+	Edges        NodeListEdges `json:"-"`
 	selectValues sql.SelectValues
 }
 
@@ -183,6 +183,18 @@ func (nl *NodeList) String() string {
 	builder.WriteString(fmt.Sprintf("%v", nl.RootElements))
 	builder.WriteByte(')')
 	return builder.String()
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (nl *NodeList) MarshalJSON() ([]byte, error) {
+	type Alias NodeList
+	return json.Marshal(&struct {
+		*Alias
+		NodeListEdges
+	}{
+		Alias:         (*Alias)(nl),
+		NodeListEdges: nl.Edges,
+	})
 }
 
 // NodeLists is a parsable slice of NodeList.

--- a/internal/backends/ent/nodelist_query.go
+++ b/internal/backends/ent/nodelist_query.go
@@ -377,7 +377,7 @@ func (nlq *NodeListQuery) WithNodes(opts ...func(*NodeQuery)) *NodeListQuery {
 // Example:
 //
 //	var v []struct {
-//		ProtoMessage *sbom.NodeList `json:"proto_message,omitempty"`
+//		ProtoMessage *sbom.NodeList `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -400,7 +400,7 @@ func (nlq *NodeListQuery) GroupBy(field string, fields ...string) *NodeListGroup
 // Example:
 //
 //	var v []struct {
-//		ProtoMessage *sbom.NodeList `json:"proto_message,omitempty"`
+//		ProtoMessage *sbom.NodeList `json:"-"`
 //	}
 //
 //	client.NodeList.Query().

--- a/internal/backends/ent/person_query.go
+++ b/internal/backends/ent/person_query.go
@@ -448,7 +448,7 @@ func (pq *PersonQuery) WithNode(opts ...func(*NodeQuery)) *PersonQuery {
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -471,7 +471,7 @@ func (pq *PersonQuery) GroupBy(field string, fields ...string) *PersonGroupBy {
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //	}
 //
 //	client.Person.Query().

--- a/internal/backends/ent/property.go
+++ b/internal/backends/ent/property.go
@@ -8,6 +8,7 @@
 package ent
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -24,20 +25,20 @@ import (
 type Property struct {
 	config `json:"-"`
 	// ID of the ent.
-	ID uuid.UUID `json:"id,omitempty"`
+	ID uuid.UUID `json:"-"`
 	// DocumentID holds the value of the "document_id" field.
-	DocumentID uuid.UUID `json:"document_id,omitempty"`
+	DocumentID uuid.UUID `json:"-"`
 	// ProtoMessage holds the value of the "proto_message" field.
-	ProtoMessage *sbom.Property `json:"proto_message,omitempty"`
+	ProtoMessage *sbom.Property `json:"-"`
 	// NodeID holds the value of the "node_id" field.
-	NodeID uuid.UUID `json:"node_id,omitempty"`
+	NodeID uuid.UUID `json:"-"`
 	// Name holds the value of the "name" field.
 	Name string `json:"name,omitempty"`
 	// Data holds the value of the "data" field.
 	Data string `json:"data,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the PropertyQuery when eager-loading is set.
-	Edges        PropertyEdges `json:"edges"`
+	Edges        PropertyEdges `json:"-"`
 	selectValues sql.SelectValues
 }
 
@@ -46,7 +47,7 @@ type PropertyEdges struct {
 	// Document holds the value of the document edge.
 	Document *Document `json:"document,omitempty"`
 	// Node holds the value of the node edge.
-	Node *Node `json:"node,omitempty"`
+	Node *Node `json:"-"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
 	loadedTypes [2]bool
@@ -200,6 +201,18 @@ func (pr *Property) String() string {
 	builder.WriteString(pr.Data)
 	builder.WriteByte(')')
 	return builder.String()
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (pr *Property) MarshalJSON() ([]byte, error) {
+	type Alias Property
+	return json.Marshal(&struct {
+		*Alias
+		PropertyEdges
+	}{
+		Alias:         (*Alias)(pr),
+		PropertyEdges: pr.Edges,
+	})
 }
 
 // Properties is a parsable slice of Property.

--- a/internal/backends/ent/property_query.go
+++ b/internal/backends/ent/property_query.go
@@ -340,7 +340,7 @@ func (pq *PropertyQuery) WithNode(opts ...func(*NodeQuery)) *PropertyQuery {
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -363,7 +363,7 @@ func (pq *PropertyQuery) GroupBy(field string, fields ...string) *PropertyGroupB
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //	}
 //
 //	client.Property.Query().

--- a/internal/backends/ent/purpose_query.go
+++ b/internal/backends/ent/purpose_query.go
@@ -340,7 +340,7 @@ func (pq *PurposeQuery) WithNode(opts ...func(*NodeQuery)) *PurposeQuery {
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -363,7 +363,7 @@ func (pq *PurposeQuery) GroupBy(field string, fields ...string) *PurposeGroupBy 
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //	}
 //
 //	client.Purpose.Query().

--- a/internal/backends/ent/schema/mixin.go
+++ b/internal/backends/ent/schema/mixin.go
@@ -77,7 +77,8 @@ func (pmm ProtoMessageMixin[T]) Fields() []ent.Field {
 			GoType(goType).
 			Nillable().
 			Unique().
-			Immutable(),
+			Immutable().
+			StructTag(`json:"-"`),
 	)
 }
 
@@ -92,8 +93,9 @@ func (UUIDMixin) Fields() []ent.Field {
 		field.UUID("id", uuid.UUID{}).
 			Unique().
 			Immutable().
-			Default(func() uuid.UUID { return uuid.Must(uuid.NewV7()) }).
-			Annotations(schema.Comment("Unique identifier field")),
+			StructTag(`json:"-"`).
+			Annotations(schema.Comment("Unique identifier field")).
+			Default(func() uuid.UUID { return uuid.Must(uuid.NewV7()) }),
 	}
 }
 

--- a/internal/backends/ent/sourcedata.go
+++ b/internal/backends/ent/sourcedata.go
@@ -25,13 +25,13 @@ import (
 type SourceData struct {
 	config `json:"-"`
 	// ID of the ent.
-	ID uuid.UUID `json:"id,omitempty"`
+	ID uuid.UUID `json:"-"`
 	// DocumentID holds the value of the "document_id" field.
-	DocumentID uuid.UUID `json:"document_id,omitempty"`
+	DocumentID uuid.UUID `json:"-"`
 	// ProtoMessage holds the value of the "proto_message" field.
-	ProtoMessage *sbom.SourceData `json:"proto_message,omitempty"`
+	ProtoMessage *sbom.SourceData `json:"-"`
 	// MetadataID holds the value of the "metadata_id" field.
-	MetadataID uuid.UUID `json:"metadata_id,omitempty"`
+	MetadataID uuid.UUID `json:"-"`
 	// Format holds the value of the "format" field.
 	Format string `json:"format,omitempty"`
 	// Size holds the value of the "size" field.
@@ -42,7 +42,7 @@ type SourceData struct {
 	Hashes map[int32]string `json:"hashes,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the SourceDataQuery when eager-loading is set.
-	Edges        SourceDataEdges `json:"edges"`
+	Edges        SourceDataEdges `json:"-"`
 	selectValues sql.SelectValues
 }
 
@@ -51,7 +51,7 @@ type SourceDataEdges struct {
 	// Document holds the value of the document edge.
 	Document *Document `json:"document,omitempty"`
 	// Metadata holds the value of the metadata edge.
-	Metadata *Metadata `json:"metadata,omitempty"`
+	Metadata *Metadata `json:"-"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
 	loadedTypes [2]bool
@@ -232,6 +232,18 @@ func (sd *SourceData) String() string {
 	builder.WriteString(fmt.Sprintf("%v", sd.Hashes))
 	builder.WriteByte(')')
 	return builder.String()
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (sd *SourceData) MarshalJSON() ([]byte, error) {
+	type Alias SourceData
+	return json.Marshal(&struct {
+		*Alias
+		SourceDataEdges
+	}{
+		Alias:           (*Alias)(sd),
+		SourceDataEdges: sd.Edges,
+	})
 }
 
 // SourceDataSlice is a parsable slice of SourceData.

--- a/internal/backends/ent/sourcedata_query.go
+++ b/internal/backends/ent/sourcedata_query.go
@@ -340,7 +340,7 @@ func (sdq *SourceDataQuery) WithMetadata(opts ...func(*MetadataQuery)) *SourceDa
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -363,7 +363,7 @@ func (sdq *SourceDataQuery) GroupBy(field string, fields ...string) *SourceDataG
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //	}
 //
 //	client.SourceData.Query().

--- a/internal/backends/ent/template/jsonencode.tmpl
+++ b/internal/backends/ent/template/jsonencode.tmpl
@@ -1,0 +1,17 @@
+{{/* gotype: entgo.io/ent/entc/gen.Type */}}
+
+{{ define "model/additional/jsonencode" }}
+{{ if $.Edges }}
+	// MarshalJSON implements the json.Marshaler interface.
+	func ({{ $.Receiver }} *{{ $.Name }}) MarshalJSON() ([]byte, error) {
+		type Alias {{ $.Name }}
+		return json.Marshal(&struct {
+			*Alias
+			{{ $.Name }}Edges
+		}{
+			Alias: (*Alias)({{ $.Receiver }}),
+			{{ $.Name }}Edges: {{ $.Receiver }}.Edges,
+		})
+	}
+{{ end }}
+{{ end }}

--- a/internal/backends/ent/tool.go
+++ b/internal/backends/ent/tool.go
@@ -8,6 +8,7 @@
 package ent
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -24,13 +25,13 @@ import (
 type Tool struct {
 	config `json:"-"`
 	// ID of the ent.
-	ID uuid.UUID `json:"id,omitempty"`
+	ID uuid.UUID `json:"-"`
 	// DocumentID holds the value of the "document_id" field.
-	DocumentID uuid.UUID `json:"document_id,omitempty"`
+	DocumentID uuid.UUID `json:"-"`
 	// ProtoMessage holds the value of the "proto_message" field.
-	ProtoMessage *sbom.Tool `json:"proto_message,omitempty"`
+	ProtoMessage *sbom.Tool `json:"-"`
 	// MetadataID holds the value of the "metadata_id" field.
-	MetadataID uuid.UUID `json:"metadata_id,omitempty"`
+	MetadataID uuid.UUID `json:"-"`
 	// Name holds the value of the "name" field.
 	Name string `json:"name,omitempty"`
 	// Version holds the value of the "version" field.
@@ -39,7 +40,7 @@ type Tool struct {
 	Vendor string `json:"vendor,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ToolQuery when eager-loading is set.
-	Edges        ToolEdges `json:"edges"`
+	Edges        ToolEdges `json:"-"`
 	selectValues sql.SelectValues
 }
 
@@ -48,7 +49,7 @@ type ToolEdges struct {
 	// Document holds the value of the document edge.
 	Document *Document `json:"document,omitempty"`
 	// Metadata holds the value of the metadata edge.
-	Metadata *Metadata `json:"metadata,omitempty"`
+	Metadata *Metadata `json:"-"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
 	loadedTypes [2]bool
@@ -211,6 +212,18 @@ func (t *Tool) String() string {
 	builder.WriteString(t.Vendor)
 	builder.WriteByte(')')
 	return builder.String()
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (t *Tool) MarshalJSON() ([]byte, error) {
+	type Alias Tool
+	return json.Marshal(&struct {
+		*Alias
+		ToolEdges
+	}{
+		Alias:     (*Alias)(t),
+		ToolEdges: t.Edges,
+	})
 }
 
 // Tools is a parsable slice of Tool.

--- a/internal/backends/ent/tool_query.go
+++ b/internal/backends/ent/tool_query.go
@@ -340,7 +340,7 @@ func (tq *ToolQuery) WithMetadata(opts ...func(*MetadataQuery)) *ToolQuery {
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -363,7 +363,7 @@ func (tq *ToolQuery) GroupBy(field string, fields ...string) *ToolGroupBy {
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"document_id,omitempty"`
+//		DocumentID uuid.UUID `json:"-"`
 //	}
 //
 //	client.Tool.Query().


### PR DESCRIPTION
This PR modifies the struct tags of the generated ent types and adds a custom `MarshalJSON` method for each. This change is mostly cosmetic, but it aligns more closely with the original protobom structure when marshaled to JSON. 

> [!NOTE]
> Only the following files are manually modified; the rest are auto-generated
>
> - `internal/backends/ent/schema/*.go`
> - `internal/backends/ent/template/jsonencode.tmpl`
> - `internal/backends/ent/entc.go`

/cc @ashearin @lmphil @pkwiatkowski1 @Strakeln @jmayer-lm @EphraimEM