### PR TITLE
refactor: set all inverse edges to required

### DIFF
--- a/backends/ent/annotations.go
+++ b/backends/ent/annotations.go
@@ -65,19 +65,10 @@ func (backend *Backend) AddAnnotationToNodes(name, value string, nodeIDs ...stri
 	}
 
 	for idx := range nodes {
-		documentID, err := nodes[idx].
-			QueryNodeLists().
-			QueryDocument().
-			OnlyID(backend.ctx)
-		if err != nil {
-			return fmt.Errorf("querying node edges for document ID: %w", err)
-		}
-
 		data = append(data, &ent.Annotation{
-			DocumentID: &documentID,
-			NodeID:     &nodes[idx].ID,
-			Name:       name,
-			Value:      value,
+			NodeID: &nodes[idx].ID,
+			Name:   name,
+			Value:  value,
 		})
 	}
 

--- a/internal/backends/ent/annotation/annotation.go
+++ b/internal/backends/ent/annotation/annotation.go
@@ -8,6 +8,7 @@
 package annotation
 
 import (
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 )
@@ -69,7 +70,13 @@ func ValidColumn(column string) bool {
 	return false
 }
 
+// Note that the variables below are initialized by the runtime
+// package on the initialization of the application. Therefore,
+// it should be imported in the main as follows:
+//
+//	import _ "github.com/protobom/storage/internal/backends/ent/runtime"
 var (
+	Hooks [1]ent.Hook
 	// DefaultIsUnique holds the default value on creation for the "is_unique" field.
 	DefaultIsUnique bool
 )

--- a/internal/backends/ent/annotation_create.go
+++ b/internal/backends/ent/annotation_create.go
@@ -100,7 +100,9 @@ func (ac *AnnotationCreate) Mutation() *AnnotationMutation {
 
 // Save creates the Annotation in the database.
 func (ac *AnnotationCreate) Save(ctx context.Context) (*Annotation, error) {
-	ac.defaults()
+	if err := ac.defaults(); err != nil {
+		return nil, err
+	}
 	return withHooks(ctx, ac.sqlSave, ac.mutation, ac.hooks)
 }
 
@@ -127,11 +129,12 @@ func (ac *AnnotationCreate) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (ac *AnnotationCreate) defaults() {
+func (ac *AnnotationCreate) defaults() error {
 	if _, ok := ac.mutation.IsUnique(); !ok {
 		v := annotation.DefaultIsUnique
 		ac.mutation.SetIsUnique(v)
 	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.

--- a/internal/backends/ent/client.go
+++ b/internal/backends/ent/client.go
@@ -471,7 +471,8 @@ func (c *AnnotationClient) QueryNode(a *Annotation) *NodeQuery {
 
 // Hooks returns the client hooks.
 func (c *AnnotationClient) Hooks() []Hook {
-	return c.hooks.Annotation
+	hooks := c.hooks.Annotation
+	return append(hooks[:len(hooks):len(hooks)], annotation.Hooks[:]...)
 }
 
 // Interceptors returns the client interceptors.
@@ -1379,7 +1380,8 @@ func (c *HashesEntryClient) QueryNodes(he *HashesEntry) *NodeQuery {
 
 // Hooks returns the client hooks.
 func (c *HashesEntryClient) Hooks() []Hook {
-	return c.hooks.HashesEntry
+	hooks := c.hooks.HashesEntry
+	return append(hooks[:len(hooks):len(hooks)], hashesentry.Hooks[:]...)
 }
 
 // Interceptors returns the client interceptors.

--- a/internal/backends/ent/documenttype/where.go
+++ b/internal/backends/ent/documenttype/where.go
@@ -175,16 +175,6 @@ func MetadataIDNotIn(vs ...uuid.UUID) predicate.DocumentType {
 	return predicate.DocumentType(sql.FieldNotIn(FieldMetadataID, vs...))
 }
 
-// MetadataIDIsNil applies the IsNil predicate on the "metadata_id" field.
-func MetadataIDIsNil() predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldIsNull(FieldMetadataID))
-}
-
-// MetadataIDNotNil applies the NotNil predicate on the "metadata_id" field.
-func MetadataIDNotNil() predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldNotNull(FieldMetadataID))
-}
-
 // TypeEQ applies the EQ predicate on the "type" field.
 func TypeEQ(v Type) predicate.DocumentType {
 	return predicate.DocumentType(sql.FieldEQ(FieldType, v))

--- a/internal/backends/ent/documenttype_create.go
+++ b/internal/backends/ent/documenttype_create.go
@@ -57,14 +57,6 @@ func (dtc *DocumentTypeCreate) SetMetadataID(u uuid.UUID) *DocumentTypeCreate {
 	return dtc
 }
 
-// SetNillableMetadataID sets the "metadata_id" field if the given value is not nil.
-func (dtc *DocumentTypeCreate) SetNillableMetadataID(u *uuid.UUID) *DocumentTypeCreate {
-	if u != nil {
-		dtc.SetMetadataID(*u)
-	}
-	return dtc
-}
-
 // SetType sets the "type" field.
 func (dtc *DocumentTypeCreate) SetType(d documenttype.Type) *DocumentTypeCreate {
 	dtc.mutation.SetType(d)
@@ -190,10 +182,16 @@ func (dtc *DocumentTypeCreate) check() error {
 	if _, ok := dtc.mutation.ProtoMessage(); !ok {
 		return &ValidationError{Name: "proto_message", err: errors.New(`ent: missing required field "DocumentType.proto_message"`)}
 	}
+	if _, ok := dtc.mutation.MetadataID(); !ok {
+		return &ValidationError{Name: "metadata_id", err: errors.New(`ent: missing required field "DocumentType.metadata_id"`)}
+	}
 	if v, ok := dtc.mutation.GetType(); ok {
 		if err := documenttype.TypeValidator(v); err != nil {
 			return &ValidationError{Name: "type", err: fmt.Errorf(`ent: validator failed for field "DocumentType.type": %w`, err)}
 		}
+	}
+	if len(dtc.mutation.MetadataIDs()) == 0 {
+		return &ValidationError{Name: "metadata", err: errors.New(`ent: missing required edge "DocumentType.metadata"`)}
 	}
 	return nil
 }
@@ -345,12 +343,6 @@ func (u *DocumentTypeUpsert) UpdateMetadataID() *DocumentTypeUpsert {
 	return u
 }
 
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (u *DocumentTypeUpsert) ClearMetadataID() *DocumentTypeUpsert {
-	u.SetNull(documenttype.FieldMetadataID)
-	return u
-}
-
 // SetType sets the "type" field.
 func (u *DocumentTypeUpsert) SetType(v documenttype.Type) *DocumentTypeUpsert {
 	u.Set(documenttype.FieldType, v)
@@ -470,13 +462,6 @@ func (u *DocumentTypeUpsertOne) SetMetadataID(v uuid.UUID) *DocumentTypeUpsertOn
 func (u *DocumentTypeUpsertOne) UpdateMetadataID() *DocumentTypeUpsertOne {
 	return u.Update(func(s *DocumentTypeUpsert) {
 		s.UpdateMetadataID()
-	})
-}
-
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (u *DocumentTypeUpsertOne) ClearMetadataID() *DocumentTypeUpsertOne {
-	return u.Update(func(s *DocumentTypeUpsert) {
-		s.ClearMetadataID()
 	})
 }
 
@@ -775,13 +760,6 @@ func (u *DocumentTypeUpsertBulk) SetMetadataID(v uuid.UUID) *DocumentTypeUpsertB
 func (u *DocumentTypeUpsertBulk) UpdateMetadataID() *DocumentTypeUpsertBulk {
 	return u.Update(func(s *DocumentTypeUpsert) {
 		s.UpdateMetadataID()
-	})
-}
-
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (u *DocumentTypeUpsertBulk) ClearMetadataID() *DocumentTypeUpsertBulk {
-	return u.Update(func(s *DocumentTypeUpsert) {
-		s.ClearMetadataID()
 	})
 }
 

--- a/internal/backends/ent/documenttype_update.go
+++ b/internal/backends/ent/documenttype_update.go
@@ -48,12 +48,6 @@ func (dtu *DocumentTypeUpdate) SetNillableMetadataID(u *uuid.UUID) *DocumentType
 	return dtu
 }
 
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (dtu *DocumentTypeUpdate) ClearMetadataID() *DocumentTypeUpdate {
-	dtu.mutation.ClearMetadataID()
-	return dtu
-}
-
 // SetType sets the "type" field.
 func (dtu *DocumentTypeUpdate) SetType(d documenttype.Type) *DocumentTypeUpdate {
 	dtu.mutation.SetType(d)
@@ -164,6 +158,9 @@ func (dtu *DocumentTypeUpdate) check() error {
 			return &ValidationError{Name: "type", err: fmt.Errorf(`ent: validator failed for field "DocumentType.type": %w`, err)}
 		}
 	}
+	if dtu.mutation.MetadataCleared() && len(dtu.mutation.MetadataIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "DocumentType.metadata"`)
+	}
 	return nil
 }
 
@@ -257,12 +254,6 @@ func (dtuo *DocumentTypeUpdateOne) SetNillableMetadataID(u *uuid.UUID) *Document
 	if u != nil {
 		dtuo.SetMetadataID(*u)
 	}
-	return dtuo
-}
-
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (dtuo *DocumentTypeUpdateOne) ClearMetadataID() *DocumentTypeUpdateOne {
-	dtuo.mutation.ClearMetadataID()
 	return dtuo
 }
 
@@ -388,6 +379,9 @@ func (dtuo *DocumentTypeUpdateOne) check() error {
 		if err := documenttype.TypeValidator(v); err != nil {
 			return &ValidationError{Name: "type", err: fmt.Errorf(`ent: validator failed for field "DocumentType.type": %w`, err)}
 		}
+	}
+	if dtuo.mutation.MetadataCleared() && len(dtuo.mutation.MetadataIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "DocumentType.metadata"`)
 	}
 	return nil
 }

--- a/internal/backends/ent/edgetype_create.go
+++ b/internal/backends/ent/edgetype_create.go
@@ -205,6 +205,9 @@ func (etc *EdgeTypeCreate) check() error {
 	if len(etc.mutation.ToIDs()) == 0 {
 		return &ValidationError{Name: "to", err: errors.New(`ent: missing required edge "EdgeType.to"`)}
 	}
+	if len(etc.mutation.NodeListsIDs()) == 0 {
+		return &ValidationError{Name: "node_lists", err: errors.New(`ent: missing required edge "EdgeType.node_lists"`)}
+	}
 	return nil
 }
 

--- a/internal/backends/ent/externalreference_create.go
+++ b/internal/backends/ent/externalreference_create.go
@@ -206,6 +206,9 @@ func (erc *ExternalReferenceCreate) check() error {
 			return &ValidationError{Name: "type", err: fmt.Errorf(`ent: validator failed for field "ExternalReference.type": %w`, err)}
 		}
 	}
+	if len(erc.mutation.NodesIDs()) == 0 {
+		return &ValidationError{Name: "nodes", err: errors.New(`ent: missing required edge "ExternalReference.nodes"`)}
+	}
 	return nil
 }
 

--- a/internal/backends/ent/hashesentry/hashesentry.go
+++ b/internal/backends/ent/hashesentry/hashesentry.go
@@ -10,6 +10,7 @@ package hashesentry
 import (
 	"fmt"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"github.com/google/uuid"
@@ -80,7 +81,13 @@ func ValidColumn(column string) bool {
 	return false
 }
 
+// Note that the variables below are initialized by the runtime
+// package on the initialization of the application. Therefore,
+// it should be imported in the main as follows:
+//
+//	import _ "github.com/protobom/storage/internal/backends/ent/runtime"
 var (
+	Hooks [1]ent.Hook
 	// DefaultDocumentID holds the default value on creation for the "document_id" field.
 	DefaultDocumentID func() uuid.UUID
 	// DefaultID holds the default value on creation for the "id" field.

--- a/internal/backends/ent/hashesentry_create.go
+++ b/internal/backends/ent/hashesentry_create.go
@@ -113,7 +113,9 @@ func (hec *HashesEntryCreate) Mutation() *HashesEntryMutation {
 
 // Save creates the HashesEntry in the database.
 func (hec *HashesEntryCreate) Save(ctx context.Context) (*HashesEntry, error) {
-	hec.defaults()
+	if err := hec.defaults(); err != nil {
+		return nil, err
+	}
 	return withHooks(ctx, hec.sqlSave, hec.mutation, hec.hooks)
 }
 
@@ -140,15 +142,22 @@ func (hec *HashesEntryCreate) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (hec *HashesEntryCreate) defaults() {
+func (hec *HashesEntryCreate) defaults() error {
 	if _, ok := hec.mutation.DocumentID(); !ok {
+		if hashesentry.DefaultDocumentID == nil {
+			return fmt.Errorf("ent: uninitialized hashesentry.DefaultDocumentID (forgotten import ent/runtime?)")
+		}
 		v := hashesentry.DefaultDocumentID()
 		hec.mutation.SetDocumentID(v)
 	}
 	if _, ok := hec.mutation.ID(); !ok {
+		if hashesentry.DefaultID == nil {
+			return fmt.Errorf("ent: uninitialized hashesentry.DefaultID (forgotten import ent/runtime?)")
+		}
 		v := hashesentry.DefaultID()
 		hec.mutation.SetID(v)
 	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.

--- a/internal/backends/ent/identifiersentry_create.go
+++ b/internal/backends/ent/identifiersentry_create.go
@@ -148,6 +148,9 @@ func (iec *IdentifiersEntryCreate) check() error {
 	if _, ok := iec.mutation.Value(); !ok {
 		return &ValidationError{Name: "value", err: errors.New(`ent: missing required field "IdentifiersEntry.value"`)}
 	}
+	if len(iec.mutation.NodesIDs()) == 0 {
+		return &ValidationError{Name: "nodes", err: errors.New(`ent: missing required edge "IdentifiersEntry.nodes"`)}
+	}
 	return nil
 }
 

--- a/internal/backends/ent/migrate/migrations/20250121151156_required_inverse_edges.sql
+++ b/internal/backends/ent/migrate/migrations/20250121151156_required_inverse_edges.sql
@@ -1,0 +1,89 @@
+-- Disable the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = off;
+-- Create "new_document_types" table
+CREATE TABLE `new_document_types` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `type` text NULL,
+  `name` text NULL,
+  `description` text NULL,
+  `document_id` uuid NULL,
+  `metadata_id` uuid NOT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `document_types_documents_document` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `document_types_metadata_document_types` FOREIGN KEY (`metadata_id`) REFERENCES `metadata` (`id`) ON DELETE CASCADE
+);
+-- Copy rows from old table "document_types" to new temporary table "new_document_types"
+INSERT INTO `new_document_types` (`id`, `proto_message`, `type`, `name`, `description`, `document_id`, `metadata_id`) SELECT `id`, `proto_message`, `type`, `name`, `description`, `document_id`, `metadata_id` FROM `document_types`;
+-- Drop "document_types" table after copying rows
+DROP TABLE `document_types`;
+-- Rename temporary table "new_document_types" to "document_types"
+ALTER TABLE `new_document_types` RENAME TO `document_types`;
+-- Create index "document_types_proto_message_key" to table: "document_types"
+CREATE UNIQUE INDEX `document_types_proto_message_key` ON `document_types` (`proto_message`);
+-- Create index "idx_document_types" to table: "document_types"
+CREATE UNIQUE INDEX `idx_document_types` ON `document_types` (`metadata_id`, `type`, `name`, `description`);
+-- Create "new_purposes" table
+CREATE TABLE `new_purposes` (
+  `id` integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `primary_purpose` text NOT NULL,
+  `node_id` uuid NOT NULL,
+  `document_id` uuid NULL,
+  CONSTRAINT `purposes_nodes_primary_purpose` FOREIGN KEY (`node_id`) REFERENCES `nodes` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `purposes_documents_document` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE
+);
+-- Copy rows from old table "purposes" to new temporary table "new_purposes"
+INSERT INTO `new_purposes` (`id`, `primary_purpose`, `node_id`, `document_id`) SELECT `id`, `primary_purpose`, `node_id`, `document_id` FROM `purposes`;
+-- Drop "purposes" table after copying rows
+DROP TABLE `purposes`;
+-- Rename temporary table "new_purposes" to "purposes"
+ALTER TABLE `new_purposes` RENAME TO `purposes`;
+-- Create index "idx_purposes" to table: "purposes"
+CREATE UNIQUE INDEX `idx_purposes` ON `purposes` (`node_id`, `primary_purpose`);
+-- Create "new_tools" table
+CREATE TABLE `new_tools` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `name` text NOT NULL,
+  `version` text NOT NULL,
+  `vendor` text NOT NULL,
+  `metadata_id` uuid NOT NULL,
+  `document_id` uuid NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `tools_metadata_tools` FOREIGN KEY (`metadata_id`) REFERENCES `metadata` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `tools_documents_document` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE
+);
+-- Copy rows from old table "tools" to new temporary table "new_tools"
+INSERT INTO `new_tools` (`id`, `proto_message`, `name`, `version`, `vendor`, `metadata_id`, `document_id`) SELECT `id`, `proto_message`, `name`, `version`, `vendor`, `metadata_id`, `document_id` FROM `tools`;
+-- Drop "tools" table after copying rows
+DROP TABLE `tools`;
+-- Rename temporary table "new_tools" to "tools"
+ALTER TABLE `new_tools` RENAME TO `tools`;
+-- Create index "tools_proto_message_key" to table: "tools"
+CREATE UNIQUE INDEX `tools_proto_message_key` ON `tools` (`proto_message`);
+-- Create index "idx_tools" to table: "tools"
+CREATE UNIQUE INDEX `idx_tools` ON `tools` (`metadata_id`, `name`, `version`, `vendor`);
+-- Create "new_properties" table
+CREATE TABLE `new_properties` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `name` text NOT NULL,
+  `data` text NOT NULL,
+  `node_id` uuid NOT NULL,
+  `document_id` uuid NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `properties_nodes_properties` FOREIGN KEY (`node_id`) REFERENCES `nodes` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `properties_documents_document` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE
+);
+-- Copy rows from old table "properties" to new temporary table "new_properties"
+INSERT INTO `new_properties` (`id`, `proto_message`, `name`, `data`, `node_id`, `document_id`) SELECT `id`, `proto_message`, `name`, `data`, `node_id`, `document_id` FROM `properties`;
+-- Drop "properties" table after copying rows
+DROP TABLE `properties`;
+-- Rename temporary table "new_properties" to "properties"
+ALTER TABLE `new_properties` RENAME TO `properties`;
+-- Create index "properties_proto_message_key" to table: "properties"
+CREATE UNIQUE INDEX `properties_proto_message_key` ON `properties` (`proto_message`);
+-- Create index "idx_property" to table: "properties"
+CREATE UNIQUE INDEX `idx_property` ON `properties` (`name`, `data`);
+-- Enable back the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = on;

--- a/internal/backends/ent/migrate/migrations/atlas.sum
+++ b/internal/backends/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:FilEZAOzP6rpZ/6QLfIYAESM3YKn+OUaJwmca7ToIRM=
+h1:wllKMNgozTa+73uaYDnl1dIrxia7UfyFF80Tt9cl+JM=
 20241016141529_initial.sql h1:cZ5Nr+1kj075buwWNz8SHKlRSFaV3L0dzpT9htnXQY4=
 20241101155047_store_protos.sql h1:ALraUjMTZaPGDf+y7IXSLp/LRVWXP3rG6kKQb3ZJf5I=
 20241109194036_ext_ref_type_fix.sql h1:hvLOKWxV23ea20Po7TLLx0VVfevihIQmR2Ft9nX2Nis=
@@ -10,3 +10,4 @@ h1:FilEZAOzP6rpZ/6QLfIYAESM3YKn+OUaJwmca7ToIRM=
 20250111195831_identifiers_entries.sql h1:t+6QoPwVYJFuXnS8zPiFeL3F/NvQorfgi5sAxGcEn6c=
 20250116171940_annotations_nillable_document_id.sql h1:m7rHNc6tZKrgqTH2QWYJ6x7cZheeS1r3pihYyHATV8U=
 20250116180706_embed_uuid_mixin.sql h1:ZYkxRXC/nkJslenl3XH2yGfeqWPyFuzLMsIImlOOOok=
+20250121151156_required_inverse_edges.sql h1:pCYwsp9BZ2rohlhGkOXCk89r5jwW5l/nFJ+OdeSaL94=

--- a/internal/backends/ent/migrate/schema.go
+++ b/internal/backends/ent/migrate/schema.go
@@ -121,7 +121,7 @@ var (
 		{Name: "name", Type: field.TypeString, Nullable: true},
 		{Name: "description", Type: field.TypeString, Nullable: true},
 		{Name: "document_id", Type: field.TypeUUID, Nullable: true},
-		{Name: "metadata_id", Type: field.TypeUUID, Nullable: true},
+		{Name: "metadata_id", Type: field.TypeUUID},
 	}
 	// DocumentTypesTable holds the schema information for the "document_types" table.
 	DocumentTypesTable = &schema.Table{
@@ -437,7 +437,7 @@ var (
 		{Name: "proto_message", Type: field.TypeBytes, Unique: true},
 		{Name: "name", Type: field.TypeString},
 		{Name: "data", Type: field.TypeString},
-		{Name: "node_id", Type: field.TypeUUID, Nullable: true},
+		{Name: "node_id", Type: field.TypeUUID},
 		{Name: "document_id", Type: field.TypeUUID, Nullable: true},
 	}
 	// PropertiesTable holds the schema information for the "properties" table.
@@ -471,7 +471,7 @@ var (
 	PurposesColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "primary_purpose", Type: field.TypeEnum, Enums: []string{"UNKNOWN_PURPOSE", "APPLICATION", "ARCHIVE", "BOM", "CONFIGURATION", "CONTAINER", "DATA", "DEVICE", "DEVICE_DRIVER", "DOCUMENTATION", "EVIDENCE", "EXECUTABLE", "FILE", "FIRMWARE", "FRAMEWORK", "INSTALL", "LIBRARY", "MACHINE_LEARNING_MODEL", "MANIFEST", "MODEL", "MODULE", "OPERATING_SYSTEM", "OTHER", "PATCH", "PLATFORM", "REQUIREMENT", "SOURCE", "SPECIFICATION", "TEST"}},
-		{Name: "node_id", Type: field.TypeUUID, Nullable: true},
+		{Name: "node_id", Type: field.TypeUUID},
 		{Name: "document_id", Type: field.TypeUUID, Nullable: true},
 	}
 	// PurposesTable holds the schema information for the "purposes" table.
@@ -546,7 +546,7 @@ var (
 		{Name: "name", Type: field.TypeString},
 		{Name: "version", Type: field.TypeString},
 		{Name: "vendor", Type: field.TypeString},
-		{Name: "metadata_id", Type: field.TypeUUID, Nullable: true},
+		{Name: "metadata_id", Type: field.TypeUUID},
 		{Name: "document_id", Type: field.TypeUUID, Nullable: true},
 	}
 	// ToolsTable holds the schema information for the "tools" table.

--- a/internal/backends/ent/mutation.go
+++ b/internal/backends/ent/mutation.go
@@ -1597,22 +1597,9 @@ func (m *DocumentTypeMutation) OldMetadataID(ctx context.Context) (v uuid.UUID, 
 	return oldValue.MetadataID, nil
 }
 
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (m *DocumentTypeMutation) ClearMetadataID() {
-	m.metadata = nil
-	m.clearedFields[documenttype.FieldMetadataID] = struct{}{}
-}
-
-// MetadataIDCleared returns if the "metadata_id" field was cleared in this mutation.
-func (m *DocumentTypeMutation) MetadataIDCleared() bool {
-	_, ok := m.clearedFields[documenttype.FieldMetadataID]
-	return ok
-}
-
 // ResetMetadataID resets all changes to the "metadata_id" field.
 func (m *DocumentTypeMutation) ResetMetadataID() {
 	m.metadata = nil
-	delete(m.clearedFields, documenttype.FieldMetadataID)
 }
 
 // SetType sets the "type" field.
@@ -1797,7 +1784,7 @@ func (m *DocumentTypeMutation) ClearMetadata() {
 
 // MetadataCleared reports if the "metadata" edge to the Metadata entity was cleared.
 func (m *DocumentTypeMutation) MetadataCleared() bool {
-	return m.MetadataIDCleared() || m.clearedmetadata
+	return m.clearedmetadata
 }
 
 // MetadataIDs returns the "metadata" edge IDs in the mutation.
@@ -1994,9 +1981,6 @@ func (m *DocumentTypeMutation) ClearedFields() []string {
 	if m.FieldCleared(documenttype.FieldDocumentID) {
 		fields = append(fields, documenttype.FieldDocumentID)
 	}
-	if m.FieldCleared(documenttype.FieldMetadataID) {
-		fields = append(fields, documenttype.FieldMetadataID)
-	}
 	if m.FieldCleared(documenttype.FieldType) {
 		fields = append(fields, documenttype.FieldType)
 	}
@@ -2022,9 +2006,6 @@ func (m *DocumentTypeMutation) ClearField(name string) error {
 	switch name {
 	case documenttype.FieldDocumentID:
 		m.ClearDocumentID()
-		return nil
-	case documenttype.FieldMetadataID:
-		m.ClearMetadataID()
 		return nil
 	case documenttype.FieldType:
 		m.ClearType()
@@ -10788,22 +10769,9 @@ func (m *PropertyMutation) OldNodeID(ctx context.Context) (v uuid.UUID, err erro
 	return oldValue.NodeID, nil
 }
 
-// ClearNodeID clears the value of the "node_id" field.
-func (m *PropertyMutation) ClearNodeID() {
-	m.node = nil
-	m.clearedFields[property.FieldNodeID] = struct{}{}
-}
-
-// NodeIDCleared returns if the "node_id" field was cleared in this mutation.
-func (m *PropertyMutation) NodeIDCleared() bool {
-	_, ok := m.clearedFields[property.FieldNodeID]
-	return ok
-}
-
 // ResetNodeID resets all changes to the "node_id" field.
 func (m *PropertyMutation) ResetNodeID() {
 	m.node = nil
-	delete(m.clearedFields, property.FieldNodeID)
 }
 
 // SetName sets the "name" field.
@@ -10913,7 +10881,7 @@ func (m *PropertyMutation) ClearNode() {
 
 // NodeCleared reports if the "node" edge to the Node entity was cleared.
 func (m *PropertyMutation) NodeCleared() bool {
-	return m.NodeIDCleared() || m.clearednode
+	return m.clearednode
 }
 
 // NodeIDs returns the "node" edge IDs in the mutation.
@@ -11096,9 +11064,6 @@ func (m *PropertyMutation) ClearedFields() []string {
 	if m.FieldCleared(property.FieldDocumentID) {
 		fields = append(fields, property.FieldDocumentID)
 	}
-	if m.FieldCleared(property.FieldNodeID) {
-		fields = append(fields, property.FieldNodeID)
-	}
 	return fields
 }
 
@@ -11115,9 +11080,6 @@ func (m *PropertyMutation) ClearField(name string) error {
 	switch name {
 	case property.FieldDocumentID:
 		m.ClearDocumentID()
-		return nil
-	case property.FieldNodeID:
-		m.ClearNodeID()
 		return nil
 	}
 	return fmt.Errorf("unknown Property nullable field %s", name)
@@ -11433,22 +11395,9 @@ func (m *PurposeMutation) OldNodeID(ctx context.Context) (v uuid.UUID, err error
 	return oldValue.NodeID, nil
 }
 
-// ClearNodeID clears the value of the "node_id" field.
-func (m *PurposeMutation) ClearNodeID() {
-	m.node = nil
-	m.clearedFields[purpose.FieldNodeID] = struct{}{}
-}
-
-// NodeIDCleared returns if the "node_id" field was cleared in this mutation.
-func (m *PurposeMutation) NodeIDCleared() bool {
-	_, ok := m.clearedFields[purpose.FieldNodeID]
-	return ok
-}
-
 // ResetNodeID resets all changes to the "node_id" field.
 func (m *PurposeMutation) ResetNodeID() {
 	m.node = nil
-	delete(m.clearedFields, purpose.FieldNodeID)
 }
 
 // SetPrimaryPurpose sets the "primary_purpose" field.
@@ -11522,7 +11471,7 @@ func (m *PurposeMutation) ClearNode() {
 
 // NodeCleared reports if the "node" edge to the Node entity was cleared.
 func (m *PurposeMutation) NodeCleared() bool {
-	return m.NodeIDCleared() || m.clearednode
+	return m.clearednode
 }
 
 // NodeIDs returns the "node" edge IDs in the mutation.
@@ -11677,9 +11626,6 @@ func (m *PurposeMutation) ClearedFields() []string {
 	if m.FieldCleared(purpose.FieldDocumentID) {
 		fields = append(fields, purpose.FieldDocumentID)
 	}
-	if m.FieldCleared(purpose.FieldNodeID) {
-		fields = append(fields, purpose.FieldNodeID)
-	}
 	return fields
 }
 
@@ -11696,9 +11642,6 @@ func (m *PurposeMutation) ClearField(name string) error {
 	switch name {
 	case purpose.FieldDocumentID:
 		m.ClearDocumentID()
-		return nil
-	case purpose.FieldNodeID:
-		m.ClearNodeID()
 		return nil
 	}
 	return fmt.Errorf("unknown Purpose nullable field %s", name)
@@ -12905,22 +12848,9 @@ func (m *ToolMutation) OldMetadataID(ctx context.Context) (v uuid.UUID, err erro
 	return oldValue.MetadataID, nil
 }
 
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (m *ToolMutation) ClearMetadataID() {
-	m.metadata = nil
-	m.clearedFields[tool.FieldMetadataID] = struct{}{}
-}
-
-// MetadataIDCleared returns if the "metadata_id" field was cleared in this mutation.
-func (m *ToolMutation) MetadataIDCleared() bool {
-	_, ok := m.clearedFields[tool.FieldMetadataID]
-	return ok
-}
-
 // ResetMetadataID resets all changes to the "metadata_id" field.
 func (m *ToolMutation) ResetMetadataID() {
 	m.metadata = nil
-	delete(m.clearedFields, tool.FieldMetadataID)
 }
 
 // SetName sets the "name" field.
@@ -13066,7 +12996,7 @@ func (m *ToolMutation) ClearMetadata() {
 
 // MetadataCleared reports if the "metadata" edge to the Metadata entity was cleared.
 func (m *ToolMutation) MetadataCleared() bool {
-	return m.MetadataIDCleared() || m.clearedmetadata
+	return m.clearedmetadata
 }
 
 // MetadataIDs returns the "metadata" edge IDs in the mutation.
@@ -13263,9 +13193,6 @@ func (m *ToolMutation) ClearedFields() []string {
 	if m.FieldCleared(tool.FieldDocumentID) {
 		fields = append(fields, tool.FieldDocumentID)
 	}
-	if m.FieldCleared(tool.FieldMetadataID) {
-		fields = append(fields, tool.FieldMetadataID)
-	}
 	return fields
 }
 
@@ -13282,9 +13209,6 @@ func (m *ToolMutation) ClearField(name string) error {
 	switch name {
 	case tool.FieldDocumentID:
 		m.ClearDocumentID()
-		return nil
-	case tool.FieldMetadataID:
-		m.ClearMetadataID()
 		return nil
 	}
 	return fmt.Errorf("unknown Tool nullable field %s", name)

--- a/internal/backends/ent/node_create.go
+++ b/internal/backends/ent/node_create.go
@@ -522,6 +522,9 @@ func (nc *NodeCreate) check() error {
 	if _, ok := nc.mutation.FileTypes(); !ok {
 		return &ValidationError{Name: "file_types", err: errors.New(`ent: missing required field "Node.file_types"`)}
 	}
+	if len(nc.mutation.NodeListsIDs()) == 0 {
+		return &ValidationError{Name: "node_lists", err: errors.New(`ent: missing required edge "Node.node_lists"`)}
+	}
 	return nil
 }
 

--- a/internal/backends/ent/person/person.go
+++ b/internal/backends/ent/person/person.go
@@ -122,7 +122,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/protobom/storage/internal/backends/ent/runtime"
 var (
-	Hooks [1]ent.Hook
+	Hooks [2]ent.Hook
 	// DefaultDocumentID holds the default value on creation for the "document_id" field.
 	DefaultDocumentID func() uuid.UUID
 	// DefaultID holds the default value on creation for the "id" field.

--- a/internal/backends/ent/property/where.go
+++ b/internal/backends/ent/property/where.go
@@ -175,16 +175,6 @@ func NodeIDNotIn(vs ...uuid.UUID) predicate.Property {
 	return predicate.Property(sql.FieldNotIn(FieldNodeID, vs...))
 }
 
-// NodeIDIsNil applies the IsNil predicate on the "node_id" field.
-func NodeIDIsNil() predicate.Property {
-	return predicate.Property(sql.FieldIsNull(FieldNodeID))
-}
-
-// NodeIDNotNil applies the NotNil predicate on the "node_id" field.
-func NodeIDNotNil() predicate.Property {
-	return predicate.Property(sql.FieldNotNull(FieldNodeID))
-}
-
 // NameEQ applies the EQ predicate on the "name" field.
 func NameEQ(v string) predicate.Property {
 	return predicate.Property(sql.FieldEQ(FieldName, v))

--- a/internal/backends/ent/property_create.go
+++ b/internal/backends/ent/property_create.go
@@ -57,14 +57,6 @@ func (pc *PropertyCreate) SetNodeID(u uuid.UUID) *PropertyCreate {
 	return pc
 }
 
-// SetNillableNodeID sets the "node_id" field if the given value is not nil.
-func (pc *PropertyCreate) SetNillableNodeID(u *uuid.UUID) *PropertyCreate {
-	if u != nil {
-		pc.SetNodeID(*u)
-	}
-	return pc
-}
-
 // SetName sets the "name" field.
 func (pc *PropertyCreate) SetName(s string) *PropertyCreate {
 	pc.mutation.SetName(s)
@@ -160,11 +152,17 @@ func (pc *PropertyCreate) check() error {
 	if _, ok := pc.mutation.ProtoMessage(); !ok {
 		return &ValidationError{Name: "proto_message", err: errors.New(`ent: missing required field "Property.proto_message"`)}
 	}
+	if _, ok := pc.mutation.NodeID(); !ok {
+		return &ValidationError{Name: "node_id", err: errors.New(`ent: missing required field "Property.node_id"`)}
+	}
 	if _, ok := pc.mutation.Name(); !ok {
 		return &ValidationError{Name: "name", err: errors.New(`ent: missing required field "Property.name"`)}
 	}
 	if _, ok := pc.mutation.Data(); !ok {
 		return &ValidationError{Name: "data", err: errors.New(`ent: missing required field "Property.data"`)}
+	}
+	if len(pc.mutation.NodeIDs()) == 0 {
+		return &ValidationError{Name: "node", err: errors.New(`ent: missing required edge "Property.node"`)}
 	}
 	return nil
 }
@@ -312,12 +310,6 @@ func (u *PropertyUpsert) UpdateNodeID() *PropertyUpsert {
 	return u
 }
 
-// ClearNodeID clears the value of the "node_id" field.
-func (u *PropertyUpsert) ClearNodeID() *PropertyUpsert {
-	u.SetNull(property.FieldNodeID)
-	return u
-}
-
 // SetName sets the "name" field.
 func (u *PropertyUpsert) SetName(v string) *PropertyUpsert {
 	u.Set(property.FieldName, v)
@@ -407,13 +399,6 @@ func (u *PropertyUpsertOne) SetNodeID(v uuid.UUID) *PropertyUpsertOne {
 func (u *PropertyUpsertOne) UpdateNodeID() *PropertyUpsertOne {
 	return u.Update(func(s *PropertyUpsert) {
 		s.UpdateNodeID()
-	})
-}
-
-// ClearNodeID clears the value of the "node_id" field.
-func (u *PropertyUpsertOne) ClearNodeID() *PropertyUpsertOne {
-	return u.Update(func(s *PropertyUpsert) {
-		s.ClearNodeID()
 	})
 }
 
@@ -677,13 +662,6 @@ func (u *PropertyUpsertBulk) SetNodeID(v uuid.UUID) *PropertyUpsertBulk {
 func (u *PropertyUpsertBulk) UpdateNodeID() *PropertyUpsertBulk {
 	return u.Update(func(s *PropertyUpsert) {
 		s.UpdateNodeID()
-	})
-}
-
-// ClearNodeID clears the value of the "node_id" field.
-func (u *PropertyUpsertBulk) ClearNodeID() *PropertyUpsertBulk {
-	return u.Update(func(s *PropertyUpsert) {
-		s.ClearNodeID()
 	})
 }
 

--- a/internal/backends/ent/property_update.go
+++ b/internal/backends/ent/property_update.go
@@ -48,12 +48,6 @@ func (pu *PropertyUpdate) SetNillableNodeID(u *uuid.UUID) *PropertyUpdate {
 	return pu
 }
 
-// ClearNodeID clears the value of the "node_id" field.
-func (pu *PropertyUpdate) ClearNodeID() *PropertyUpdate {
-	pu.mutation.ClearNodeID()
-	return pu
-}
-
 // SetName sets the "name" field.
 func (pu *PropertyUpdate) SetName(s string) *PropertyUpdate {
 	pu.mutation.SetName(s)
@@ -125,7 +119,18 @@ func (pu *PropertyUpdate) ExecX(ctx context.Context) {
 	}
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (pu *PropertyUpdate) check() error {
+	if pu.mutation.NodeCleared() && len(pu.mutation.NodeIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Property.node"`)
+	}
+	return nil
+}
+
 func (pu *PropertyUpdate) sqlSave(ctx context.Context) (n int, err error) {
+	if err := pu.check(); err != nil {
+		return n, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(property.Table, property.Columns, sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID))
 	if ps := pu.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
@@ -200,12 +205,6 @@ func (puo *PropertyUpdateOne) SetNillableNodeID(u *uuid.UUID) *PropertyUpdateOne
 	if u != nil {
 		puo.SetNodeID(*u)
 	}
-	return puo
-}
-
-// ClearNodeID clears the value of the "node_id" field.
-func (puo *PropertyUpdateOne) ClearNodeID() *PropertyUpdateOne {
-	puo.mutation.ClearNodeID()
 	return puo
 }
 
@@ -293,7 +292,18 @@ func (puo *PropertyUpdateOne) ExecX(ctx context.Context) {
 	}
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (puo *PropertyUpdateOne) check() error {
+	if puo.mutation.NodeCleared() && len(puo.mutation.NodeIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Property.node"`)
+	}
+	return nil
+}
+
 func (puo *PropertyUpdateOne) sqlSave(ctx context.Context) (_node *Property, err error) {
+	if err := puo.check(); err != nil {
+		return _node, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(property.Table, property.Columns, sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID))
 	id, ok := puo.mutation.ID()
 	if !ok {

--- a/internal/backends/ent/purpose/where.go
+++ b/internal/backends/ent/purpose/where.go
@@ -119,16 +119,6 @@ func NodeIDNotIn(vs ...uuid.UUID) predicate.Purpose {
 	return predicate.Purpose(sql.FieldNotIn(FieldNodeID, vs...))
 }
 
-// NodeIDIsNil applies the IsNil predicate on the "node_id" field.
-func NodeIDIsNil() predicate.Purpose {
-	return predicate.Purpose(sql.FieldIsNull(FieldNodeID))
-}
-
-// NodeIDNotNil applies the NotNil predicate on the "node_id" field.
-func NodeIDNotNil() predicate.Purpose {
-	return predicate.Purpose(sql.FieldNotNull(FieldNodeID))
-}
-
 // PrimaryPurposeEQ applies the EQ predicate on the "primary_purpose" field.
 func PrimaryPurposeEQ(v PrimaryPurpose) predicate.Purpose {
 	return predicate.Purpose(sql.FieldEQ(FieldPrimaryPurpose, v))

--- a/internal/backends/ent/purpose_create.go
+++ b/internal/backends/ent/purpose_create.go
@@ -49,14 +49,6 @@ func (pc *PurposeCreate) SetNodeID(u uuid.UUID) *PurposeCreate {
 	return pc
 }
 
-// SetNillableNodeID sets the "node_id" field if the given value is not nil.
-func (pc *PurposeCreate) SetNillableNodeID(u *uuid.UUID) *PurposeCreate {
-	if u != nil {
-		pc.SetNodeID(*u)
-	}
-	return pc
-}
-
 // SetPrimaryPurpose sets the "primary_purpose" field.
 func (pc *PurposeCreate) SetPrimaryPurpose(pp purpose.PrimaryPurpose) *PurposeCreate {
 	pc.mutation.SetPrimaryPurpose(pp)
@@ -116,6 +108,9 @@ func (pc *PurposeCreate) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (pc *PurposeCreate) check() error {
+	if _, ok := pc.mutation.NodeID(); !ok {
+		return &ValidationError{Name: "node_id", err: errors.New(`ent: missing required field "Purpose.node_id"`)}
+	}
 	if _, ok := pc.mutation.PrimaryPurpose(); !ok {
 		return &ValidationError{Name: "primary_purpose", err: errors.New(`ent: missing required field "Purpose.primary_purpose"`)}
 	}
@@ -123,6 +118,9 @@ func (pc *PurposeCreate) check() error {
 		if err := purpose.PrimaryPurposeValidator(v); err != nil {
 			return &ValidationError{Name: "primary_purpose", err: fmt.Errorf(`ent: validator failed for field "Purpose.primary_purpose": %w`, err)}
 		}
+	}
+	if len(pc.mutation.NodeIDs()) == 0 {
+		return &ValidationError{Name: "node", err: errors.New(`ent: missing required edge "Purpose.node"`)}
 	}
 	return nil
 }
@@ -253,12 +251,6 @@ func (u *PurposeUpsert) UpdateNodeID() *PurposeUpsert {
 	return u
 }
 
-// ClearNodeID clears the value of the "node_id" field.
-func (u *PurposeUpsert) ClearNodeID() *PurposeUpsert {
-	u.SetNull(purpose.FieldNodeID)
-	return u
-}
-
 // SetPrimaryPurpose sets the "primary_purpose" field.
 func (u *PurposeUpsert) SetPrimaryPurpose(v purpose.PrimaryPurpose) *PurposeUpsert {
 	u.Set(purpose.FieldPrimaryPurpose, v)
@@ -327,13 +319,6 @@ func (u *PurposeUpsertOne) SetNodeID(v uuid.UUID) *PurposeUpsertOne {
 func (u *PurposeUpsertOne) UpdateNodeID() *PurposeUpsertOne {
 	return u.Update(func(s *PurposeUpsert) {
 		s.UpdateNodeID()
-	})
-}
-
-// ClearNodeID clears the value of the "node_id" field.
-func (u *PurposeUpsertOne) ClearNodeID() *PurposeUpsertOne {
-	return u.Update(func(s *PurposeUpsert) {
-		s.ClearNodeID()
 	})
 }
 
@@ -573,13 +558,6 @@ func (u *PurposeUpsertBulk) SetNodeID(v uuid.UUID) *PurposeUpsertBulk {
 func (u *PurposeUpsertBulk) UpdateNodeID() *PurposeUpsertBulk {
 	return u.Update(func(s *PurposeUpsert) {
 		s.UpdateNodeID()
-	})
-}
-
-// ClearNodeID clears the value of the "node_id" field.
-func (u *PurposeUpsertBulk) ClearNodeID() *PurposeUpsertBulk {
-	return u.Update(func(s *PurposeUpsert) {
-		s.ClearNodeID()
 	})
 }
 

--- a/internal/backends/ent/purpose_update.go
+++ b/internal/backends/ent/purpose_update.go
@@ -48,12 +48,6 @@ func (pu *PurposeUpdate) SetNillableNodeID(u *uuid.UUID) *PurposeUpdate {
 	return pu
 }
 
-// ClearNodeID clears the value of the "node_id" field.
-func (pu *PurposeUpdate) ClearNodeID() *PurposeUpdate {
-	pu.mutation.ClearNodeID()
-	return pu
-}
-
 // SetPrimaryPurpose sets the "primary_purpose" field.
 func (pu *PurposeUpdate) SetPrimaryPurpose(pp purpose.PrimaryPurpose) *PurposeUpdate {
 	pu.mutation.SetPrimaryPurpose(pp)
@@ -117,6 +111,9 @@ func (pu *PurposeUpdate) check() error {
 		if err := purpose.PrimaryPurposeValidator(v); err != nil {
 			return &ValidationError{Name: "primary_purpose", err: fmt.Errorf(`ent: validator failed for field "Purpose.primary_purpose": %w`, err)}
 		}
+	}
+	if pu.mutation.NodeCleared() && len(pu.mutation.NodeIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Purpose.node"`)
 	}
 	return nil
 }
@@ -199,12 +196,6 @@ func (puo *PurposeUpdateOne) SetNillableNodeID(u *uuid.UUID) *PurposeUpdateOne {
 	return puo
 }
 
-// ClearNodeID clears the value of the "node_id" field.
-func (puo *PurposeUpdateOne) ClearNodeID() *PurposeUpdateOne {
-	puo.mutation.ClearNodeID()
-	return puo
-}
-
 // SetPrimaryPurpose sets the "primary_purpose" field.
 func (puo *PurposeUpdateOne) SetPrimaryPurpose(pp purpose.PrimaryPurpose) *PurposeUpdateOne {
 	puo.mutation.SetPrimaryPurpose(pp)
@@ -281,6 +272,9 @@ func (puo *PurposeUpdateOne) check() error {
 		if err := purpose.PrimaryPurposeValidator(v); err != nil {
 			return &ValidationError{Name: "primary_purpose", err: fmt.Errorf(`ent: validator failed for field "Purpose.primary_purpose": %w`, err)}
 		}
+	}
+	if puo.mutation.NodeCleared() && len(puo.mutation.NodeIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Purpose.node"`)
 	}
 	return nil
 }

--- a/internal/backends/ent/runtime/runtime.go
+++ b/internal/backends/ent/runtime/runtime.go
@@ -31,6 +31,8 @@ import (
 // (default values, validators, hooks and policies) and stitches it
 // to their package variables.
 func init() {
+	annotationHooks := schema.Annotation{}.Hooks()
+	annotation.Hooks[0] = annotationHooks[0]
 	annotationFields := schema.Annotation{}.Fields()
 	_ = annotationFields
 	// annotationDescIsUnique is the schema descriptor for is_unique field.
@@ -98,6 +100,8 @@ func init() {
 	// externalreference.DefaultID holds the default value on creation for the id field.
 	externalreference.DefaultID = externalreferenceDescID.Default.(func() uuid.UUID)
 	hashesentryMixin := schema.HashesEntry{}.Mixin()
+	hashesentryHooks := schema.HashesEntry{}.Hooks()
+	hashesentry.Hooks[0] = hashesentryHooks[0]
 	hashesentryMixinFields0 := hashesentryMixin[0].Fields()
 	_ = hashesentryMixinFields0
 	hashesentryMixinFields1 := hashesentryMixin[1].Fields()
@@ -176,7 +180,9 @@ func init() {
 	nodelist.DefaultID = nodelistDescID.Default.(func() uuid.UUID)
 	personMixin := schema.Person{}.Mixin()
 	personMixinHooks1 := personMixin[1].Hooks()
+	personHooks := schema.Person{}.Hooks()
 	person.Hooks[0] = personMixinHooks1[0]
+	person.Hooks[1] = personHooks[0]
 	personMixinFields0 := personMixin[0].Fields()
 	_ = personMixinFields0
 	personMixinFields1 := personMixin[1].Fields()

--- a/internal/backends/ent/schema/document_type.go
+++ b/internal/backends/ent/schema/document_type.go
@@ -28,7 +28,7 @@ func (DocumentType) Mixin() []ent.Mixin {
 
 func (DocumentType) Fields() []ent.Field {
 	return []ent.Field{
-		field.UUID("metadata_id", uuid.UUID{}).Optional(),
+		field.UUID("metadata_id", uuid.UUID{}),
 		field.Enum("type").
 			Values(enumValues(new(sbom.DocumentType_SBOMType))...).
 			Optional().
@@ -42,6 +42,7 @@ func (DocumentType) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("metadata", Metadata.Type).
 			Ref("document_types").
+			Required().
 			Unique().
 			Field("metadata_id"),
 	}

--- a/internal/backends/ent/schema/edge_type.go
+++ b/internal/backends/ent/schema/edge_type.go
@@ -48,7 +48,8 @@ func (EdgeType) Edges() []ent.Edge {
 			Annotations(entsql.OnDelete(entsql.Cascade)).
 			Field("to_node_id"),
 		edge.From("node_lists", NodeList.Type).
-			Ref("edge_types"),
+			Ref("edge_types").
+			Required(),
 	}
 }
 

--- a/internal/backends/ent/schema/external_reference.go
+++ b/internal/backends/ent/schema/external_reference.go
@@ -40,6 +40,8 @@ func (ExternalReference) Edges() []ent.Edge {
 		edge.To("hashes", HashesEntry.Type).
 			StorageKey(edge.Table("ext_ref_hashes"), edge.Columns("ext_ref_id", "hash_entry_id")).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
-		edge.From("nodes", Node.Type).Ref("external_references"),
+		edge.From("nodes", Node.Type).
+			Ref("external_references").
+			Required(),
 	}
 }

--- a/internal/backends/ent/schema/hashes_entry.go
+++ b/internal/backends/ent/schema/hashes_entry.go
@@ -6,16 +6,24 @@
 package schema
 
 import (
+	"context"
+	"errors"
+
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
 	"github.com/protobom/protobom/pkg/sbom"
+
+	entint "github.com/protobom/storage/internal/backends/ent"
+	"github.com/protobom/storage/internal/backends/ent/hook"
 )
 
 type HashesEntry struct {
 	ent.Schema
 }
+
+var errInvalidHashesEntry = errors.New("at least one of external_reference_id or node_id must be set")
 
 func (HashesEntry) Mixin() []ent.Mixin {
 	return []ent.Mixin{
@@ -38,10 +46,32 @@ func (HashesEntry) Edges() []ent.Edge {
 	}
 }
 
+func (HashesEntry) Hooks() []ent.Hook {
+	return []ent.Hook{
+		hook.On(hashesEntryHook, ent.OpCreate|ent.OpUpdate|ent.OpUpdateOne),
+	}
+}
+
 func (HashesEntry) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("hash_algorithm", "hash_data").
 			Unique().
 			StorageKey("idx_hashes"),
 	}
+}
+
+func hashesEntryHook(next ent.Mutator) ent.Mutator {
+	return hook.HashesEntryFunc(
+		func(ctx context.Context, mutation *entint.HashesEntryMutation) (entint.Value, error) {
+			extRefs := mutation.ExternalReferencesIDs()
+			nodes := mutation.NodesIDs()
+
+			// Fail validation if neither external_reference_id nor node_id are set.
+			if len(extRefs) == 0 && len(nodes) == 0 {
+				return nil, errInvalidHashesEntry
+			}
+
+			return next.Mutate(ctx, mutation)
+		},
+	)
 }

--- a/internal/backends/ent/schema/identifiers_entry.go
+++ b/internal/backends/ent/schema/identifiers_entry.go
@@ -33,7 +33,9 @@ func (IdentifiersEntry) Fields() []ent.Field {
 
 func (IdentifiersEntry) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("nodes", Node.Type).Ref("identifiers"),
+		edge.From("nodes", Node.Type).
+			Ref("identifiers").
+			Required(),
 	}
 }
 

--- a/internal/backends/ent/schema/node.go
+++ b/internal/backends/ent/schema/node.go
@@ -81,7 +81,9 @@ func (Node) Edges() []ent.Edge {
 			Annotations(entsql.OnDelete(entsql.Cascade)),
 		edge.To("properties", Property.Type).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
-		edge.From("node_lists", NodeList.Type).Ref("nodes"),
+		edge.From("node_lists", NodeList.Type).
+			Ref("nodes").
+			Required(),
 	}
 }
 

--- a/internal/backends/ent/schema/person.go
+++ b/internal/backends/ent/schema/person.go
@@ -7,6 +7,9 @@
 package schema
 
 import (
+	"context"
+	"errors"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
@@ -14,11 +17,16 @@ import (
 	"entgo.io/ent/schema/index"
 	"github.com/google/uuid"
 	"github.com/protobom/protobom/pkg/sbom"
+
+	entint "github.com/protobom/storage/internal/backends/ent"
+	"github.com/protobom/storage/internal/backends/ent/hook"
 )
 
 type Person struct {
 	ent.Schema
 }
+
+var errInvalidPerson = errors.New("either metadata_id or node_id (exclusive) must be set")
 
 func (Person) Mixin() []ent.Mixin {
 	return []ent.Mixin{
@@ -58,6 +66,12 @@ func (Person) Edges() []ent.Edge {
 	}
 }
 
+func (Person) Hooks() []ent.Hook {
+	return []ent.Hook{
+		hook.On(personHook, ent.OpCreate|ent.OpUpdate|ent.OpUpdateOne),
+	}
+}
+
 func (Person) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("metadata_id", "name", "is_org", "email", "url", "phone").
@@ -69,4 +83,20 @@ func (Person) Indexes() []ent.Index {
 			Annotations(entsql.IndexWhere("metadata_id IS NULL AND node_id IS NOT NULL")).
 			StorageKey("idx_person_node_id"),
 	}
+}
+
+func personHook(next ent.Mutator) ent.Mutator {
+	return hook.PersonFunc(
+		func(ctx context.Context, mutation *entint.PersonMutation) (entint.Value, error) {
+			_, nodeExists := mutation.NodeID()
+			_, metadataExists := mutation.MetadataID()
+
+			// Fail validation if both metadata_id and node_id are set, or neither are.
+			if metadataExists == nodeExists {
+				return nil, errInvalidPerson
+			}
+
+			return next.Mutate(ctx, mutation)
+		},
+	)
 }

--- a/internal/backends/ent/schema/property.go
+++ b/internal/backends/ent/schema/property.go
@@ -28,7 +28,7 @@ func (Property) Mixin() []ent.Mixin {
 
 func (Property) Fields() []ent.Field {
 	return []ent.Field{
-		field.UUID("node_id", uuid.UUID{}).Optional(),
+		field.UUID("node_id", uuid.UUID{}),
 		field.String("name"),
 		field.String("data"),
 	}
@@ -38,6 +38,7 @@ func (Property) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("node", Node.Type).
 			Ref("properties").
+			Required().
 			Unique().
 			Field("node_id"),
 	}

--- a/internal/backends/ent/schema/purpose.go
+++ b/internal/backends/ent/schema/purpose.go
@@ -27,7 +27,7 @@ func (Purpose) Mixin() []ent.Mixin {
 
 func (Purpose) Fields() []ent.Field {
 	return []ent.Field{
-		field.UUID("node_id", uuid.UUID{}).Optional(),
+		field.UUID("node_id", uuid.UUID{}),
 		field.Enum("primary_purpose").Values(enumValues(new(sbom.Purpose))...),
 	}
 }
@@ -36,6 +36,7 @@ func (Purpose) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("node", Node.Type).
 			Ref("primary_purpose").
+			Required().
 			Unique().
 			Field("node_id"),
 	}

--- a/internal/backends/ent/schema/tool.go
+++ b/internal/backends/ent/schema/tool.go
@@ -28,7 +28,7 @@ func (Tool) Mixin() []ent.Mixin {
 
 func (Tool) Fields() []ent.Field {
 	return []ent.Field{
-		field.UUID("metadata_id", uuid.UUID{}).Optional(),
+		field.UUID("metadata_id", uuid.UUID{}),
 		field.String("name"),
 		field.String("version"),
 		field.String("vendor"),
@@ -39,6 +39,7 @@ func (Tool) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("metadata", Metadata.Type).
 			Ref("tools").
+			Required().
 			Unique().
 			Field("metadata_id"),
 	}

--- a/internal/backends/ent/tool/where.go
+++ b/internal/backends/ent/tool/where.go
@@ -180,16 +180,6 @@ func MetadataIDNotIn(vs ...uuid.UUID) predicate.Tool {
 	return predicate.Tool(sql.FieldNotIn(FieldMetadataID, vs...))
 }
 
-// MetadataIDIsNil applies the IsNil predicate on the "metadata_id" field.
-func MetadataIDIsNil() predicate.Tool {
-	return predicate.Tool(sql.FieldIsNull(FieldMetadataID))
-}
-
-// MetadataIDNotNil applies the NotNil predicate on the "metadata_id" field.
-func MetadataIDNotNil() predicate.Tool {
-	return predicate.Tool(sql.FieldNotNull(FieldMetadataID))
-}
-
 // NameEQ applies the EQ predicate on the "name" field.
 func NameEQ(v string) predicate.Tool {
 	return predicate.Tool(sql.FieldEQ(FieldName, v))

--- a/internal/backends/ent/tool_create.go
+++ b/internal/backends/ent/tool_create.go
@@ -57,14 +57,6 @@ func (tc *ToolCreate) SetMetadataID(u uuid.UUID) *ToolCreate {
 	return tc
 }
 
-// SetNillableMetadataID sets the "metadata_id" field if the given value is not nil.
-func (tc *ToolCreate) SetNillableMetadataID(u *uuid.UUID) *ToolCreate {
-	if u != nil {
-		tc.SetMetadataID(*u)
-	}
-	return tc
-}
-
 // SetName sets the "name" field.
 func (tc *ToolCreate) SetName(s string) *ToolCreate {
 	tc.mutation.SetName(s)
@@ -166,6 +158,9 @@ func (tc *ToolCreate) check() error {
 	if _, ok := tc.mutation.ProtoMessage(); !ok {
 		return &ValidationError{Name: "proto_message", err: errors.New(`ent: missing required field "Tool.proto_message"`)}
 	}
+	if _, ok := tc.mutation.MetadataID(); !ok {
+		return &ValidationError{Name: "metadata_id", err: errors.New(`ent: missing required field "Tool.metadata_id"`)}
+	}
 	if _, ok := tc.mutation.Name(); !ok {
 		return &ValidationError{Name: "name", err: errors.New(`ent: missing required field "Tool.name"`)}
 	}
@@ -174,6 +169,9 @@ func (tc *ToolCreate) check() error {
 	}
 	if _, ok := tc.mutation.Vendor(); !ok {
 		return &ValidationError{Name: "vendor", err: errors.New(`ent: missing required field "Tool.vendor"`)}
+	}
+	if len(tc.mutation.MetadataIDs()) == 0 {
+		return &ValidationError{Name: "metadata", err: errors.New(`ent: missing required edge "Tool.metadata"`)}
 	}
 	return nil
 }
@@ -325,12 +323,6 @@ func (u *ToolUpsert) UpdateMetadataID() *ToolUpsert {
 	return u
 }
 
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (u *ToolUpsert) ClearMetadataID() *ToolUpsert {
-	u.SetNull(tool.FieldMetadataID)
-	return u
-}
-
 // SetName sets the "name" field.
 func (u *ToolUpsert) SetName(v string) *ToolUpsert {
 	u.Set(tool.FieldName, v)
@@ -432,13 +424,6 @@ func (u *ToolUpsertOne) SetMetadataID(v uuid.UUID) *ToolUpsertOne {
 func (u *ToolUpsertOne) UpdateMetadataID() *ToolUpsertOne {
 	return u.Update(func(s *ToolUpsert) {
 		s.UpdateMetadataID()
-	})
-}
-
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (u *ToolUpsertOne) ClearMetadataID() *ToolUpsertOne {
-	return u.Update(func(s *ToolUpsert) {
-		s.ClearMetadataID()
 	})
 }
 
@@ -716,13 +701,6 @@ func (u *ToolUpsertBulk) SetMetadataID(v uuid.UUID) *ToolUpsertBulk {
 func (u *ToolUpsertBulk) UpdateMetadataID() *ToolUpsertBulk {
 	return u.Update(func(s *ToolUpsert) {
 		s.UpdateMetadataID()
-	})
-}
-
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (u *ToolUpsertBulk) ClearMetadataID() *ToolUpsertBulk {
-	return u.Update(func(s *ToolUpsert) {
-		s.ClearMetadataID()
 	})
 }
 

--- a/internal/backends/ent/tool_update.go
+++ b/internal/backends/ent/tool_update.go
@@ -48,12 +48,6 @@ func (tu *ToolUpdate) SetNillableMetadataID(u *uuid.UUID) *ToolUpdate {
 	return tu
 }
 
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (tu *ToolUpdate) ClearMetadataID() *ToolUpdate {
-	tu.mutation.ClearMetadataID()
-	return tu
-}
-
 // SetName sets the "name" field.
 func (tu *ToolUpdate) SetName(s string) *ToolUpdate {
 	tu.mutation.SetName(s)
@@ -139,7 +133,18 @@ func (tu *ToolUpdate) ExecX(ctx context.Context) {
 	}
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (tu *ToolUpdate) check() error {
+	if tu.mutation.MetadataCleared() && len(tu.mutation.MetadataIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Tool.metadata"`)
+	}
+	return nil
+}
+
 func (tu *ToolUpdate) sqlSave(ctx context.Context) (n int, err error) {
+	if err := tu.check(); err != nil {
+		return n, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(tool.Table, tool.Columns, sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID))
 	if ps := tu.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
@@ -217,12 +222,6 @@ func (tuo *ToolUpdateOne) SetNillableMetadataID(u *uuid.UUID) *ToolUpdateOne {
 	if u != nil {
 		tuo.SetMetadataID(*u)
 	}
-	return tuo
-}
-
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (tuo *ToolUpdateOne) ClearMetadataID() *ToolUpdateOne {
-	tuo.mutation.ClearMetadataID()
 	return tuo
 }
 
@@ -324,7 +323,18 @@ func (tuo *ToolUpdateOne) ExecX(ctx context.Context) {
 	}
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (tuo *ToolUpdateOne) check() error {
+	if tuo.mutation.MetadataCleared() && len(tuo.mutation.MetadataIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Tool.metadata"`)
+	}
+	return nil
+}
+
 func (tuo *ToolUpdateOne) sqlSave(ctx context.Context) (_node *Tool, err error) {
+	if err := tuo.check(); err != nil {
+		return _node, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(tool.Table, tool.Columns, sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID))
 	id, ok := tuo.mutation.ID()
 	if !ok {


### PR DESCRIPTION
This PR sets all inverse/from edges to be required, meaning a child entity must always have a back-reference to its owner/parent.

In cases where a "one of" or "any of" relationship is defined, such as the `Annotation` type requiring one and only one of document or node ID (XOR), a schema hook has been added to validate that requirement.

> [!NOTE]
> Only the following files are manually modified; the rest are auto-generated
>
> - `backends/ent/*.go`
> - `internal/backends/ent/schema/*.go`

/cc @ashearin @lmphil @pkwiatkowski1 @Strakeln @jmayer-lm @EphraimEM