### PR TITLE
refactor: set all inverse edges to allow multiple parents 

### DIFF
--- a/backends/ent/annotations.go
+++ b/backends/ent/annotations.go
@@ -29,9 +29,9 @@ func (backend *Backend) AddAnnotationToDocuments(name, value string, documentIDs
 	}
 
 	docUUIDs, err := backend.client.Metadata.Query().
-		WithDocument().
+		WithDocuments().
 		Where(predicates...).
-		QueryDocument().
+		QueryDocuments().
 		IDs(backend.ctx)
 	if err != nil {
 		return fmt.Errorf("querying documents: %w", err)
@@ -80,9 +80,9 @@ func (backend *Backend) AddDocumentAnnotations(documentID, name string, values .
 	data := ent.Annotations{}
 
 	ids, err := backend.client.Metadata.Query().
-		WithDocument().
+		WithDocuments().
 		Where(metadata.NativeIDEQ(documentID)).
-		QueryDocument().
+		QueryDocuments().
 		IDs(backend.ctx)
 	if err != nil {
 		return fmt.Errorf("querying documents: %w", err)
@@ -132,9 +132,9 @@ func (backend *Backend) ClearDocumentAnnotations(documentIDs ...string) error {
 	}
 
 	docUUIDs, err := backend.client.Metadata.Query().
-		WithDocument().
+		WithDocuments().
 		Where(metadata.NativeIDIn(documentIDs...)).
-		QueryDocument().
+		QueryDocuments().
 		IDs(backend.ctx)
 	if err != nil {
 		return fmt.Errorf("querying document IDs: %w", err)
@@ -409,9 +409,9 @@ func (backend *Backend) SetDocumentAnnotations(documentID, name string, values .
 // SetDocumentUniqueAnnotation sets a named annotation value that is unique to the specified document.
 func (backend *Backend) SetDocumentUniqueAnnotation(documentID, name, value string) error {
 	ids, err := backend.client.Metadata.Query().
-		WithDocument().
+		WithDocuments().
 		Where(metadata.NativeIDEQ(documentID)).
-		QueryDocument().
+		QueryDocuments().
 		IDs(backend.ctx)
 	if err != nil {
 		return fmt.Errorf("%w", err)
@@ -454,7 +454,7 @@ func (backend *Backend) SetNodeUniqueAnnotation(nodeID, name, value string) erro
 	for idx := range nodes {
 		documentID, err := nodes[idx].
 			QueryNodeLists().
-			QueryDocument().
+			QueryDocuments().
 			OnlyID(backend.ctx)
 		if err != nil {
 			return fmt.Errorf("querying node edges for document ID: %w", err)

--- a/backends/ent/retrieve.go
+++ b/backends/ent/retrieve.go
@@ -53,9 +53,9 @@ func (backend *Backend) GetDocumentsByID(ids ...string) ([]*sbom.Document, error
 	documents := []*sbom.Document{}
 
 	docUUIDs, err := backend.client.Metadata.Query().
-		WithDocument().
+		WithDocuments().
 		Where(metadata.NativeIDIn(ids...)).
-		QueryDocument().
+		QueryDocuments().
 		IDs(backend.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("querying documents IDs: %w", err)
@@ -89,7 +89,7 @@ func (backend *Backend) GetExternalReferencesByDocumentID(
 	id string, types ...string,
 ) ([]*sbom.ExternalReference, error) {
 	predicates := []predicate.ExternalReference{
-		externalreference.HasDocumentWith(document.HasMetadataWith(metadata.NativeIDEQ(id))),
+		externalreference.HasDocumentsWith(document.HasMetadataWith(metadata.NativeIDEQ(id))),
 	}
 
 	extRefTypes := []externalreference.Type{}

--- a/backends/ent/store_test.go
+++ b/backends/ent/store_test.go
@@ -9,7 +9,6 @@ package ent_test
 import (
 	"os"
 	"path/filepath"
-	"slices"
 	"testing"
 
 	"github.com/protobom/protobom/pkg/reader"
@@ -83,9 +82,7 @@ func (ss *storeSuite) TestBackend_Store() {
 		msg, err := proto.MarshalOptions{Deterministic: true}.Marshal(document)
 		ss.Require().NoError(err)
 
-		ss.True(slices.ContainsFunc(messages, func(b []byte) bool {
-			return slices.Equal(msg, b)
-		}))
+		ss.Contains(messages, msg)
 	}
 }
 

--- a/internal/backends/ent/client.go
+++ b/internal/backends/ent/client.go
@@ -627,7 +627,7 @@ func (c *DocumentClient) QueryMetadata(d *Document) *MetadataQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(document.Table, document.FieldID, id),
 			sqlgraph.To(metadata.Table, metadata.FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, document.MetadataTable, document.MetadataColumn),
+			sqlgraph.Edge(sqlgraph.M2O, false, document.MetadataTable, document.MetadataColumn),
 		)
 		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
 		return fromV, nil
@@ -643,7 +643,183 @@ func (c *DocumentClient) QueryNodeList(d *Document) *NodeListQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(document.Table, document.FieldID, id),
 			sqlgraph.To(nodelist.Table, nodelist.FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, document.NodeListTable, document.NodeListColumn),
+			sqlgraph.Edge(sqlgraph.M2O, false, document.NodeListTable, document.NodeListColumn),
+		)
+		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryDocumentTypes queries the document_types edge of a Document.
+func (c *DocumentClient) QueryDocumentTypes(d *Document) *DocumentTypeQuery {
+	query := (&DocumentTypeClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := d.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(document.Table, document.FieldID, id),
+			sqlgraph.To(documenttype.Table, documenttype.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, document.DocumentTypesTable, document.DocumentTypesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryEdgeTypes queries the edge_types edge of a Document.
+func (c *DocumentClient) QueryEdgeTypes(d *Document) *EdgeTypeQuery {
+	query := (&EdgeTypeClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := d.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(document.Table, document.FieldID, id),
+			sqlgraph.To(edgetype.Table, edgetype.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, document.EdgeTypesTable, document.EdgeTypesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryExternalReferences queries the external_references edge of a Document.
+func (c *DocumentClient) QueryExternalReferences(d *Document) *ExternalReferenceQuery {
+	query := (&ExternalReferenceClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := d.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(document.Table, document.FieldID, id),
+			sqlgraph.To(externalreference.Table, externalreference.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, document.ExternalReferencesTable, document.ExternalReferencesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryHashes queries the hashes edge of a Document.
+func (c *DocumentClient) QueryHashes(d *Document) *HashesEntryQuery {
+	query := (&HashesEntryClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := d.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(document.Table, document.FieldID, id),
+			sqlgraph.To(hashesentry.Table, hashesentry.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, document.HashesTable, document.HashesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryIdentifiers queries the identifiers edge of a Document.
+func (c *DocumentClient) QueryIdentifiers(d *Document) *IdentifiersEntryQuery {
+	query := (&IdentifiersEntryClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := d.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(document.Table, document.FieldID, id),
+			sqlgraph.To(identifiersentry.Table, identifiersentry.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, document.IdentifiersTable, document.IdentifiersPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryNodes queries the nodes edge of a Document.
+func (c *DocumentClient) QueryNodes(d *Document) *NodeQuery {
+	query := (&NodeClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := d.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(document.Table, document.FieldID, id),
+			sqlgraph.To(node.Table, node.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, document.NodesTable, document.NodesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryPersons queries the persons edge of a Document.
+func (c *DocumentClient) QueryPersons(d *Document) *PersonQuery {
+	query := (&PersonClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := d.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(document.Table, document.FieldID, id),
+			sqlgraph.To(person.Table, person.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, document.PersonsTable, document.PersonsPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryProperties queries the properties edge of a Document.
+func (c *DocumentClient) QueryProperties(d *Document) *PropertyQuery {
+	query := (&PropertyClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := d.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(document.Table, document.FieldID, id),
+			sqlgraph.To(property.Table, property.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, document.PropertiesTable, document.PropertiesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryPurposes queries the purposes edge of a Document.
+func (c *DocumentClient) QueryPurposes(d *Document) *PurposeQuery {
+	query := (&PurposeClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := d.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(document.Table, document.FieldID, id),
+			sqlgraph.To(purpose.Table, purpose.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, document.PurposesTable, document.PurposesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QuerySourceData queries the source_data edge of a Document.
+func (c *DocumentClient) QuerySourceData(d *Document) *SourceDataQuery {
+	query := (&SourceDataClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := d.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(document.Table, document.FieldID, id),
+			sqlgraph.To(sourcedata.Table, sourcedata.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, document.SourceDataTable, document.SourceDataPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryTools queries the tools edge of a Document.
+func (c *DocumentClient) QueryTools(d *Document) *ToolQuery {
+	query := (&ToolClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := d.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(document.Table, document.FieldID, id),
+			sqlgraph.To(tool.Table, tool.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, document.ToolsTable, document.ToolsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
 		return fromV, nil
@@ -653,7 +829,8 @@ func (c *DocumentClient) QueryNodeList(d *Document) *NodeListQuery {
 
 // Hooks returns the client hooks.
 func (c *DocumentClient) Hooks() []Hook {
-	return c.hooks.Document
+	hooks := c.hooks.Document
+	return append(hooks[:len(hooks):len(hooks)], document.Hooks[:]...)
 }
 
 // Interceptors returns the client interceptors.
@@ -784,15 +961,15 @@ func (c *DocumentTypeClient) GetX(ctx context.Context, id uuid.UUID) *DocumentTy
 	return obj
 }
 
-// QueryDocument queries the document edge of a DocumentType.
-func (c *DocumentTypeClient) QueryDocument(dt *DocumentType) *DocumentQuery {
+// QueryDocuments queries the documents edge of a DocumentType.
+func (c *DocumentTypeClient) QueryDocuments(dt *DocumentType) *DocumentQuery {
 	query := (&DocumentClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := dt.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(documenttype.Table, documenttype.FieldID, id),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, documenttype.DocumentTable, documenttype.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, documenttype.DocumentsTable, documenttype.DocumentsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(dt.driver.Dialect(), step)
 		return fromV, nil
@@ -808,7 +985,7 @@ func (c *DocumentTypeClient) QueryMetadata(dt *DocumentType) *MetadataQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(documenttype.Table, documenttype.FieldID, id),
 			sqlgraph.To(metadata.Table, metadata.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, documenttype.MetadataTable, documenttype.MetadataColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, documenttype.MetadataTable, documenttype.MetadataPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(dt.driver.Dialect(), step)
 		return fromV, nil
@@ -950,22 +1127,6 @@ func (c *EdgeTypeClient) GetX(ctx context.Context, id uuid.UUID) *EdgeType {
 	return obj
 }
 
-// QueryDocument queries the document edge of a EdgeType.
-func (c *EdgeTypeClient) QueryDocument(et *EdgeType) *DocumentQuery {
-	query := (&DocumentClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := et.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(edgetype.Table, edgetype.FieldID, id),
-			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, edgetype.DocumentTable, edgetype.DocumentColumn),
-		)
-		fromV = sqlgraph.Neighbors(et.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
 // QueryFrom queries the from edge of a EdgeType.
 func (c *EdgeTypeClient) QueryFrom(et *EdgeType) *NodeQuery {
 	query := (&NodeClient{config: c.config}).Query()
@@ -991,6 +1152,22 @@ func (c *EdgeTypeClient) QueryTo(et *EdgeType) *NodeQuery {
 			sqlgraph.From(edgetype.Table, edgetype.FieldID, id),
 			sqlgraph.To(node.Table, node.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, false, edgetype.ToTable, edgetype.ToColumn),
+		)
+		fromV = sqlgraph.Neighbors(et.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryDocuments queries the documents edge of a EdgeType.
+func (c *EdgeTypeClient) QueryDocuments(et *EdgeType) *DocumentQuery {
+	query := (&DocumentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := et.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(edgetype.Table, edgetype.FieldID, id),
+			sqlgraph.To(document.Table, document.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, edgetype.DocumentsTable, edgetype.DocumentsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(et.driver.Dialect(), step)
 		return fromV, nil
@@ -1148,22 +1325,6 @@ func (c *ExternalReferenceClient) GetX(ctx context.Context, id uuid.UUID) *Exter
 	return obj
 }
 
-// QueryDocument queries the document edge of a ExternalReference.
-func (c *ExternalReferenceClient) QueryDocument(er *ExternalReference) *DocumentQuery {
-	query := (&DocumentClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := er.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(externalreference.Table, externalreference.FieldID, id),
-			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, externalreference.DocumentTable, externalreference.DocumentColumn),
-		)
-		fromV = sqlgraph.Neighbors(er.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
 // QueryHashes queries the hashes edge of a ExternalReference.
 func (c *ExternalReferenceClient) QueryHashes(er *ExternalReference) *HashesEntryQuery {
 	query := (&HashesEntryClient{config: c.config}).Query()
@@ -1173,6 +1334,22 @@ func (c *ExternalReferenceClient) QueryHashes(er *ExternalReference) *HashesEntr
 			sqlgraph.From(externalreference.Table, externalreference.FieldID, id),
 			sqlgraph.To(hashesentry.Table, hashesentry.FieldID),
 			sqlgraph.Edge(sqlgraph.M2M, false, externalreference.HashesTable, externalreference.HashesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(er.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryDocuments queries the documents edge of a ExternalReference.
+func (c *ExternalReferenceClient) QueryDocuments(er *ExternalReference) *DocumentQuery {
+	query := (&DocumentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := er.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(externalreference.Table, externalreference.FieldID, id),
+			sqlgraph.To(document.Table, document.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, externalreference.DocumentsTable, externalreference.DocumentsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(er.driver.Dialect(), step)
 		return fromV, nil
@@ -1330,15 +1507,15 @@ func (c *HashesEntryClient) GetX(ctx context.Context, id uuid.UUID) *HashesEntry
 	return obj
 }
 
-// QueryDocument queries the document edge of a HashesEntry.
-func (c *HashesEntryClient) QueryDocument(he *HashesEntry) *DocumentQuery {
+// QueryDocuments queries the documents edge of a HashesEntry.
+func (c *HashesEntryClient) QueryDocuments(he *HashesEntry) *DocumentQuery {
 	query := (&DocumentClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := he.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(hashesentry.Table, hashesentry.FieldID, id),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, hashesentry.DocumentTable, hashesentry.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, hashesentry.DocumentsTable, hashesentry.DocumentsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(he.driver.Dialect(), step)
 		return fromV, nil
@@ -1371,6 +1548,22 @@ func (c *HashesEntryClient) QueryNodes(he *HashesEntry) *NodeQuery {
 			sqlgraph.From(hashesentry.Table, hashesentry.FieldID, id),
 			sqlgraph.To(node.Table, node.FieldID),
 			sqlgraph.Edge(sqlgraph.M2M, true, hashesentry.NodesTable, hashesentry.NodesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(he.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QuerySourceData queries the source_data edge of a HashesEntry.
+func (c *HashesEntryClient) QuerySourceData(he *HashesEntry) *SourceDataQuery {
+	query := (&SourceDataClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := he.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(hashesentry.Table, hashesentry.FieldID, id),
+			sqlgraph.To(sourcedata.Table, sourcedata.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, hashesentry.SourceDataTable, hashesentry.SourceDataPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(he.driver.Dialect(), step)
 		return fromV, nil
@@ -1512,15 +1705,15 @@ func (c *IdentifiersEntryClient) GetX(ctx context.Context, id uuid.UUID) *Identi
 	return obj
 }
 
-// QueryDocument queries the document edge of a IdentifiersEntry.
-func (c *IdentifiersEntryClient) QueryDocument(ie *IdentifiersEntry) *DocumentQuery {
+// QueryDocuments queries the documents edge of a IdentifiersEntry.
+func (c *IdentifiersEntryClient) QueryDocuments(ie *IdentifiersEntry) *DocumentQuery {
 	query := (&DocumentClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ie.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(identifiersentry.Table, identifiersentry.FieldID, id),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, identifiersentry.DocumentTable, identifiersentry.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, identifiersentry.DocumentsTable, identifiersentry.DocumentsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(ie.driver.Dialect(), step)
 		return fromV, nil
@@ -1546,7 +1739,8 @@ func (c *IdentifiersEntryClient) QueryNodes(ie *IdentifiersEntry) *NodeQuery {
 
 // Hooks returns the client hooks.
 func (c *IdentifiersEntryClient) Hooks() []Hook {
-	return c.hooks.IdentifiersEntry
+	hooks := c.hooks.IdentifiersEntry
+	return append(hooks[:len(hooks):len(hooks)], identifiersentry.Hooks[:]...)
 }
 
 // Interceptors returns the client interceptors.
@@ -1677,22 +1871,6 @@ func (c *MetadataClient) GetX(ctx context.Context, id uuid.UUID) *Metadata {
 	return obj
 }
 
-// QueryDocument queries the document edge of a Metadata.
-func (c *MetadataClient) QueryDocument(m *Metadata) *DocumentQuery {
-	query := (&DocumentClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := m.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(metadata.Table, metadata.FieldID, id),
-			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, metadata.DocumentTable, metadata.DocumentColumn),
-		)
-		fromV = sqlgraph.Neighbors(m.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
 // QueryTools queries the tools edge of a Metadata.
 func (c *MetadataClient) QueryTools(m *Metadata) *ToolQuery {
 	query := (&ToolClient{config: c.config}).Query()
@@ -1701,7 +1879,7 @@ func (c *MetadataClient) QueryTools(m *Metadata) *ToolQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(metadata.Table, metadata.FieldID, id),
 			sqlgraph.To(tool.Table, tool.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, metadata.ToolsTable, metadata.ToolsColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, metadata.ToolsTable, metadata.ToolsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(m.driver.Dialect(), step)
 		return fromV, nil
@@ -1717,7 +1895,7 @@ func (c *MetadataClient) QueryAuthors(m *Metadata) *PersonQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(metadata.Table, metadata.FieldID, id),
 			sqlgraph.To(person.Table, person.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, metadata.AuthorsTable, metadata.AuthorsColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, metadata.AuthorsTable, metadata.AuthorsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(m.driver.Dialect(), step)
 		return fromV, nil
@@ -1733,7 +1911,7 @@ func (c *MetadataClient) QueryDocumentTypes(m *Metadata) *DocumentTypeQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(metadata.Table, metadata.FieldID, id),
 			sqlgraph.To(documenttype.Table, documenttype.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, metadata.DocumentTypesTable, metadata.DocumentTypesColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, metadata.DocumentTypesTable, metadata.DocumentTypesPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(m.driver.Dialect(), step)
 		return fromV, nil
@@ -1749,7 +1927,23 @@ func (c *MetadataClient) QuerySourceData(m *Metadata) *SourceDataQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(metadata.Table, metadata.FieldID, id),
 			sqlgraph.To(sourcedata.Table, sourcedata.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, metadata.SourceDataTable, metadata.SourceDataColumn),
+			sqlgraph.Edge(sqlgraph.M2O, false, metadata.SourceDataTable, metadata.SourceDataColumn),
+		)
+		fromV = sqlgraph.Neighbors(m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryDocuments queries the documents edge of a Metadata.
+func (c *MetadataClient) QueryDocuments(m *Metadata) *DocumentQuery {
+	query := (&DocumentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(metadata.Table, metadata.FieldID, id),
+			sqlgraph.To(document.Table, document.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, true, metadata.DocumentsTable, metadata.DocumentsColumn),
 		)
 		fromV = sqlgraph.Neighbors(m.driver.Dialect(), step)
 		return fromV, nil
@@ -1891,22 +2085,6 @@ func (c *NodeClient) GetX(ctx context.Context, id uuid.UUID) *Node {
 	return obj
 }
 
-// QueryDocument queries the document edge of a Node.
-func (c *NodeClient) QueryDocument(n *Node) *DocumentQuery {
-	query := (&DocumentClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := n.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(node.Table, node.FieldID, id),
-			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, node.DocumentTable, node.DocumentColumn),
-		)
-		fromV = sqlgraph.Neighbors(n.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
 // QueryAnnotations queries the annotations edge of a Node.
 func (c *NodeClient) QueryAnnotations(n *Node) *AnnotationQuery {
 	query := (&AnnotationClient{config: c.config}).Query()
@@ -1931,7 +2109,7 @@ func (c *NodeClient) QuerySuppliers(n *Node) *PersonQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(node.Table, node.FieldID, id),
 			sqlgraph.To(person.Table, person.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, node.SuppliersTable, node.SuppliersColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, node.SuppliersTable, node.SuppliersPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(n.driver.Dialect(), step)
 		return fromV, nil
@@ -1947,7 +2125,7 @@ func (c *NodeClient) QueryOriginators(n *Node) *PersonQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(node.Table, node.FieldID, id),
 			sqlgraph.To(person.Table, person.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, node.OriginatorsTable, node.OriginatorsColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, node.OriginatorsTable, node.OriginatorsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(n.driver.Dialect(), step)
 		return fromV, nil
@@ -1979,7 +2157,7 @@ func (c *NodeClient) QueryPrimaryPurpose(n *Node) *PurposeQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(node.Table, node.FieldID, id),
 			sqlgraph.To(purpose.Table, purpose.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, node.PrimaryPurposeTable, node.PrimaryPurposeColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, node.PrimaryPurposeTable, node.PrimaryPurposePrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(n.driver.Dialect(), step)
 		return fromV, nil
@@ -2059,7 +2237,23 @@ func (c *NodeClient) QueryProperties(n *Node) *PropertyQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(node.Table, node.FieldID, id),
 			sqlgraph.To(property.Table, property.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, node.PropertiesTable, node.PropertiesColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, node.PropertiesTable, node.PropertiesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(n.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryDocuments queries the documents edge of a Node.
+func (c *NodeClient) QueryDocuments(n *Node) *DocumentQuery {
+	query := (&DocumentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := n.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(node.Table, node.FieldID, id),
+			sqlgraph.To(document.Table, document.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, node.DocumentsTable, node.DocumentsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(n.driver.Dialect(), step)
 		return fromV, nil
@@ -2233,22 +2427,6 @@ func (c *NodeListClient) GetX(ctx context.Context, id uuid.UUID) *NodeList {
 	return obj
 }
 
-// QueryDocument queries the document edge of a NodeList.
-func (c *NodeListClient) QueryDocument(nl *NodeList) *DocumentQuery {
-	query := (&DocumentClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := nl.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(nodelist.Table, nodelist.FieldID, id),
-			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, nodelist.DocumentTable, nodelist.DocumentColumn),
-		)
-		fromV = sqlgraph.Neighbors(nl.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
 // QueryEdgeTypes queries the edge_types edge of a NodeList.
 func (c *NodeListClient) QueryEdgeTypes(nl *NodeList) *EdgeTypeQuery {
 	query := (&EdgeTypeClient{config: c.config}).Query()
@@ -2274,6 +2452,22 @@ func (c *NodeListClient) QueryNodes(nl *NodeList) *NodeQuery {
 			sqlgraph.From(nodelist.Table, nodelist.FieldID, id),
 			sqlgraph.To(node.Table, node.FieldID),
 			sqlgraph.Edge(sqlgraph.M2M, false, nodelist.NodesTable, nodelist.NodesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(nl.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryDocuments queries the documents edge of a NodeList.
+func (c *NodeListClient) QueryDocuments(nl *NodeList) *DocumentQuery {
+	query := (&DocumentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := nl.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(nodelist.Table, nodelist.FieldID, id),
+			sqlgraph.To(document.Table, document.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, true, nodelist.DocumentsTable, nodelist.DocumentsColumn),
 		)
 		fromV = sqlgraph.Neighbors(nl.driver.Dialect(), step)
 		return fromV, nil
@@ -2415,22 +2609,6 @@ func (c *PersonClient) GetX(ctx context.Context, id uuid.UUID) *Person {
 	return obj
 }
 
-// QueryDocument queries the document edge of a Person.
-func (c *PersonClient) QueryDocument(pe *Person) *DocumentQuery {
-	query := (&DocumentClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := pe.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(person.Table, person.FieldID, id),
-			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, person.DocumentTable, person.DocumentColumn),
-		)
-		fromV = sqlgraph.Neighbors(pe.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
 // QueryContactOwner queries the contact_owner edge of a Person.
 func (c *PersonClient) QueryContactOwner(pe *Person) *PersonQuery {
 	query := (&PersonClient{config: c.config}).Query()
@@ -2439,7 +2617,7 @@ func (c *PersonClient) QueryContactOwner(pe *Person) *PersonQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(person.Table, person.FieldID, id),
 			sqlgraph.To(person.Table, person.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, person.ContactOwnerTable, person.ContactOwnerColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, person.ContactOwnerTable, person.ContactOwnerPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(pe.driver.Dialect(), step)
 		return fromV, nil
@@ -2455,7 +2633,23 @@ func (c *PersonClient) QueryContacts(pe *Person) *PersonQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(person.Table, person.FieldID, id),
 			sqlgraph.To(person.Table, person.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, person.ContactsTable, person.ContactsColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, person.ContactsTable, person.ContactsPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(pe.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryDocuments queries the documents edge of a Person.
+func (c *PersonClient) QueryDocuments(pe *Person) *DocumentQuery {
+	query := (&DocumentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := pe.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(person.Table, person.FieldID, id),
+			sqlgraph.To(document.Table, document.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, person.DocumentsTable, person.DocumentsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(pe.driver.Dialect(), step)
 		return fromV, nil
@@ -2471,7 +2665,7 @@ func (c *PersonClient) QueryMetadata(pe *Person) *MetadataQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(person.Table, person.FieldID, id),
 			sqlgraph.To(metadata.Table, metadata.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, person.MetadataTable, person.MetadataColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, person.MetadataTable, person.MetadataPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(pe.driver.Dialect(), step)
 		return fromV, nil
@@ -2479,15 +2673,31 @@ func (c *PersonClient) QueryMetadata(pe *Person) *MetadataQuery {
 	return query
 }
 
-// QueryNode queries the node edge of a Person.
-func (c *PersonClient) QueryNode(pe *Person) *NodeQuery {
+// QueryOriginatorNodes queries the originator_nodes edge of a Person.
+func (c *PersonClient) QueryOriginatorNodes(pe *Person) *NodeQuery {
 	query := (&NodeClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(person.Table, person.FieldID, id),
 			sqlgraph.To(node.Table, node.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, person.NodeTable, person.NodeColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, person.OriginatorNodesTable, person.OriginatorNodesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(pe.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QuerySupplierNodes queries the supplier_nodes edge of a Person.
+func (c *PersonClient) QuerySupplierNodes(pe *Person) *NodeQuery {
+	query := (&NodeClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := pe.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(person.Table, person.FieldID, id),
+			sqlgraph.To(node.Table, node.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, person.SupplierNodesTable, person.SupplierNodesPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(pe.driver.Dialect(), step)
 		return fromV, nil
@@ -2629,15 +2839,15 @@ func (c *PropertyClient) GetX(ctx context.Context, id uuid.UUID) *Property {
 	return obj
 }
 
-// QueryDocument queries the document edge of a Property.
-func (c *PropertyClient) QueryDocument(pr *Property) *DocumentQuery {
+// QueryDocuments queries the documents edge of a Property.
+func (c *PropertyClient) QueryDocuments(pr *Property) *DocumentQuery {
 	query := (&DocumentClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(property.Table, property.FieldID, id),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, property.DocumentTable, property.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, property.DocumentsTable, property.DocumentsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
 		return fromV, nil
@@ -2645,15 +2855,15 @@ func (c *PropertyClient) QueryDocument(pr *Property) *DocumentQuery {
 	return query
 }
 
-// QueryNode queries the node edge of a Property.
-func (c *PropertyClient) QueryNode(pr *Property) *NodeQuery {
+// QueryNodes queries the nodes edge of a Property.
+func (c *PropertyClient) QueryNodes(pr *Property) *NodeQuery {
 	query := (&NodeClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(property.Table, property.FieldID, id),
 			sqlgraph.To(node.Table, node.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, property.NodeTable, property.NodeColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, property.NodesTable, property.NodesPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
 		return fromV, nil
@@ -2795,15 +3005,15 @@ func (c *PurposeClient) GetX(ctx context.Context, id int) *Purpose {
 	return obj
 }
 
-// QueryDocument queries the document edge of a Purpose.
-func (c *PurposeClient) QueryDocument(pu *Purpose) *DocumentQuery {
+// QueryDocuments queries the documents edge of a Purpose.
+func (c *PurposeClient) QueryDocuments(pu *Purpose) *DocumentQuery {
 	query := (&DocumentClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pu.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(purpose.Table, purpose.FieldID, id),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, purpose.DocumentTable, purpose.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, purpose.DocumentsTable, purpose.DocumentsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(pu.driver.Dialect(), step)
 		return fromV, nil
@@ -2811,15 +3021,15 @@ func (c *PurposeClient) QueryDocument(pu *Purpose) *DocumentQuery {
 	return query
 }
 
-// QueryNode queries the node edge of a Purpose.
-func (c *PurposeClient) QueryNode(pu *Purpose) *NodeQuery {
+// QueryNodes queries the nodes edge of a Purpose.
+func (c *PurposeClient) QueryNodes(pu *Purpose) *NodeQuery {
 	query := (&NodeClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pu.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(purpose.Table, purpose.FieldID, id),
 			sqlgraph.To(node.Table, node.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, purpose.NodeTable, purpose.NodeColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, purpose.NodesTable, purpose.NodesPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(pu.driver.Dialect(), step)
 		return fromV, nil
@@ -2960,15 +3170,31 @@ func (c *SourceDataClient) GetX(ctx context.Context, id uuid.UUID) *SourceData {
 	return obj
 }
 
-// QueryDocument queries the document edge of a SourceData.
-func (c *SourceDataClient) QueryDocument(sd *SourceData) *DocumentQuery {
+// QueryHashes queries the hashes edge of a SourceData.
+func (c *SourceDataClient) QueryHashes(sd *SourceData) *HashesEntryQuery {
+	query := (&HashesEntryClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := sd.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(sourcedata.Table, sourcedata.FieldID, id),
+			sqlgraph.To(hashesentry.Table, hashesentry.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, sourcedata.HashesTable, sourcedata.HashesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(sd.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryDocuments queries the documents edge of a SourceData.
+func (c *SourceDataClient) QueryDocuments(sd *SourceData) *DocumentQuery {
 	query := (&DocumentClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := sd.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(sourcedata.Table, sourcedata.FieldID, id),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, sourcedata.DocumentTable, sourcedata.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, sourcedata.DocumentsTable, sourcedata.DocumentsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(sd.driver.Dialect(), step)
 		return fromV, nil
@@ -2984,7 +3210,7 @@ func (c *SourceDataClient) QueryMetadata(sd *SourceData) *MetadataQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(sourcedata.Table, sourcedata.FieldID, id),
 			sqlgraph.To(metadata.Table, metadata.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, sourcedata.MetadataTable, sourcedata.MetadataColumn),
+			sqlgraph.Edge(sqlgraph.O2M, true, sourcedata.MetadataTable, sourcedata.MetadataColumn),
 		)
 		fromV = sqlgraph.Neighbors(sd.driver.Dialect(), step)
 		return fromV, nil
@@ -3126,15 +3352,15 @@ func (c *ToolClient) GetX(ctx context.Context, id uuid.UUID) *Tool {
 	return obj
 }
 
-// QueryDocument queries the document edge of a Tool.
-func (c *ToolClient) QueryDocument(t *Tool) *DocumentQuery {
+// QueryDocuments queries the documents edge of a Tool.
+func (c *ToolClient) QueryDocuments(t *Tool) *DocumentQuery {
 	query := (&DocumentClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(tool.Table, tool.FieldID, id),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, tool.DocumentTable, tool.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, tool.DocumentsTable, tool.DocumentsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(t.driver.Dialect(), step)
 		return fromV, nil
@@ -3150,7 +3376,7 @@ func (c *ToolClient) QueryMetadata(t *Tool) *MetadataQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(tool.Table, tool.FieldID, id),
 			sqlgraph.To(metadata.Table, metadata.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, tool.MetadataTable, tool.MetadataColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, tool.MetadataTable, tool.MetadataPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(t.driver.Dialect(), step)
 		return fromV, nil

--- a/internal/backends/ent/document.go
+++ b/internal/backends/ent/document.go
@@ -40,12 +40,34 @@ type DocumentEdges struct {
 	// Annotations holds the value of the annotations edge.
 	Annotations []*Annotation `json:"-"`
 	// Metadata holds the value of the metadata edge.
-	Metadata *Metadata `json:"-"`
+	Metadata *Metadata `json:"metadata,omitempty"`
 	// NodeList holds the value of the node_list edge.
-	NodeList *NodeList `json:"-"`
+	NodeList *NodeList `json:"node_list,omitempty"`
+	// DocumentTypes holds the value of the document_types edge.
+	DocumentTypes []*DocumentType `json:"document_types,omitempty"`
+	// EdgeTypes holds the value of the edge_types edge.
+	EdgeTypes []*EdgeType `json:"edge_types,omitempty"`
+	// ExternalReferences holds the value of the external_references edge.
+	ExternalReferences []*ExternalReference `json:"external_references,omitempty"`
+	// Hashes holds the value of the hashes edge.
+	Hashes []*HashesEntry `json:"hashes,omitempty"`
+	// Identifiers holds the value of the identifiers edge.
+	Identifiers []*IdentifiersEntry `json:"identifiers,omitempty"`
+	// Nodes holds the value of the nodes edge.
+	Nodes []*Node `json:"nodes,omitempty"`
+	// Persons holds the value of the persons edge.
+	Persons []*Person `json:"persons,omitempty"`
+	// Properties holds the value of the properties edge.
+	Properties []*Property `json:"properties,omitempty"`
+	// Purposes holds the value of the purposes edge.
+	Purposes []*Purpose `json:"purposes,omitempty"`
+	// SourceData holds the value of the source_data edge.
+	SourceData []*SourceData `json:"source_data,omitempty"`
+	// Tools holds the value of the tools edge.
+	Tools []*Tool `json:"tools,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [3]bool
+	loadedTypes [14]bool
 }
 
 // AnnotationsOrErr returns the Annotations value or an error if the edge
@@ -77,6 +99,105 @@ func (e DocumentEdges) NodeListOrErr() (*NodeList, error) {
 		return nil, &NotFoundError{label: nodelist.Label}
 	}
 	return nil, &NotLoadedError{edge: "node_list"}
+}
+
+// DocumentTypesOrErr returns the DocumentTypes value or an error if the edge
+// was not loaded in eager-loading.
+func (e DocumentEdges) DocumentTypesOrErr() ([]*DocumentType, error) {
+	if e.loadedTypes[3] {
+		return e.DocumentTypes, nil
+	}
+	return nil, &NotLoadedError{edge: "document_types"}
+}
+
+// EdgeTypesOrErr returns the EdgeTypes value or an error if the edge
+// was not loaded in eager-loading.
+func (e DocumentEdges) EdgeTypesOrErr() ([]*EdgeType, error) {
+	if e.loadedTypes[4] {
+		return e.EdgeTypes, nil
+	}
+	return nil, &NotLoadedError{edge: "edge_types"}
+}
+
+// ExternalReferencesOrErr returns the ExternalReferences value or an error if the edge
+// was not loaded in eager-loading.
+func (e DocumentEdges) ExternalReferencesOrErr() ([]*ExternalReference, error) {
+	if e.loadedTypes[5] {
+		return e.ExternalReferences, nil
+	}
+	return nil, &NotLoadedError{edge: "external_references"}
+}
+
+// HashesOrErr returns the Hashes value or an error if the edge
+// was not loaded in eager-loading.
+func (e DocumentEdges) HashesOrErr() ([]*HashesEntry, error) {
+	if e.loadedTypes[6] {
+		return e.Hashes, nil
+	}
+	return nil, &NotLoadedError{edge: "hashes"}
+}
+
+// IdentifiersOrErr returns the Identifiers value or an error if the edge
+// was not loaded in eager-loading.
+func (e DocumentEdges) IdentifiersOrErr() ([]*IdentifiersEntry, error) {
+	if e.loadedTypes[7] {
+		return e.Identifiers, nil
+	}
+	return nil, &NotLoadedError{edge: "identifiers"}
+}
+
+// NodesOrErr returns the Nodes value or an error if the edge
+// was not loaded in eager-loading.
+func (e DocumentEdges) NodesOrErr() ([]*Node, error) {
+	if e.loadedTypes[8] {
+		return e.Nodes, nil
+	}
+	return nil, &NotLoadedError{edge: "nodes"}
+}
+
+// PersonsOrErr returns the Persons value or an error if the edge
+// was not loaded in eager-loading.
+func (e DocumentEdges) PersonsOrErr() ([]*Person, error) {
+	if e.loadedTypes[9] {
+		return e.Persons, nil
+	}
+	return nil, &NotLoadedError{edge: "persons"}
+}
+
+// PropertiesOrErr returns the Properties value or an error if the edge
+// was not loaded in eager-loading.
+func (e DocumentEdges) PropertiesOrErr() ([]*Property, error) {
+	if e.loadedTypes[10] {
+		return e.Properties, nil
+	}
+	return nil, &NotLoadedError{edge: "properties"}
+}
+
+// PurposesOrErr returns the Purposes value or an error if the edge
+// was not loaded in eager-loading.
+func (e DocumentEdges) PurposesOrErr() ([]*Purpose, error) {
+	if e.loadedTypes[11] {
+		return e.Purposes, nil
+	}
+	return nil, &NotLoadedError{edge: "purposes"}
+}
+
+// SourceDataOrErr returns the SourceData value or an error if the edge
+// was not loaded in eager-loading.
+func (e DocumentEdges) SourceDataOrErr() ([]*SourceData, error) {
+	if e.loadedTypes[12] {
+		return e.SourceData, nil
+	}
+	return nil, &NotLoadedError{edge: "source_data"}
+}
+
+// ToolsOrErr returns the Tools value or an error if the edge
+// was not loaded in eager-loading.
+func (e DocumentEdges) ToolsOrErr() ([]*Tool, error) {
+	if e.loadedTypes[13] {
+		return e.Tools, nil
+	}
+	return nil, &NotLoadedError{edge: "tools"}
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -145,6 +266,61 @@ func (d *Document) QueryMetadata() *MetadataQuery {
 // QueryNodeList queries the "node_list" edge of the Document entity.
 func (d *Document) QueryNodeList() *NodeListQuery {
 	return NewDocumentClient(d.config).QueryNodeList(d)
+}
+
+// QueryDocumentTypes queries the "document_types" edge of the Document entity.
+func (d *Document) QueryDocumentTypes() *DocumentTypeQuery {
+	return NewDocumentClient(d.config).QueryDocumentTypes(d)
+}
+
+// QueryEdgeTypes queries the "edge_types" edge of the Document entity.
+func (d *Document) QueryEdgeTypes() *EdgeTypeQuery {
+	return NewDocumentClient(d.config).QueryEdgeTypes(d)
+}
+
+// QueryExternalReferences queries the "external_references" edge of the Document entity.
+func (d *Document) QueryExternalReferences() *ExternalReferenceQuery {
+	return NewDocumentClient(d.config).QueryExternalReferences(d)
+}
+
+// QueryHashes queries the "hashes" edge of the Document entity.
+func (d *Document) QueryHashes() *HashesEntryQuery {
+	return NewDocumentClient(d.config).QueryHashes(d)
+}
+
+// QueryIdentifiers queries the "identifiers" edge of the Document entity.
+func (d *Document) QueryIdentifiers() *IdentifiersEntryQuery {
+	return NewDocumentClient(d.config).QueryIdentifiers(d)
+}
+
+// QueryNodes queries the "nodes" edge of the Document entity.
+func (d *Document) QueryNodes() *NodeQuery {
+	return NewDocumentClient(d.config).QueryNodes(d)
+}
+
+// QueryPersons queries the "persons" edge of the Document entity.
+func (d *Document) QueryPersons() *PersonQuery {
+	return NewDocumentClient(d.config).QueryPersons(d)
+}
+
+// QueryProperties queries the "properties" edge of the Document entity.
+func (d *Document) QueryProperties() *PropertyQuery {
+	return NewDocumentClient(d.config).QueryProperties(d)
+}
+
+// QueryPurposes queries the "purposes" edge of the Document entity.
+func (d *Document) QueryPurposes() *PurposeQuery {
+	return NewDocumentClient(d.config).QueryPurposes(d)
+}
+
+// QuerySourceData queries the "source_data" edge of the Document entity.
+func (d *Document) QuerySourceData() *SourceDataQuery {
+	return NewDocumentClient(d.config).QuerySourceData(d)
+}
+
+// QueryTools queries the "tools" edge of the Document entity.
+func (d *Document) QueryTools() *ToolQuery {
+	return NewDocumentClient(d.config).QueryTools(d)
 }
 
 // Update returns a builder for updating this Document.

--- a/internal/backends/ent/document/document.go
+++ b/internal/backends/ent/document/document.go
@@ -8,6 +8,7 @@
 package document
 
 import (
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"github.com/google/uuid"
@@ -28,6 +29,28 @@ const (
 	EdgeMetadata = "metadata"
 	// EdgeNodeList holds the string denoting the node_list edge name in mutations.
 	EdgeNodeList = "node_list"
+	// EdgeDocumentTypes holds the string denoting the document_types edge name in mutations.
+	EdgeDocumentTypes = "document_types"
+	// EdgeEdgeTypes holds the string denoting the edge_types edge name in mutations.
+	EdgeEdgeTypes = "edge_types"
+	// EdgeExternalReferences holds the string denoting the external_references edge name in mutations.
+	EdgeExternalReferences = "external_references"
+	// EdgeHashes holds the string denoting the hashes edge name in mutations.
+	EdgeHashes = "hashes"
+	// EdgeIdentifiers holds the string denoting the identifiers edge name in mutations.
+	EdgeIdentifiers = "identifiers"
+	// EdgeNodes holds the string denoting the nodes edge name in mutations.
+	EdgeNodes = "nodes"
+	// EdgePersons holds the string denoting the persons edge name in mutations.
+	EdgePersons = "persons"
+	// EdgeProperties holds the string denoting the properties edge name in mutations.
+	EdgeProperties = "properties"
+	// EdgePurposes holds the string denoting the purposes edge name in mutations.
+	EdgePurposes = "purposes"
+	// EdgeSourceData holds the string denoting the source_data edge name in mutations.
+	EdgeSourceData = "source_data"
+	// EdgeTools holds the string denoting the tools edge name in mutations.
+	EdgeTools = "tools"
 	// Table holds the table name of the document in the database.
 	Table = "documents"
 	// AnnotationsTable is the table that holds the annotations relation/edge.
@@ -51,6 +74,61 @@ const (
 	NodeListInverseTable = "node_lists"
 	// NodeListColumn is the table column denoting the node_list relation/edge.
 	NodeListColumn = "node_list_id"
+	// DocumentTypesTable is the table that holds the document_types relation/edge. The primary key declared below.
+	DocumentTypesTable = "document_document_types"
+	// DocumentTypesInverseTable is the table name for the DocumentType entity.
+	// It exists in this package in order to avoid circular dependency with the "documenttype" package.
+	DocumentTypesInverseTable = "document_types"
+	// EdgeTypesTable is the table that holds the edge_types relation/edge. The primary key declared below.
+	EdgeTypesTable = "document_edge_types"
+	// EdgeTypesInverseTable is the table name for the EdgeType entity.
+	// It exists in this package in order to avoid circular dependency with the "edgetype" package.
+	EdgeTypesInverseTable = "edge_types"
+	// ExternalReferencesTable is the table that holds the external_references relation/edge. The primary key declared below.
+	ExternalReferencesTable = "document_external_references"
+	// ExternalReferencesInverseTable is the table name for the ExternalReference entity.
+	// It exists in this package in order to avoid circular dependency with the "externalreference" package.
+	ExternalReferencesInverseTable = "external_references"
+	// HashesTable is the table that holds the hashes relation/edge. The primary key declared below.
+	HashesTable = "document_hashes"
+	// HashesInverseTable is the table name for the HashesEntry entity.
+	// It exists in this package in order to avoid circular dependency with the "hashesentry" package.
+	HashesInverseTable = "hashes_entries"
+	// IdentifiersTable is the table that holds the identifiers relation/edge. The primary key declared below.
+	IdentifiersTable = "document_identifiers"
+	// IdentifiersInverseTable is the table name for the IdentifiersEntry entity.
+	// It exists in this package in order to avoid circular dependency with the "identifiersentry" package.
+	IdentifiersInverseTable = "identifiers_entries"
+	// NodesTable is the table that holds the nodes relation/edge. The primary key declared below.
+	NodesTable = "document_nodes"
+	// NodesInverseTable is the table name for the Node entity.
+	// It exists in this package in order to avoid circular dependency with the "node" package.
+	NodesInverseTable = "nodes"
+	// PersonsTable is the table that holds the persons relation/edge. The primary key declared below.
+	PersonsTable = "document_persons"
+	// PersonsInverseTable is the table name for the Person entity.
+	// It exists in this package in order to avoid circular dependency with the "person" package.
+	PersonsInverseTable = "persons"
+	// PropertiesTable is the table that holds the properties relation/edge. The primary key declared below.
+	PropertiesTable = "document_properties"
+	// PropertiesInverseTable is the table name for the Property entity.
+	// It exists in this package in order to avoid circular dependency with the "property" package.
+	PropertiesInverseTable = "properties"
+	// PurposesTable is the table that holds the purposes relation/edge. The primary key declared below.
+	PurposesTable = "document_purposes"
+	// PurposesInverseTable is the table name for the Purpose entity.
+	// It exists in this package in order to avoid circular dependency with the "purpose" package.
+	PurposesInverseTable = "purposes"
+	// SourceDataTable is the table that holds the source_data relation/edge. The primary key declared below.
+	SourceDataTable = "document_source_data"
+	// SourceDataInverseTable is the table name for the SourceData entity.
+	// It exists in this package in order to avoid circular dependency with the "sourcedata" package.
+	SourceDataInverseTable = "source_data"
+	// ToolsTable is the table that holds the tools relation/edge. The primary key declared below.
+	ToolsTable = "document_tools"
+	// ToolsInverseTable is the table name for the Tool entity.
+	// It exists in this package in order to avoid circular dependency with the "tool" package.
+	ToolsInverseTable = "tools"
 )
 
 // Columns holds all SQL columns for document fields.
@@ -59,6 +137,42 @@ var Columns = []string{
 	FieldMetadataID,
 	FieldNodeListID,
 }
+
+var (
+	// DocumentTypesPrimaryKey and DocumentTypesColumn2 are the table columns denoting the
+	// primary key for the document_types relation (M2M).
+	DocumentTypesPrimaryKey = []string{"document_id", "document_type_id"}
+	// EdgeTypesPrimaryKey and EdgeTypesColumn2 are the table columns denoting the
+	// primary key for the edge_types relation (M2M).
+	EdgeTypesPrimaryKey = []string{"document_id", "edge_type_id"}
+	// ExternalReferencesPrimaryKey and ExternalReferencesColumn2 are the table columns denoting the
+	// primary key for the external_references relation (M2M).
+	ExternalReferencesPrimaryKey = []string{"document_id", "external_reference_id"}
+	// HashesPrimaryKey and HashesColumn2 are the table columns denoting the
+	// primary key for the hashes relation (M2M).
+	HashesPrimaryKey = []string{"document_id", "hashes_entry_id"}
+	// IdentifiersPrimaryKey and IdentifiersColumn2 are the table columns denoting the
+	// primary key for the identifiers relation (M2M).
+	IdentifiersPrimaryKey = []string{"document_id", "identifiers_entry_id"}
+	// NodesPrimaryKey and NodesColumn2 are the table columns denoting the
+	// primary key for the nodes relation (M2M).
+	NodesPrimaryKey = []string{"document_id", "node_id"}
+	// PersonsPrimaryKey and PersonsColumn2 are the table columns denoting the
+	// primary key for the persons relation (M2M).
+	PersonsPrimaryKey = []string{"document_id", "person_id"}
+	// PropertiesPrimaryKey and PropertiesColumn2 are the table columns denoting the
+	// primary key for the properties relation (M2M).
+	PropertiesPrimaryKey = []string{"document_id", "property_id"}
+	// PurposesPrimaryKey and PurposesColumn2 are the table columns denoting the
+	// primary key for the purposes relation (M2M).
+	PurposesPrimaryKey = []string{"document_id", "purpose_id"}
+	// SourceDataPrimaryKey and SourceDataColumn2 are the table columns denoting the
+	// primary key for the source_data relation (M2M).
+	SourceDataPrimaryKey = []string{"document_id", "source_data_id"}
+	// ToolsPrimaryKey and ToolsColumn2 are the table columns denoting the
+	// primary key for the tools relation (M2M).
+	ToolsPrimaryKey = []string{"document_id", "tool_id"}
+)
 
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
@@ -70,7 +184,13 @@ func ValidColumn(column string) bool {
 	return false
 }
 
+// Note that the variables below are initialized by the runtime
+// package on the initialization of the application. Therefore,
+// it should be imported in the main as follows:
+//
+//	import _ "github.com/protobom/storage/internal/backends/ent/runtime"
 var (
+	Hooks [1]ent.Hook
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() uuid.UUID
 )
@@ -120,6 +240,160 @@ func ByNodeListField(field string, opts ...sql.OrderTermOption) OrderOption {
 		sqlgraph.OrderByNeighborTerms(s, newNodeListStep(), sql.OrderByField(field, opts...))
 	}
 }
+
+// ByDocumentTypesCount orders the results by document_types count.
+func ByDocumentTypesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newDocumentTypesStep(), opts...)
+	}
+}
+
+// ByDocumentTypes orders the results by document_types terms.
+func ByDocumentTypes(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newDocumentTypesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByEdgeTypesCount orders the results by edge_types count.
+func ByEdgeTypesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newEdgeTypesStep(), opts...)
+	}
+}
+
+// ByEdgeTypes orders the results by edge_types terms.
+func ByEdgeTypes(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newEdgeTypesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByExternalReferencesCount orders the results by external_references count.
+func ByExternalReferencesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newExternalReferencesStep(), opts...)
+	}
+}
+
+// ByExternalReferences orders the results by external_references terms.
+func ByExternalReferences(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newExternalReferencesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByHashesCount orders the results by hashes count.
+func ByHashesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newHashesStep(), opts...)
+	}
+}
+
+// ByHashes orders the results by hashes terms.
+func ByHashes(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newHashesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByIdentifiersCount orders the results by identifiers count.
+func ByIdentifiersCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newIdentifiersStep(), opts...)
+	}
+}
+
+// ByIdentifiers orders the results by identifiers terms.
+func ByIdentifiers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newIdentifiersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByNodesCount orders the results by nodes count.
+func ByNodesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newNodesStep(), opts...)
+	}
+}
+
+// ByNodes orders the results by nodes terms.
+func ByNodes(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newNodesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByPersonsCount orders the results by persons count.
+func ByPersonsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newPersonsStep(), opts...)
+	}
+}
+
+// ByPersons orders the results by persons terms.
+func ByPersons(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPersonsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByPropertiesCount orders the results by properties count.
+func ByPropertiesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newPropertiesStep(), opts...)
+	}
+}
+
+// ByProperties orders the results by properties terms.
+func ByProperties(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPropertiesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByPurposesCount orders the results by purposes count.
+func ByPurposesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newPurposesStep(), opts...)
+	}
+}
+
+// ByPurposes orders the results by purposes terms.
+func ByPurposes(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPurposesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// BySourceDataCount orders the results by source_data count.
+func BySourceDataCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newSourceDataStep(), opts...)
+	}
+}
+
+// BySourceData orders the results by source_data terms.
+func BySourceData(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newSourceDataStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByToolsCount orders the results by tools count.
+func ByToolsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newToolsStep(), opts...)
+	}
+}
+
+// ByTools orders the results by tools terms.
+func ByTools(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newToolsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
 func newAnnotationsStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
@@ -131,13 +405,90 @@ func newMetadataStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(MetadataInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2O, true, MetadataTable, MetadataColumn),
+		sqlgraph.Edge(sqlgraph.M2O, false, MetadataTable, MetadataColumn),
 	)
 }
 func newNodeListStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(NodeListInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2O, true, NodeListTable, NodeListColumn),
+		sqlgraph.Edge(sqlgraph.M2O, false, NodeListTable, NodeListColumn),
+	)
+}
+func newDocumentTypesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(DocumentTypesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, DocumentTypesTable, DocumentTypesPrimaryKey...),
+	)
+}
+func newEdgeTypesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(EdgeTypesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, EdgeTypesTable, EdgeTypesPrimaryKey...),
+	)
+}
+func newExternalReferencesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ExternalReferencesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, ExternalReferencesTable, ExternalReferencesPrimaryKey...),
+	)
+}
+func newHashesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(HashesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, HashesTable, HashesPrimaryKey...),
+	)
+}
+func newIdentifiersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(IdentifiersInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, IdentifiersTable, IdentifiersPrimaryKey...),
+	)
+}
+func newNodesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(NodesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, NodesTable, NodesPrimaryKey...),
+	)
+}
+func newPersonsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PersonsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, PersonsTable, PersonsPrimaryKey...),
+	)
+}
+func newPropertiesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PropertiesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, PropertiesTable, PropertiesPrimaryKey...),
+	)
+}
+func newPurposesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PurposesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, PurposesTable, PurposesPrimaryKey...),
+	)
+}
+func newSourceDataStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(SourceDataInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, SourceDataTable, SourceDataPrimaryKey...),
+	)
+}
+func newToolsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ToolsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, ToolsTable, ToolsPrimaryKey...),
 	)
 }

--- a/internal/backends/ent/document/where.go
+++ b/internal/backends/ent/document/where.go
@@ -157,7 +157,7 @@ func HasMetadata() predicate.Document {
 	return predicate.Document(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, MetadataTable, MetadataColumn),
+			sqlgraph.Edge(sqlgraph.M2O, false, MetadataTable, MetadataColumn),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -180,7 +180,7 @@ func HasNodeList() predicate.Document {
 	return predicate.Document(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, NodeListTable, NodeListColumn),
+			sqlgraph.Edge(sqlgraph.M2O, false, NodeListTable, NodeListColumn),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -190,6 +190,259 @@ func HasNodeList() predicate.Document {
 func HasNodeListWith(preds ...predicate.NodeList) predicate.Document {
 	return predicate.Document(func(s *sql.Selector) {
 		step := newNodeListStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasDocumentTypes applies the HasEdge predicate on the "document_types" edge.
+func HasDocumentTypes() predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, DocumentTypesTable, DocumentTypesPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasDocumentTypesWith applies the HasEdge predicate on the "document_types" edge with a given conditions (other predicates).
+func HasDocumentTypesWith(preds ...predicate.DocumentType) predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := newDocumentTypesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasEdgeTypes applies the HasEdge predicate on the "edge_types" edge.
+func HasEdgeTypes() predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, EdgeTypesTable, EdgeTypesPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasEdgeTypesWith applies the HasEdge predicate on the "edge_types" edge with a given conditions (other predicates).
+func HasEdgeTypesWith(preds ...predicate.EdgeType) predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := newEdgeTypesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasExternalReferences applies the HasEdge predicate on the "external_references" edge.
+func HasExternalReferences() predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, ExternalReferencesTable, ExternalReferencesPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasExternalReferencesWith applies the HasEdge predicate on the "external_references" edge with a given conditions (other predicates).
+func HasExternalReferencesWith(preds ...predicate.ExternalReference) predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := newExternalReferencesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasHashes applies the HasEdge predicate on the "hashes" edge.
+func HasHashes() predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, HashesTable, HashesPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasHashesWith applies the HasEdge predicate on the "hashes" edge with a given conditions (other predicates).
+func HasHashesWith(preds ...predicate.HashesEntry) predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := newHashesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasIdentifiers applies the HasEdge predicate on the "identifiers" edge.
+func HasIdentifiers() predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, IdentifiersTable, IdentifiersPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasIdentifiersWith applies the HasEdge predicate on the "identifiers" edge with a given conditions (other predicates).
+func HasIdentifiersWith(preds ...predicate.IdentifiersEntry) predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := newIdentifiersStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasNodes applies the HasEdge predicate on the "nodes" edge.
+func HasNodes() predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, NodesTable, NodesPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasNodesWith applies the HasEdge predicate on the "nodes" edge with a given conditions (other predicates).
+func HasNodesWith(preds ...predicate.Node) predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := newNodesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasPersons applies the HasEdge predicate on the "persons" edge.
+func HasPersons() predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, PersonsTable, PersonsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasPersonsWith applies the HasEdge predicate on the "persons" edge with a given conditions (other predicates).
+func HasPersonsWith(preds ...predicate.Person) predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := newPersonsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasProperties applies the HasEdge predicate on the "properties" edge.
+func HasProperties() predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, PropertiesTable, PropertiesPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasPropertiesWith applies the HasEdge predicate on the "properties" edge with a given conditions (other predicates).
+func HasPropertiesWith(preds ...predicate.Property) predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := newPropertiesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasPurposes applies the HasEdge predicate on the "purposes" edge.
+func HasPurposes() predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, PurposesTable, PurposesPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasPurposesWith applies the HasEdge predicate on the "purposes" edge with a given conditions (other predicates).
+func HasPurposesWith(preds ...predicate.Purpose) predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := newPurposesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasSourceData applies the HasEdge predicate on the "source_data" edge.
+func HasSourceData() predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, SourceDataTable, SourceDataPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasSourceDataWith applies the HasEdge predicate on the "source_data" edge with a given conditions (other predicates).
+func HasSourceDataWith(preds ...predicate.SourceData) predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := newSourceDataStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasTools applies the HasEdge predicate on the "tools" edge.
+func HasTools() predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, ToolsTable, ToolsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasToolsWith applies the HasEdge predicate on the "tools" edge with a given conditions (other predicates).
+func HasToolsWith(preds ...predicate.Tool) predicate.Document {
+	return predicate.Document(func(s *sql.Selector) {
+		step := newToolsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/backends/ent/document_create.go
+++ b/internal/backends/ent/document_create.go
@@ -19,8 +19,19 @@ import (
 	"github.com/google/uuid"
 	"github.com/protobom/storage/internal/backends/ent/annotation"
 	"github.com/protobom/storage/internal/backends/ent/document"
+	"github.com/protobom/storage/internal/backends/ent/documenttype"
+	"github.com/protobom/storage/internal/backends/ent/edgetype"
+	"github.com/protobom/storage/internal/backends/ent/externalreference"
+	"github.com/protobom/storage/internal/backends/ent/hashesentry"
+	"github.com/protobom/storage/internal/backends/ent/identifiersentry"
 	"github.com/protobom/storage/internal/backends/ent/metadata"
+	"github.com/protobom/storage/internal/backends/ent/node"
 	"github.com/protobom/storage/internal/backends/ent/nodelist"
+	"github.com/protobom/storage/internal/backends/ent/person"
+	"github.com/protobom/storage/internal/backends/ent/property"
+	"github.com/protobom/storage/internal/backends/ent/purpose"
+	"github.com/protobom/storage/internal/backends/ent/sourcedata"
+	"github.com/protobom/storage/internal/backends/ent/tool"
 )
 
 // DocumentCreate is the builder for creating a Document entity.
@@ -98,6 +109,171 @@ func (dc *DocumentCreate) SetNodeList(n *NodeList) *DocumentCreate {
 	return dc.SetNodeListID(n.ID)
 }
 
+// AddDocumentTypeIDs adds the "document_types" edge to the DocumentType entity by IDs.
+func (dc *DocumentCreate) AddDocumentTypeIDs(ids ...uuid.UUID) *DocumentCreate {
+	dc.mutation.AddDocumentTypeIDs(ids...)
+	return dc
+}
+
+// AddDocumentTypes adds the "document_types" edges to the DocumentType entity.
+func (dc *DocumentCreate) AddDocumentTypes(d ...*DocumentType) *DocumentCreate {
+	ids := make([]uuid.UUID, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return dc.AddDocumentTypeIDs(ids...)
+}
+
+// AddEdgeTypeIDs adds the "edge_types" edge to the EdgeType entity by IDs.
+func (dc *DocumentCreate) AddEdgeTypeIDs(ids ...uuid.UUID) *DocumentCreate {
+	dc.mutation.AddEdgeTypeIDs(ids...)
+	return dc
+}
+
+// AddEdgeTypes adds the "edge_types" edges to the EdgeType entity.
+func (dc *DocumentCreate) AddEdgeTypes(e ...*EdgeType) *DocumentCreate {
+	ids := make([]uuid.UUID, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return dc.AddEdgeTypeIDs(ids...)
+}
+
+// AddExternalReferenceIDs adds the "external_references" edge to the ExternalReference entity by IDs.
+func (dc *DocumentCreate) AddExternalReferenceIDs(ids ...uuid.UUID) *DocumentCreate {
+	dc.mutation.AddExternalReferenceIDs(ids...)
+	return dc
+}
+
+// AddExternalReferences adds the "external_references" edges to the ExternalReference entity.
+func (dc *DocumentCreate) AddExternalReferences(e ...*ExternalReference) *DocumentCreate {
+	ids := make([]uuid.UUID, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return dc.AddExternalReferenceIDs(ids...)
+}
+
+// AddHashIDs adds the "hashes" edge to the HashesEntry entity by IDs.
+func (dc *DocumentCreate) AddHashIDs(ids ...uuid.UUID) *DocumentCreate {
+	dc.mutation.AddHashIDs(ids...)
+	return dc
+}
+
+// AddHashes adds the "hashes" edges to the HashesEntry entity.
+func (dc *DocumentCreate) AddHashes(h ...*HashesEntry) *DocumentCreate {
+	ids := make([]uuid.UUID, len(h))
+	for i := range h {
+		ids[i] = h[i].ID
+	}
+	return dc.AddHashIDs(ids...)
+}
+
+// AddIdentifierIDs adds the "identifiers" edge to the IdentifiersEntry entity by IDs.
+func (dc *DocumentCreate) AddIdentifierIDs(ids ...uuid.UUID) *DocumentCreate {
+	dc.mutation.AddIdentifierIDs(ids...)
+	return dc
+}
+
+// AddIdentifiers adds the "identifiers" edges to the IdentifiersEntry entity.
+func (dc *DocumentCreate) AddIdentifiers(i ...*IdentifiersEntry) *DocumentCreate {
+	ids := make([]uuid.UUID, len(i))
+	for j := range i {
+		ids[j] = i[j].ID
+	}
+	return dc.AddIdentifierIDs(ids...)
+}
+
+// AddNodeIDs adds the "nodes" edge to the Node entity by IDs.
+func (dc *DocumentCreate) AddNodeIDs(ids ...uuid.UUID) *DocumentCreate {
+	dc.mutation.AddNodeIDs(ids...)
+	return dc
+}
+
+// AddNodes adds the "nodes" edges to the Node entity.
+func (dc *DocumentCreate) AddNodes(n ...*Node) *DocumentCreate {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return dc.AddNodeIDs(ids...)
+}
+
+// AddPersonIDs adds the "persons" edge to the Person entity by IDs.
+func (dc *DocumentCreate) AddPersonIDs(ids ...uuid.UUID) *DocumentCreate {
+	dc.mutation.AddPersonIDs(ids...)
+	return dc
+}
+
+// AddPersons adds the "persons" edges to the Person entity.
+func (dc *DocumentCreate) AddPersons(p ...*Person) *DocumentCreate {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return dc.AddPersonIDs(ids...)
+}
+
+// AddPropertyIDs adds the "properties" edge to the Property entity by IDs.
+func (dc *DocumentCreate) AddPropertyIDs(ids ...uuid.UUID) *DocumentCreate {
+	dc.mutation.AddPropertyIDs(ids...)
+	return dc
+}
+
+// AddProperties adds the "properties" edges to the Property entity.
+func (dc *DocumentCreate) AddProperties(p ...*Property) *DocumentCreate {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return dc.AddPropertyIDs(ids...)
+}
+
+// AddPurposeIDs adds the "purposes" edge to the Purpose entity by IDs.
+func (dc *DocumentCreate) AddPurposeIDs(ids ...int) *DocumentCreate {
+	dc.mutation.AddPurposeIDs(ids...)
+	return dc
+}
+
+// AddPurposes adds the "purposes" edges to the Purpose entity.
+func (dc *DocumentCreate) AddPurposes(p ...*Purpose) *DocumentCreate {
+	ids := make([]int, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return dc.AddPurposeIDs(ids...)
+}
+
+// AddSourceDatumIDs adds the "source_data" edge to the SourceData entity by IDs.
+func (dc *DocumentCreate) AddSourceDatumIDs(ids ...uuid.UUID) *DocumentCreate {
+	dc.mutation.AddSourceDatumIDs(ids...)
+	return dc
+}
+
+// AddSourceData adds the "source_data" edges to the SourceData entity.
+func (dc *DocumentCreate) AddSourceData(s ...*SourceData) *DocumentCreate {
+	ids := make([]uuid.UUID, len(s))
+	for i := range s {
+		ids[i] = s[i].ID
+	}
+	return dc.AddSourceDatumIDs(ids...)
+}
+
+// AddToolIDs adds the "tools" edge to the Tool entity by IDs.
+func (dc *DocumentCreate) AddToolIDs(ids ...uuid.UUID) *DocumentCreate {
+	dc.mutation.AddToolIDs(ids...)
+	return dc
+}
+
+// AddTools adds the "tools" edges to the Tool entity.
+func (dc *DocumentCreate) AddTools(t ...*Tool) *DocumentCreate {
+	ids := make([]uuid.UUID, len(t))
+	for i := range t {
+		ids[i] = t[i].ID
+	}
+	return dc.AddToolIDs(ids...)
+}
+
 // Mutation returns the DocumentMutation object of the builder.
 func (dc *DocumentCreate) Mutation() *DocumentMutation {
 	return dc.mutation
@@ -105,7 +281,9 @@ func (dc *DocumentCreate) Mutation() *DocumentMutation {
 
 // Save creates the Document in the database.
 func (dc *DocumentCreate) Save(ctx context.Context) (*Document, error) {
-	dc.defaults()
+	if err := dc.defaults(); err != nil {
+		return nil, err
+	}
 	return withHooks(ctx, dc.sqlSave, dc.mutation, dc.hooks)
 }
 
@@ -132,11 +310,15 @@ func (dc *DocumentCreate) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (dc *DocumentCreate) defaults() {
+func (dc *DocumentCreate) defaults() error {
 	if _, ok := dc.mutation.ID(); !ok {
+		if document.DefaultID == nil {
+			return fmt.Errorf("ent: uninitialized document.DefaultID (forgotten import ent/runtime?)")
+		}
 		v := document.DefaultID()
 		dc.mutation.SetID(v)
 	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -195,8 +377,8 @@ func (dc *DocumentCreate) createSpec() (*Document, *sqlgraph.CreateSpec) {
 	}
 	if nodes := dc.mutation.MetadataIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2O,
-			Inverse: true,
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
 			Table:   document.MetadataTable,
 			Columns: []string{document.MetadataColumn},
 			Bidi:    false,
@@ -212,8 +394,8 @@ func (dc *DocumentCreate) createSpec() (*Document, *sqlgraph.CreateSpec) {
 	}
 	if nodes := dc.mutation.NodeListIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2O,
-			Inverse: true,
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
 			Table:   document.NodeListTable,
 			Columns: []string{document.NodeListColumn},
 			Bidi:    false,
@@ -225,6 +407,182 @@ func (dc *DocumentCreate) createSpec() (*Document, *sqlgraph.CreateSpec) {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.NodeListID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := dc.mutation.DocumentTypesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.DocumentTypesTable,
+			Columns: document.DocumentTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(documenttype.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := dc.mutation.EdgeTypesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.EdgeTypesTable,
+			Columns: document.EdgeTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(edgetype.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := dc.mutation.ExternalReferencesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ExternalReferencesTable,
+			Columns: document.ExternalReferencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(externalreference.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := dc.mutation.HashesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.HashesTable,
+			Columns: document.HashesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(hashesentry.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := dc.mutation.IdentifiersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.IdentifiersTable,
+			Columns: document.IdentifiersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(identifiersentry.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := dc.mutation.NodesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.NodesTable,
+			Columns: document.NodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := dc.mutation.PersonsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PersonsTable,
+			Columns: document.PersonsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := dc.mutation.PropertiesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PropertiesTable,
+			Columns: document.PropertiesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := dc.mutation.PurposesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PurposesTable,
+			Columns: document.PurposesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(purpose.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := dc.mutation.SourceDataIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.SourceDataTable,
+			Columns: document.SourceDataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := dc.mutation.ToolsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ToolsTable,
+			Columns: document.ToolsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/internal/backends/ent/document_update.go
+++ b/internal/backends/ent/document_update.go
@@ -15,9 +15,21 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 	"github.com/protobom/storage/internal/backends/ent/annotation"
 	"github.com/protobom/storage/internal/backends/ent/document"
+	"github.com/protobom/storage/internal/backends/ent/documenttype"
+	"github.com/protobom/storage/internal/backends/ent/edgetype"
+	"github.com/protobom/storage/internal/backends/ent/externalreference"
+	"github.com/protobom/storage/internal/backends/ent/hashesentry"
+	"github.com/protobom/storage/internal/backends/ent/identifiersentry"
+	"github.com/protobom/storage/internal/backends/ent/node"
+	"github.com/protobom/storage/internal/backends/ent/person"
 	"github.com/protobom/storage/internal/backends/ent/predicate"
+	"github.com/protobom/storage/internal/backends/ent/property"
+	"github.com/protobom/storage/internal/backends/ent/purpose"
+	"github.com/protobom/storage/internal/backends/ent/sourcedata"
+	"github.com/protobom/storage/internal/backends/ent/tool"
 )
 
 // DocumentUpdate is the builder for updating Document entities.
@@ -48,6 +60,171 @@ func (du *DocumentUpdate) AddAnnotations(a ...*Annotation) *DocumentUpdate {
 	return du.AddAnnotationIDs(ids...)
 }
 
+// AddDocumentTypeIDs adds the "document_types" edge to the DocumentType entity by IDs.
+func (du *DocumentUpdate) AddDocumentTypeIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.AddDocumentTypeIDs(ids...)
+	return du
+}
+
+// AddDocumentTypes adds the "document_types" edges to the DocumentType entity.
+func (du *DocumentUpdate) AddDocumentTypes(d ...*DocumentType) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return du.AddDocumentTypeIDs(ids...)
+}
+
+// AddEdgeTypeIDs adds the "edge_types" edge to the EdgeType entity by IDs.
+func (du *DocumentUpdate) AddEdgeTypeIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.AddEdgeTypeIDs(ids...)
+	return du
+}
+
+// AddEdgeTypes adds the "edge_types" edges to the EdgeType entity.
+func (du *DocumentUpdate) AddEdgeTypes(e ...*EdgeType) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return du.AddEdgeTypeIDs(ids...)
+}
+
+// AddExternalReferenceIDs adds the "external_references" edge to the ExternalReference entity by IDs.
+func (du *DocumentUpdate) AddExternalReferenceIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.AddExternalReferenceIDs(ids...)
+	return du
+}
+
+// AddExternalReferences adds the "external_references" edges to the ExternalReference entity.
+func (du *DocumentUpdate) AddExternalReferences(e ...*ExternalReference) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return du.AddExternalReferenceIDs(ids...)
+}
+
+// AddHashIDs adds the "hashes" edge to the HashesEntry entity by IDs.
+func (du *DocumentUpdate) AddHashIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.AddHashIDs(ids...)
+	return du
+}
+
+// AddHashes adds the "hashes" edges to the HashesEntry entity.
+func (du *DocumentUpdate) AddHashes(h ...*HashesEntry) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(h))
+	for i := range h {
+		ids[i] = h[i].ID
+	}
+	return du.AddHashIDs(ids...)
+}
+
+// AddIdentifierIDs adds the "identifiers" edge to the IdentifiersEntry entity by IDs.
+func (du *DocumentUpdate) AddIdentifierIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.AddIdentifierIDs(ids...)
+	return du
+}
+
+// AddIdentifiers adds the "identifiers" edges to the IdentifiersEntry entity.
+func (du *DocumentUpdate) AddIdentifiers(i ...*IdentifiersEntry) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(i))
+	for j := range i {
+		ids[j] = i[j].ID
+	}
+	return du.AddIdentifierIDs(ids...)
+}
+
+// AddNodeIDs adds the "nodes" edge to the Node entity by IDs.
+func (du *DocumentUpdate) AddNodeIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.AddNodeIDs(ids...)
+	return du
+}
+
+// AddNodes adds the "nodes" edges to the Node entity.
+func (du *DocumentUpdate) AddNodes(n ...*Node) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return du.AddNodeIDs(ids...)
+}
+
+// AddPersonIDs adds the "persons" edge to the Person entity by IDs.
+func (du *DocumentUpdate) AddPersonIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.AddPersonIDs(ids...)
+	return du
+}
+
+// AddPersons adds the "persons" edges to the Person entity.
+func (du *DocumentUpdate) AddPersons(p ...*Person) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return du.AddPersonIDs(ids...)
+}
+
+// AddPropertyIDs adds the "properties" edge to the Property entity by IDs.
+func (du *DocumentUpdate) AddPropertyIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.AddPropertyIDs(ids...)
+	return du
+}
+
+// AddProperties adds the "properties" edges to the Property entity.
+func (du *DocumentUpdate) AddProperties(p ...*Property) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return du.AddPropertyIDs(ids...)
+}
+
+// AddPurposeIDs adds the "purposes" edge to the Purpose entity by IDs.
+func (du *DocumentUpdate) AddPurposeIDs(ids ...int) *DocumentUpdate {
+	du.mutation.AddPurposeIDs(ids...)
+	return du
+}
+
+// AddPurposes adds the "purposes" edges to the Purpose entity.
+func (du *DocumentUpdate) AddPurposes(p ...*Purpose) *DocumentUpdate {
+	ids := make([]int, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return du.AddPurposeIDs(ids...)
+}
+
+// AddSourceDatumIDs adds the "source_data" edge to the SourceData entity by IDs.
+func (du *DocumentUpdate) AddSourceDatumIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.AddSourceDatumIDs(ids...)
+	return du
+}
+
+// AddSourceData adds the "source_data" edges to the SourceData entity.
+func (du *DocumentUpdate) AddSourceData(s ...*SourceData) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(s))
+	for i := range s {
+		ids[i] = s[i].ID
+	}
+	return du.AddSourceDatumIDs(ids...)
+}
+
+// AddToolIDs adds the "tools" edge to the Tool entity by IDs.
+func (du *DocumentUpdate) AddToolIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.AddToolIDs(ids...)
+	return du
+}
+
+// AddTools adds the "tools" edges to the Tool entity.
+func (du *DocumentUpdate) AddTools(t ...*Tool) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(t))
+	for i := range t {
+		ids[i] = t[i].ID
+	}
+	return du.AddToolIDs(ids...)
+}
+
 // Mutation returns the DocumentMutation object of the builder.
 func (du *DocumentUpdate) Mutation() *DocumentMutation {
 	return du.mutation
@@ -72,6 +249,237 @@ func (du *DocumentUpdate) RemoveAnnotations(a ...*Annotation) *DocumentUpdate {
 		ids[i] = a[i].ID
 	}
 	return du.RemoveAnnotationIDs(ids...)
+}
+
+// ClearDocumentTypes clears all "document_types" edges to the DocumentType entity.
+func (du *DocumentUpdate) ClearDocumentTypes() *DocumentUpdate {
+	du.mutation.ClearDocumentTypes()
+	return du
+}
+
+// RemoveDocumentTypeIDs removes the "document_types" edge to DocumentType entities by IDs.
+func (du *DocumentUpdate) RemoveDocumentTypeIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.RemoveDocumentTypeIDs(ids...)
+	return du
+}
+
+// RemoveDocumentTypes removes "document_types" edges to DocumentType entities.
+func (du *DocumentUpdate) RemoveDocumentTypes(d ...*DocumentType) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return du.RemoveDocumentTypeIDs(ids...)
+}
+
+// ClearEdgeTypes clears all "edge_types" edges to the EdgeType entity.
+func (du *DocumentUpdate) ClearEdgeTypes() *DocumentUpdate {
+	du.mutation.ClearEdgeTypes()
+	return du
+}
+
+// RemoveEdgeTypeIDs removes the "edge_types" edge to EdgeType entities by IDs.
+func (du *DocumentUpdate) RemoveEdgeTypeIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.RemoveEdgeTypeIDs(ids...)
+	return du
+}
+
+// RemoveEdgeTypes removes "edge_types" edges to EdgeType entities.
+func (du *DocumentUpdate) RemoveEdgeTypes(e ...*EdgeType) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return du.RemoveEdgeTypeIDs(ids...)
+}
+
+// ClearExternalReferences clears all "external_references" edges to the ExternalReference entity.
+func (du *DocumentUpdate) ClearExternalReferences() *DocumentUpdate {
+	du.mutation.ClearExternalReferences()
+	return du
+}
+
+// RemoveExternalReferenceIDs removes the "external_references" edge to ExternalReference entities by IDs.
+func (du *DocumentUpdate) RemoveExternalReferenceIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.RemoveExternalReferenceIDs(ids...)
+	return du
+}
+
+// RemoveExternalReferences removes "external_references" edges to ExternalReference entities.
+func (du *DocumentUpdate) RemoveExternalReferences(e ...*ExternalReference) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return du.RemoveExternalReferenceIDs(ids...)
+}
+
+// ClearHashes clears all "hashes" edges to the HashesEntry entity.
+func (du *DocumentUpdate) ClearHashes() *DocumentUpdate {
+	du.mutation.ClearHashes()
+	return du
+}
+
+// RemoveHashIDs removes the "hashes" edge to HashesEntry entities by IDs.
+func (du *DocumentUpdate) RemoveHashIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.RemoveHashIDs(ids...)
+	return du
+}
+
+// RemoveHashes removes "hashes" edges to HashesEntry entities.
+func (du *DocumentUpdate) RemoveHashes(h ...*HashesEntry) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(h))
+	for i := range h {
+		ids[i] = h[i].ID
+	}
+	return du.RemoveHashIDs(ids...)
+}
+
+// ClearIdentifiers clears all "identifiers" edges to the IdentifiersEntry entity.
+func (du *DocumentUpdate) ClearIdentifiers() *DocumentUpdate {
+	du.mutation.ClearIdentifiers()
+	return du
+}
+
+// RemoveIdentifierIDs removes the "identifiers" edge to IdentifiersEntry entities by IDs.
+func (du *DocumentUpdate) RemoveIdentifierIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.RemoveIdentifierIDs(ids...)
+	return du
+}
+
+// RemoveIdentifiers removes "identifiers" edges to IdentifiersEntry entities.
+func (du *DocumentUpdate) RemoveIdentifiers(i ...*IdentifiersEntry) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(i))
+	for j := range i {
+		ids[j] = i[j].ID
+	}
+	return du.RemoveIdentifierIDs(ids...)
+}
+
+// ClearNodes clears all "nodes" edges to the Node entity.
+func (du *DocumentUpdate) ClearNodes() *DocumentUpdate {
+	du.mutation.ClearNodes()
+	return du
+}
+
+// RemoveNodeIDs removes the "nodes" edge to Node entities by IDs.
+func (du *DocumentUpdate) RemoveNodeIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.RemoveNodeIDs(ids...)
+	return du
+}
+
+// RemoveNodes removes "nodes" edges to Node entities.
+func (du *DocumentUpdate) RemoveNodes(n ...*Node) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return du.RemoveNodeIDs(ids...)
+}
+
+// ClearPersons clears all "persons" edges to the Person entity.
+func (du *DocumentUpdate) ClearPersons() *DocumentUpdate {
+	du.mutation.ClearPersons()
+	return du
+}
+
+// RemovePersonIDs removes the "persons" edge to Person entities by IDs.
+func (du *DocumentUpdate) RemovePersonIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.RemovePersonIDs(ids...)
+	return du
+}
+
+// RemovePersons removes "persons" edges to Person entities.
+func (du *DocumentUpdate) RemovePersons(p ...*Person) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return du.RemovePersonIDs(ids...)
+}
+
+// ClearProperties clears all "properties" edges to the Property entity.
+func (du *DocumentUpdate) ClearProperties() *DocumentUpdate {
+	du.mutation.ClearProperties()
+	return du
+}
+
+// RemovePropertyIDs removes the "properties" edge to Property entities by IDs.
+func (du *DocumentUpdate) RemovePropertyIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.RemovePropertyIDs(ids...)
+	return du
+}
+
+// RemoveProperties removes "properties" edges to Property entities.
+func (du *DocumentUpdate) RemoveProperties(p ...*Property) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return du.RemovePropertyIDs(ids...)
+}
+
+// ClearPurposes clears all "purposes" edges to the Purpose entity.
+func (du *DocumentUpdate) ClearPurposes() *DocumentUpdate {
+	du.mutation.ClearPurposes()
+	return du
+}
+
+// RemovePurposeIDs removes the "purposes" edge to Purpose entities by IDs.
+func (du *DocumentUpdate) RemovePurposeIDs(ids ...int) *DocumentUpdate {
+	du.mutation.RemovePurposeIDs(ids...)
+	return du
+}
+
+// RemovePurposes removes "purposes" edges to Purpose entities.
+func (du *DocumentUpdate) RemovePurposes(p ...*Purpose) *DocumentUpdate {
+	ids := make([]int, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return du.RemovePurposeIDs(ids...)
+}
+
+// ClearSourceData clears all "source_data" edges to the SourceData entity.
+func (du *DocumentUpdate) ClearSourceData() *DocumentUpdate {
+	du.mutation.ClearSourceData()
+	return du
+}
+
+// RemoveSourceDatumIDs removes the "source_data" edge to SourceData entities by IDs.
+func (du *DocumentUpdate) RemoveSourceDatumIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.RemoveSourceDatumIDs(ids...)
+	return du
+}
+
+// RemoveSourceData removes "source_data" edges to SourceData entities.
+func (du *DocumentUpdate) RemoveSourceData(s ...*SourceData) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(s))
+	for i := range s {
+		ids[i] = s[i].ID
+	}
+	return du.RemoveSourceDatumIDs(ids...)
+}
+
+// ClearTools clears all "tools" edges to the Tool entity.
+func (du *DocumentUpdate) ClearTools() *DocumentUpdate {
+	du.mutation.ClearTools()
+	return du
+}
+
+// RemoveToolIDs removes the "tools" edge to Tool entities by IDs.
+func (du *DocumentUpdate) RemoveToolIDs(ids ...uuid.UUID) *DocumentUpdate {
+	du.mutation.RemoveToolIDs(ids...)
+	return du
+}
+
+// RemoveTools removes "tools" edges to Tool entities.
+func (du *DocumentUpdate) RemoveTools(t ...*Tool) *DocumentUpdate {
+	ids := make([]uuid.UUID, len(t))
+	for i := range t {
+		ids[i] = t[i].ID
+	}
+	return du.RemoveToolIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -155,6 +563,501 @@ func (du *DocumentUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if du.mutation.DocumentTypesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.DocumentTypesTable,
+			Columns: document.DocumentTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(documenttype.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.RemovedDocumentTypesIDs(); len(nodes) > 0 && !du.mutation.DocumentTypesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.DocumentTypesTable,
+			Columns: document.DocumentTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(documenttype.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.DocumentTypesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.DocumentTypesTable,
+			Columns: document.DocumentTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(documenttype.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if du.mutation.EdgeTypesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.EdgeTypesTable,
+			Columns: document.EdgeTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(edgetype.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.RemovedEdgeTypesIDs(); len(nodes) > 0 && !du.mutation.EdgeTypesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.EdgeTypesTable,
+			Columns: document.EdgeTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(edgetype.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.EdgeTypesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.EdgeTypesTable,
+			Columns: document.EdgeTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(edgetype.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if du.mutation.ExternalReferencesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ExternalReferencesTable,
+			Columns: document.ExternalReferencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(externalreference.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.RemovedExternalReferencesIDs(); len(nodes) > 0 && !du.mutation.ExternalReferencesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ExternalReferencesTable,
+			Columns: document.ExternalReferencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(externalreference.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.ExternalReferencesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ExternalReferencesTable,
+			Columns: document.ExternalReferencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(externalreference.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if du.mutation.HashesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.HashesTable,
+			Columns: document.HashesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(hashesentry.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.RemovedHashesIDs(); len(nodes) > 0 && !du.mutation.HashesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.HashesTable,
+			Columns: document.HashesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(hashesentry.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.HashesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.HashesTable,
+			Columns: document.HashesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(hashesentry.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if du.mutation.IdentifiersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.IdentifiersTable,
+			Columns: document.IdentifiersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(identifiersentry.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.RemovedIdentifiersIDs(); len(nodes) > 0 && !du.mutation.IdentifiersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.IdentifiersTable,
+			Columns: document.IdentifiersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(identifiersentry.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.IdentifiersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.IdentifiersTable,
+			Columns: document.IdentifiersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(identifiersentry.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if du.mutation.NodesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.NodesTable,
+			Columns: document.NodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.RemovedNodesIDs(); len(nodes) > 0 && !du.mutation.NodesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.NodesTable,
+			Columns: document.NodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.NodesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.NodesTable,
+			Columns: document.NodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if du.mutation.PersonsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PersonsTable,
+			Columns: document.PersonsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.RemovedPersonsIDs(); len(nodes) > 0 && !du.mutation.PersonsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PersonsTable,
+			Columns: document.PersonsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.PersonsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PersonsTable,
+			Columns: document.PersonsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if du.mutation.PropertiesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PropertiesTable,
+			Columns: document.PropertiesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.RemovedPropertiesIDs(); len(nodes) > 0 && !du.mutation.PropertiesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PropertiesTable,
+			Columns: document.PropertiesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.PropertiesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PropertiesTable,
+			Columns: document.PropertiesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if du.mutation.PurposesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PurposesTable,
+			Columns: document.PurposesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(purpose.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.RemovedPurposesIDs(); len(nodes) > 0 && !du.mutation.PurposesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PurposesTable,
+			Columns: document.PurposesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(purpose.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.PurposesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PurposesTable,
+			Columns: document.PurposesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(purpose.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if du.mutation.SourceDataCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.SourceDataTable,
+			Columns: document.SourceDataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.RemovedSourceDataIDs(); len(nodes) > 0 && !du.mutation.SourceDataCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.SourceDataTable,
+			Columns: document.SourceDataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.SourceDataIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.SourceDataTable,
+			Columns: document.SourceDataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if du.mutation.ToolsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ToolsTable,
+			Columns: document.ToolsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.RemovedToolsIDs(); len(nodes) > 0 && !du.mutation.ToolsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ToolsTable,
+			Columns: document.ToolsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.ToolsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ToolsTable,
+			Columns: document.ToolsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, du.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{document.Label}
@@ -190,6 +1093,171 @@ func (duo *DocumentUpdateOne) AddAnnotations(a ...*Annotation) *DocumentUpdateOn
 	return duo.AddAnnotationIDs(ids...)
 }
 
+// AddDocumentTypeIDs adds the "document_types" edge to the DocumentType entity by IDs.
+func (duo *DocumentUpdateOne) AddDocumentTypeIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.AddDocumentTypeIDs(ids...)
+	return duo
+}
+
+// AddDocumentTypes adds the "document_types" edges to the DocumentType entity.
+func (duo *DocumentUpdateOne) AddDocumentTypes(d ...*DocumentType) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return duo.AddDocumentTypeIDs(ids...)
+}
+
+// AddEdgeTypeIDs adds the "edge_types" edge to the EdgeType entity by IDs.
+func (duo *DocumentUpdateOne) AddEdgeTypeIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.AddEdgeTypeIDs(ids...)
+	return duo
+}
+
+// AddEdgeTypes adds the "edge_types" edges to the EdgeType entity.
+func (duo *DocumentUpdateOne) AddEdgeTypes(e ...*EdgeType) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return duo.AddEdgeTypeIDs(ids...)
+}
+
+// AddExternalReferenceIDs adds the "external_references" edge to the ExternalReference entity by IDs.
+func (duo *DocumentUpdateOne) AddExternalReferenceIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.AddExternalReferenceIDs(ids...)
+	return duo
+}
+
+// AddExternalReferences adds the "external_references" edges to the ExternalReference entity.
+func (duo *DocumentUpdateOne) AddExternalReferences(e ...*ExternalReference) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return duo.AddExternalReferenceIDs(ids...)
+}
+
+// AddHashIDs adds the "hashes" edge to the HashesEntry entity by IDs.
+func (duo *DocumentUpdateOne) AddHashIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.AddHashIDs(ids...)
+	return duo
+}
+
+// AddHashes adds the "hashes" edges to the HashesEntry entity.
+func (duo *DocumentUpdateOne) AddHashes(h ...*HashesEntry) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(h))
+	for i := range h {
+		ids[i] = h[i].ID
+	}
+	return duo.AddHashIDs(ids...)
+}
+
+// AddIdentifierIDs adds the "identifiers" edge to the IdentifiersEntry entity by IDs.
+func (duo *DocumentUpdateOne) AddIdentifierIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.AddIdentifierIDs(ids...)
+	return duo
+}
+
+// AddIdentifiers adds the "identifiers" edges to the IdentifiersEntry entity.
+func (duo *DocumentUpdateOne) AddIdentifiers(i ...*IdentifiersEntry) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(i))
+	for j := range i {
+		ids[j] = i[j].ID
+	}
+	return duo.AddIdentifierIDs(ids...)
+}
+
+// AddNodeIDs adds the "nodes" edge to the Node entity by IDs.
+func (duo *DocumentUpdateOne) AddNodeIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.AddNodeIDs(ids...)
+	return duo
+}
+
+// AddNodes adds the "nodes" edges to the Node entity.
+func (duo *DocumentUpdateOne) AddNodes(n ...*Node) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return duo.AddNodeIDs(ids...)
+}
+
+// AddPersonIDs adds the "persons" edge to the Person entity by IDs.
+func (duo *DocumentUpdateOne) AddPersonIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.AddPersonIDs(ids...)
+	return duo
+}
+
+// AddPersons adds the "persons" edges to the Person entity.
+func (duo *DocumentUpdateOne) AddPersons(p ...*Person) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return duo.AddPersonIDs(ids...)
+}
+
+// AddPropertyIDs adds the "properties" edge to the Property entity by IDs.
+func (duo *DocumentUpdateOne) AddPropertyIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.AddPropertyIDs(ids...)
+	return duo
+}
+
+// AddProperties adds the "properties" edges to the Property entity.
+func (duo *DocumentUpdateOne) AddProperties(p ...*Property) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return duo.AddPropertyIDs(ids...)
+}
+
+// AddPurposeIDs adds the "purposes" edge to the Purpose entity by IDs.
+func (duo *DocumentUpdateOne) AddPurposeIDs(ids ...int) *DocumentUpdateOne {
+	duo.mutation.AddPurposeIDs(ids...)
+	return duo
+}
+
+// AddPurposes adds the "purposes" edges to the Purpose entity.
+func (duo *DocumentUpdateOne) AddPurposes(p ...*Purpose) *DocumentUpdateOne {
+	ids := make([]int, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return duo.AddPurposeIDs(ids...)
+}
+
+// AddSourceDatumIDs adds the "source_data" edge to the SourceData entity by IDs.
+func (duo *DocumentUpdateOne) AddSourceDatumIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.AddSourceDatumIDs(ids...)
+	return duo
+}
+
+// AddSourceData adds the "source_data" edges to the SourceData entity.
+func (duo *DocumentUpdateOne) AddSourceData(s ...*SourceData) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(s))
+	for i := range s {
+		ids[i] = s[i].ID
+	}
+	return duo.AddSourceDatumIDs(ids...)
+}
+
+// AddToolIDs adds the "tools" edge to the Tool entity by IDs.
+func (duo *DocumentUpdateOne) AddToolIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.AddToolIDs(ids...)
+	return duo
+}
+
+// AddTools adds the "tools" edges to the Tool entity.
+func (duo *DocumentUpdateOne) AddTools(t ...*Tool) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(t))
+	for i := range t {
+		ids[i] = t[i].ID
+	}
+	return duo.AddToolIDs(ids...)
+}
+
 // Mutation returns the DocumentMutation object of the builder.
 func (duo *DocumentUpdateOne) Mutation() *DocumentMutation {
 	return duo.mutation
@@ -214,6 +1282,237 @@ func (duo *DocumentUpdateOne) RemoveAnnotations(a ...*Annotation) *DocumentUpdat
 		ids[i] = a[i].ID
 	}
 	return duo.RemoveAnnotationIDs(ids...)
+}
+
+// ClearDocumentTypes clears all "document_types" edges to the DocumentType entity.
+func (duo *DocumentUpdateOne) ClearDocumentTypes() *DocumentUpdateOne {
+	duo.mutation.ClearDocumentTypes()
+	return duo
+}
+
+// RemoveDocumentTypeIDs removes the "document_types" edge to DocumentType entities by IDs.
+func (duo *DocumentUpdateOne) RemoveDocumentTypeIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.RemoveDocumentTypeIDs(ids...)
+	return duo
+}
+
+// RemoveDocumentTypes removes "document_types" edges to DocumentType entities.
+func (duo *DocumentUpdateOne) RemoveDocumentTypes(d ...*DocumentType) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return duo.RemoveDocumentTypeIDs(ids...)
+}
+
+// ClearEdgeTypes clears all "edge_types" edges to the EdgeType entity.
+func (duo *DocumentUpdateOne) ClearEdgeTypes() *DocumentUpdateOne {
+	duo.mutation.ClearEdgeTypes()
+	return duo
+}
+
+// RemoveEdgeTypeIDs removes the "edge_types" edge to EdgeType entities by IDs.
+func (duo *DocumentUpdateOne) RemoveEdgeTypeIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.RemoveEdgeTypeIDs(ids...)
+	return duo
+}
+
+// RemoveEdgeTypes removes "edge_types" edges to EdgeType entities.
+func (duo *DocumentUpdateOne) RemoveEdgeTypes(e ...*EdgeType) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return duo.RemoveEdgeTypeIDs(ids...)
+}
+
+// ClearExternalReferences clears all "external_references" edges to the ExternalReference entity.
+func (duo *DocumentUpdateOne) ClearExternalReferences() *DocumentUpdateOne {
+	duo.mutation.ClearExternalReferences()
+	return duo
+}
+
+// RemoveExternalReferenceIDs removes the "external_references" edge to ExternalReference entities by IDs.
+func (duo *DocumentUpdateOne) RemoveExternalReferenceIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.RemoveExternalReferenceIDs(ids...)
+	return duo
+}
+
+// RemoveExternalReferences removes "external_references" edges to ExternalReference entities.
+func (duo *DocumentUpdateOne) RemoveExternalReferences(e ...*ExternalReference) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return duo.RemoveExternalReferenceIDs(ids...)
+}
+
+// ClearHashes clears all "hashes" edges to the HashesEntry entity.
+func (duo *DocumentUpdateOne) ClearHashes() *DocumentUpdateOne {
+	duo.mutation.ClearHashes()
+	return duo
+}
+
+// RemoveHashIDs removes the "hashes" edge to HashesEntry entities by IDs.
+func (duo *DocumentUpdateOne) RemoveHashIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.RemoveHashIDs(ids...)
+	return duo
+}
+
+// RemoveHashes removes "hashes" edges to HashesEntry entities.
+func (duo *DocumentUpdateOne) RemoveHashes(h ...*HashesEntry) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(h))
+	for i := range h {
+		ids[i] = h[i].ID
+	}
+	return duo.RemoveHashIDs(ids...)
+}
+
+// ClearIdentifiers clears all "identifiers" edges to the IdentifiersEntry entity.
+func (duo *DocumentUpdateOne) ClearIdentifiers() *DocumentUpdateOne {
+	duo.mutation.ClearIdentifiers()
+	return duo
+}
+
+// RemoveIdentifierIDs removes the "identifiers" edge to IdentifiersEntry entities by IDs.
+func (duo *DocumentUpdateOne) RemoveIdentifierIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.RemoveIdentifierIDs(ids...)
+	return duo
+}
+
+// RemoveIdentifiers removes "identifiers" edges to IdentifiersEntry entities.
+func (duo *DocumentUpdateOne) RemoveIdentifiers(i ...*IdentifiersEntry) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(i))
+	for j := range i {
+		ids[j] = i[j].ID
+	}
+	return duo.RemoveIdentifierIDs(ids...)
+}
+
+// ClearNodes clears all "nodes" edges to the Node entity.
+func (duo *DocumentUpdateOne) ClearNodes() *DocumentUpdateOne {
+	duo.mutation.ClearNodes()
+	return duo
+}
+
+// RemoveNodeIDs removes the "nodes" edge to Node entities by IDs.
+func (duo *DocumentUpdateOne) RemoveNodeIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.RemoveNodeIDs(ids...)
+	return duo
+}
+
+// RemoveNodes removes "nodes" edges to Node entities.
+func (duo *DocumentUpdateOne) RemoveNodes(n ...*Node) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return duo.RemoveNodeIDs(ids...)
+}
+
+// ClearPersons clears all "persons" edges to the Person entity.
+func (duo *DocumentUpdateOne) ClearPersons() *DocumentUpdateOne {
+	duo.mutation.ClearPersons()
+	return duo
+}
+
+// RemovePersonIDs removes the "persons" edge to Person entities by IDs.
+func (duo *DocumentUpdateOne) RemovePersonIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.RemovePersonIDs(ids...)
+	return duo
+}
+
+// RemovePersons removes "persons" edges to Person entities.
+func (duo *DocumentUpdateOne) RemovePersons(p ...*Person) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return duo.RemovePersonIDs(ids...)
+}
+
+// ClearProperties clears all "properties" edges to the Property entity.
+func (duo *DocumentUpdateOne) ClearProperties() *DocumentUpdateOne {
+	duo.mutation.ClearProperties()
+	return duo
+}
+
+// RemovePropertyIDs removes the "properties" edge to Property entities by IDs.
+func (duo *DocumentUpdateOne) RemovePropertyIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.RemovePropertyIDs(ids...)
+	return duo
+}
+
+// RemoveProperties removes "properties" edges to Property entities.
+func (duo *DocumentUpdateOne) RemoveProperties(p ...*Property) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return duo.RemovePropertyIDs(ids...)
+}
+
+// ClearPurposes clears all "purposes" edges to the Purpose entity.
+func (duo *DocumentUpdateOne) ClearPurposes() *DocumentUpdateOne {
+	duo.mutation.ClearPurposes()
+	return duo
+}
+
+// RemovePurposeIDs removes the "purposes" edge to Purpose entities by IDs.
+func (duo *DocumentUpdateOne) RemovePurposeIDs(ids ...int) *DocumentUpdateOne {
+	duo.mutation.RemovePurposeIDs(ids...)
+	return duo
+}
+
+// RemovePurposes removes "purposes" edges to Purpose entities.
+func (duo *DocumentUpdateOne) RemovePurposes(p ...*Purpose) *DocumentUpdateOne {
+	ids := make([]int, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return duo.RemovePurposeIDs(ids...)
+}
+
+// ClearSourceData clears all "source_data" edges to the SourceData entity.
+func (duo *DocumentUpdateOne) ClearSourceData() *DocumentUpdateOne {
+	duo.mutation.ClearSourceData()
+	return duo
+}
+
+// RemoveSourceDatumIDs removes the "source_data" edge to SourceData entities by IDs.
+func (duo *DocumentUpdateOne) RemoveSourceDatumIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.RemoveSourceDatumIDs(ids...)
+	return duo
+}
+
+// RemoveSourceData removes "source_data" edges to SourceData entities.
+func (duo *DocumentUpdateOne) RemoveSourceData(s ...*SourceData) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(s))
+	for i := range s {
+		ids[i] = s[i].ID
+	}
+	return duo.RemoveSourceDatumIDs(ids...)
+}
+
+// ClearTools clears all "tools" edges to the Tool entity.
+func (duo *DocumentUpdateOne) ClearTools() *DocumentUpdateOne {
+	duo.mutation.ClearTools()
+	return duo
+}
+
+// RemoveToolIDs removes the "tools" edge to Tool entities by IDs.
+func (duo *DocumentUpdateOne) RemoveToolIDs(ids ...uuid.UUID) *DocumentUpdateOne {
+	duo.mutation.RemoveToolIDs(ids...)
+	return duo
+}
+
+// RemoveTools removes "tools" edges to Tool entities.
+func (duo *DocumentUpdateOne) RemoveTools(t ...*Tool) *DocumentUpdateOne {
+	ids := make([]uuid.UUID, len(t))
+	for i := range t {
+		ids[i] = t[i].ID
+	}
+	return duo.RemoveToolIDs(ids...)
 }
 
 // Where appends a list predicates to the DocumentUpdate builder.
@@ -320,6 +1619,501 @@ func (duo *DocumentUpdateOne) sqlSave(ctx context.Context) (_node *Document, err
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(annotation.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if duo.mutation.DocumentTypesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.DocumentTypesTable,
+			Columns: document.DocumentTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(documenttype.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.RemovedDocumentTypesIDs(); len(nodes) > 0 && !duo.mutation.DocumentTypesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.DocumentTypesTable,
+			Columns: document.DocumentTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(documenttype.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.DocumentTypesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.DocumentTypesTable,
+			Columns: document.DocumentTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(documenttype.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if duo.mutation.EdgeTypesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.EdgeTypesTable,
+			Columns: document.EdgeTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(edgetype.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.RemovedEdgeTypesIDs(); len(nodes) > 0 && !duo.mutation.EdgeTypesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.EdgeTypesTable,
+			Columns: document.EdgeTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(edgetype.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.EdgeTypesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.EdgeTypesTable,
+			Columns: document.EdgeTypesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(edgetype.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if duo.mutation.ExternalReferencesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ExternalReferencesTable,
+			Columns: document.ExternalReferencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(externalreference.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.RemovedExternalReferencesIDs(); len(nodes) > 0 && !duo.mutation.ExternalReferencesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ExternalReferencesTable,
+			Columns: document.ExternalReferencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(externalreference.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.ExternalReferencesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ExternalReferencesTable,
+			Columns: document.ExternalReferencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(externalreference.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if duo.mutation.HashesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.HashesTable,
+			Columns: document.HashesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(hashesentry.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.RemovedHashesIDs(); len(nodes) > 0 && !duo.mutation.HashesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.HashesTable,
+			Columns: document.HashesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(hashesentry.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.HashesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.HashesTable,
+			Columns: document.HashesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(hashesentry.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if duo.mutation.IdentifiersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.IdentifiersTable,
+			Columns: document.IdentifiersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(identifiersentry.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.RemovedIdentifiersIDs(); len(nodes) > 0 && !duo.mutation.IdentifiersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.IdentifiersTable,
+			Columns: document.IdentifiersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(identifiersentry.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.IdentifiersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.IdentifiersTable,
+			Columns: document.IdentifiersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(identifiersentry.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if duo.mutation.NodesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.NodesTable,
+			Columns: document.NodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.RemovedNodesIDs(); len(nodes) > 0 && !duo.mutation.NodesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.NodesTable,
+			Columns: document.NodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.NodesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.NodesTable,
+			Columns: document.NodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if duo.mutation.PersonsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PersonsTable,
+			Columns: document.PersonsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.RemovedPersonsIDs(); len(nodes) > 0 && !duo.mutation.PersonsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PersonsTable,
+			Columns: document.PersonsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.PersonsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PersonsTable,
+			Columns: document.PersonsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if duo.mutation.PropertiesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PropertiesTable,
+			Columns: document.PropertiesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.RemovedPropertiesIDs(); len(nodes) > 0 && !duo.mutation.PropertiesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PropertiesTable,
+			Columns: document.PropertiesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.PropertiesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PropertiesTable,
+			Columns: document.PropertiesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if duo.mutation.PurposesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PurposesTable,
+			Columns: document.PurposesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(purpose.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.RemovedPurposesIDs(); len(nodes) > 0 && !duo.mutation.PurposesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PurposesTable,
+			Columns: document.PurposesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(purpose.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.PurposesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.PurposesTable,
+			Columns: document.PurposesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(purpose.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if duo.mutation.SourceDataCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.SourceDataTable,
+			Columns: document.SourceDataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.RemovedSourceDataIDs(); len(nodes) > 0 && !duo.mutation.SourceDataCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.SourceDataTable,
+			Columns: document.SourceDataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.SourceDataIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.SourceDataTable,
+			Columns: document.SourceDataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if duo.mutation.ToolsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ToolsTable,
+			Columns: document.ToolsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.RemovedToolsIDs(); len(nodes) > 0 && !duo.mutation.ToolsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ToolsTable,
+			Columns: document.ToolsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.ToolsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   document.ToolsTable,
+			Columns: document.ToolsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/internal/backends/ent/documenttype/documenttype.go
+++ b/internal/backends/ent/documenttype/documenttype.go
@@ -21,50 +21,49 @@ const (
 	Label = "document_type"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
-	// FieldDocumentID holds the string denoting the document_id field in the database.
-	FieldDocumentID = "document_id"
 	// FieldProtoMessage holds the string denoting the proto_message field in the database.
 	FieldProtoMessage = "proto_message"
-	// FieldMetadataID holds the string denoting the metadata_id field in the database.
-	FieldMetadataID = "metadata_id"
 	// FieldType holds the string denoting the type field in the database.
 	FieldType = "type"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
 	// FieldDescription holds the string denoting the description field in the database.
 	FieldDescription = "description"
-	// EdgeDocument holds the string denoting the document edge name in mutations.
-	EdgeDocument = "document"
+	// EdgeDocuments holds the string denoting the documents edge name in mutations.
+	EdgeDocuments = "documents"
 	// EdgeMetadata holds the string denoting the metadata edge name in mutations.
 	EdgeMetadata = "metadata"
 	// Table holds the table name of the documenttype in the database.
 	Table = "document_types"
-	// DocumentTable is the table that holds the document relation/edge.
-	DocumentTable = "document_types"
-	// DocumentInverseTable is the table name for the Document entity.
+	// DocumentsTable is the table that holds the documents relation/edge. The primary key declared below.
+	DocumentsTable = "document_document_types"
+	// DocumentsInverseTable is the table name for the Document entity.
 	// It exists in this package in order to avoid circular dependency with the "document" package.
-	DocumentInverseTable = "documents"
-	// DocumentColumn is the table column denoting the document relation/edge.
-	DocumentColumn = "document_id"
-	// MetadataTable is the table that holds the metadata relation/edge.
-	MetadataTable = "document_types"
+	DocumentsInverseTable = "documents"
+	// MetadataTable is the table that holds the metadata relation/edge. The primary key declared below.
+	MetadataTable = "metadata_document_types"
 	// MetadataInverseTable is the table name for the Metadata entity.
 	// It exists in this package in order to avoid circular dependency with the "metadata" package.
 	MetadataInverseTable = "metadata"
-	// MetadataColumn is the table column denoting the metadata relation/edge.
-	MetadataColumn = "metadata_id"
 )
 
 // Columns holds all SQL columns for documenttype fields.
 var Columns = []string{
 	FieldID,
-	FieldDocumentID,
 	FieldProtoMessage,
-	FieldMetadataID,
 	FieldType,
 	FieldName,
 	FieldDescription,
 }
+
+var (
+	// DocumentsPrimaryKey and DocumentsColumn2 are the table columns denoting the
+	// primary key for the documents relation (M2M).
+	DocumentsPrimaryKey = []string{"document_id", "document_type_id"}
+	// MetadataPrimaryKey and MetadataColumn2 are the table columns denoting the
+	// primary key for the metadata relation (M2M).
+	MetadataPrimaryKey = []string{"metadata_id", "document_type_id"}
+)
 
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
@@ -83,8 +82,6 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/protobom/storage/internal/backends/ent/runtime"
 var (
 	Hooks [1]ent.Hook
-	// DefaultDocumentID holds the default value on creation for the "document_id" field.
-	DefaultDocumentID func() uuid.UUID
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() uuid.UUID
 )
@@ -127,16 +124,6 @@ func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
-// ByDocumentID orders the results by the document_id field.
-func ByDocumentID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldDocumentID, opts...).ToFunc()
-}
-
-// ByMetadataID orders the results by the metadata_id field.
-func ByMetadataID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldMetadataID, opts...).ToFunc()
-}
-
 // ByType orders the results by the type field.
 func ByType(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldType, opts...).ToFunc()
@@ -152,30 +139,44 @@ func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDescription, opts...).ToFunc()
 }
 
-// ByDocumentField orders the results by document field.
-func ByDocumentField(field string, opts ...sql.OrderTermOption) OrderOption {
+// ByDocumentsCount orders the results by documents count.
+func ByDocumentsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newDocumentStep(), sql.OrderByField(field, opts...))
+		sqlgraph.OrderByNeighborsCount(s, newDocumentsStep(), opts...)
 	}
 }
 
-// ByMetadataField orders the results by metadata field.
-func ByMetadataField(field string, opts ...sql.OrderTermOption) OrderOption {
+// ByDocuments orders the results by documents terms.
+func ByDocuments(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newMetadataStep(), sql.OrderByField(field, opts...))
+		sqlgraph.OrderByNeighborTerms(s, newDocumentsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
-func newDocumentStep() *sqlgraph.Step {
+
+// ByMetadataCount orders the results by metadata count.
+func ByMetadataCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newMetadataStep(), opts...)
+	}
+}
+
+// ByMetadata orders the results by metadata terms.
+func ByMetadata(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newMetadataStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newDocumentsStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(DocumentInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
+		sqlgraph.To(DocumentsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
 	)
 }
 func newMetadataStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(MetadataInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, true, MetadataTable, MetadataColumn),
+		sqlgraph.Edge(sqlgraph.M2M, true, MetadataTable, MetadataPrimaryKey...),
 	)
 }

--- a/internal/backends/ent/documenttype/where.go
+++ b/internal/backends/ent/documenttype/where.go
@@ -60,19 +60,9 @@ func IDLTE(id uuid.UUID) predicate.DocumentType {
 	return predicate.DocumentType(sql.FieldLTE(FieldID, id))
 }
 
-// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
-func DocumentID(v uuid.UUID) predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldEQ(FieldDocumentID, v))
-}
-
 // ProtoMessage applies equality check predicate on the "proto_message" field. It's identical to ProtoMessageEQ.
 func ProtoMessage(v *sbom.DocumentType) predicate.DocumentType {
 	return predicate.DocumentType(sql.FieldEQ(FieldProtoMessage, v))
-}
-
-// MetadataID applies equality check predicate on the "metadata_id" field. It's identical to MetadataIDEQ.
-func MetadataID(v uuid.UUID) predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldEQ(FieldMetadataID, v))
 }
 
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
@@ -83,36 +73,6 @@ func Name(v string) predicate.DocumentType {
 // Description applies equality check predicate on the "description" field. It's identical to DescriptionEQ.
 func Description(v string) predicate.DocumentType {
 	return predicate.DocumentType(sql.FieldEQ(FieldDescription, v))
-}
-
-// DocumentIDEQ applies the EQ predicate on the "document_id" field.
-func DocumentIDEQ(v uuid.UUID) predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldEQ(FieldDocumentID, v))
-}
-
-// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
-func DocumentIDNEQ(v uuid.UUID) predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldNEQ(FieldDocumentID, v))
-}
-
-// DocumentIDIn applies the In predicate on the "document_id" field.
-func DocumentIDIn(vs ...uuid.UUID) predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
-func DocumentIDNotIn(vs ...uuid.UUID) predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldNotIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDIsNil applies the IsNil predicate on the "document_id" field.
-func DocumentIDIsNil() predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldIsNull(FieldDocumentID))
-}
-
-// DocumentIDNotNil applies the NotNil predicate on the "document_id" field.
-func DocumentIDNotNil() predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldNotNull(FieldDocumentID))
 }
 
 // ProtoMessageEQ applies the EQ predicate on the "proto_message" field.
@@ -153,26 +113,6 @@ func ProtoMessageLT(v *sbom.DocumentType) predicate.DocumentType {
 // ProtoMessageLTE applies the LTE predicate on the "proto_message" field.
 func ProtoMessageLTE(v *sbom.DocumentType) predicate.DocumentType {
 	return predicate.DocumentType(sql.FieldLTE(FieldProtoMessage, v))
-}
-
-// MetadataIDEQ applies the EQ predicate on the "metadata_id" field.
-func MetadataIDEQ(v uuid.UUID) predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldEQ(FieldMetadataID, v))
-}
-
-// MetadataIDNEQ applies the NEQ predicate on the "metadata_id" field.
-func MetadataIDNEQ(v uuid.UUID) predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldNEQ(FieldMetadataID, v))
-}
-
-// MetadataIDIn applies the In predicate on the "metadata_id" field.
-func MetadataIDIn(vs ...uuid.UUID) predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldIn(FieldMetadataID, vs...))
-}
-
-// MetadataIDNotIn applies the NotIn predicate on the "metadata_id" field.
-func MetadataIDNotIn(vs ...uuid.UUID) predicate.DocumentType {
-	return predicate.DocumentType(sql.FieldNotIn(FieldMetadataID, vs...))
 }
 
 // TypeEQ applies the EQ predicate on the "type" field.
@@ -355,21 +295,21 @@ func DescriptionContainsFold(v string) predicate.DocumentType {
 	return predicate.DocumentType(sql.FieldContainsFold(FieldDescription, v))
 }
 
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.DocumentType {
+// HasDocuments applies the HasEdge predicate on the "documents" edge.
+func HasDocuments() predicate.DocumentType {
 	return predicate.DocumentType(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
 }
 
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.DocumentType {
+// HasDocumentsWith applies the HasEdge predicate on the "documents" edge with a given conditions (other predicates).
+func HasDocumentsWith(preds ...predicate.Document) predicate.DocumentType {
 	return predicate.DocumentType(func(s *sql.Selector) {
-		step := newDocumentStep()
+		step := newDocumentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -383,7 +323,7 @@ func HasMetadata() predicate.DocumentType {
 	return predicate.DocumentType(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, MetadataTable, MetadataColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, MetadataTable, MetadataPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})

--- a/internal/backends/ent/edgetype/where.go
+++ b/internal/backends/ent/edgetype/where.go
@@ -60,11 +60,6 @@ func IDLTE(id uuid.UUID) predicate.EdgeType {
 	return predicate.EdgeType(sql.FieldLTE(FieldID, id))
 }
 
-// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
-func DocumentID(v uuid.UUID) predicate.EdgeType {
-	return predicate.EdgeType(sql.FieldEQ(FieldDocumentID, v))
-}
-
 // ProtoMessage applies equality check predicate on the "proto_message" field. It's identical to ProtoMessageEQ.
 func ProtoMessage(v *sbom.Edge) predicate.EdgeType {
 	return predicate.EdgeType(sql.FieldEQ(FieldProtoMessage, v))
@@ -78,36 +73,6 @@ func NodeID(v uuid.UUID) predicate.EdgeType {
 // ToNodeID applies equality check predicate on the "to_node_id" field. It's identical to ToNodeIDEQ.
 func ToNodeID(v uuid.UUID) predicate.EdgeType {
 	return predicate.EdgeType(sql.FieldEQ(FieldToNodeID, v))
-}
-
-// DocumentIDEQ applies the EQ predicate on the "document_id" field.
-func DocumentIDEQ(v uuid.UUID) predicate.EdgeType {
-	return predicate.EdgeType(sql.FieldEQ(FieldDocumentID, v))
-}
-
-// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
-func DocumentIDNEQ(v uuid.UUID) predicate.EdgeType {
-	return predicate.EdgeType(sql.FieldNEQ(FieldDocumentID, v))
-}
-
-// DocumentIDIn applies the In predicate on the "document_id" field.
-func DocumentIDIn(vs ...uuid.UUID) predicate.EdgeType {
-	return predicate.EdgeType(sql.FieldIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
-func DocumentIDNotIn(vs ...uuid.UUID) predicate.EdgeType {
-	return predicate.EdgeType(sql.FieldNotIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDIsNil applies the IsNil predicate on the "document_id" field.
-func DocumentIDIsNil() predicate.EdgeType {
-	return predicate.EdgeType(sql.FieldIsNull(FieldDocumentID))
-}
-
-// DocumentIDNotNil applies the NotNil predicate on the "document_id" field.
-func DocumentIDNotNil() predicate.EdgeType {
-	return predicate.EdgeType(sql.FieldNotNull(FieldDocumentID))
 }
 
 // ProtoMessageEQ applies the EQ predicate on the "proto_message" field.
@@ -210,29 +175,6 @@ func ToNodeIDNotIn(vs ...uuid.UUID) predicate.EdgeType {
 	return predicate.EdgeType(sql.FieldNotIn(FieldToNodeID, vs...))
 }
 
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.EdgeType {
-	return predicate.EdgeType(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.EdgeType {
-	return predicate.EdgeType(func(s *sql.Selector) {
-		step := newDocumentStep()
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
 // HasFrom applies the HasEdge predicate on the "from" edge.
 func HasFrom() predicate.EdgeType {
 	return predicate.EdgeType(func(s *sql.Selector) {
@@ -271,6 +213,29 @@ func HasTo() predicate.EdgeType {
 func HasToWith(preds ...predicate.Node) predicate.EdgeType {
 	return predicate.EdgeType(func(s *sql.Selector) {
 		step := newToStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasDocuments applies the HasEdge predicate on the "documents" edge.
+func HasDocuments() predicate.EdgeType {
+	return predicate.EdgeType(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasDocumentsWith applies the HasEdge predicate on the "documents" edge with a given conditions (other predicates).
+func HasDocumentsWith(preds ...predicate.Document) predicate.EdgeType {
+	return predicate.EdgeType(func(s *sql.Selector) {
+		step := newDocumentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/backends/ent/externalreference/where.go
+++ b/internal/backends/ent/externalreference/where.go
@@ -60,11 +60,6 @@ func IDLTE(id uuid.UUID) predicate.ExternalReference {
 	return predicate.ExternalReference(sql.FieldLTE(FieldID, id))
 }
 
-// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
-func DocumentID(v uuid.UUID) predicate.ExternalReference {
-	return predicate.ExternalReference(sql.FieldEQ(FieldDocumentID, v))
-}
-
 // ProtoMessage applies equality check predicate on the "proto_message" field. It's identical to ProtoMessageEQ.
 func ProtoMessage(v *sbom.ExternalReference) predicate.ExternalReference {
 	return predicate.ExternalReference(sql.FieldEQ(FieldProtoMessage, v))
@@ -83,36 +78,6 @@ func Comment(v string) predicate.ExternalReference {
 // Authority applies equality check predicate on the "authority" field. It's identical to AuthorityEQ.
 func Authority(v string) predicate.ExternalReference {
 	return predicate.ExternalReference(sql.FieldEQ(FieldAuthority, v))
-}
-
-// DocumentIDEQ applies the EQ predicate on the "document_id" field.
-func DocumentIDEQ(v uuid.UUID) predicate.ExternalReference {
-	return predicate.ExternalReference(sql.FieldEQ(FieldDocumentID, v))
-}
-
-// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
-func DocumentIDNEQ(v uuid.UUID) predicate.ExternalReference {
-	return predicate.ExternalReference(sql.FieldNEQ(FieldDocumentID, v))
-}
-
-// DocumentIDIn applies the In predicate on the "document_id" field.
-func DocumentIDIn(vs ...uuid.UUID) predicate.ExternalReference {
-	return predicate.ExternalReference(sql.FieldIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
-func DocumentIDNotIn(vs ...uuid.UUID) predicate.ExternalReference {
-	return predicate.ExternalReference(sql.FieldNotIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDIsNil applies the IsNil predicate on the "document_id" field.
-func DocumentIDIsNil() predicate.ExternalReference {
-	return predicate.ExternalReference(sql.FieldIsNull(FieldDocumentID))
-}
-
-// DocumentIDNotNil applies the NotNil predicate on the "document_id" field.
-func DocumentIDNotNil() predicate.ExternalReference {
-	return predicate.ExternalReference(sql.FieldNotNull(FieldDocumentID))
 }
 
 // ProtoMessageEQ applies the EQ predicate on the "proto_message" field.
@@ -380,29 +345,6 @@ func TypeNotIn(vs ...Type) predicate.ExternalReference {
 	return predicate.ExternalReference(sql.FieldNotIn(FieldType, vs...))
 }
 
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.ExternalReference {
-	return predicate.ExternalReference(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.ExternalReference {
-	return predicate.ExternalReference(func(s *sql.Selector) {
-		step := newDocumentStep()
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
 // HasHashes applies the HasEdge predicate on the "hashes" edge.
 func HasHashes() predicate.ExternalReference {
 	return predicate.ExternalReference(func(s *sql.Selector) {
@@ -418,6 +360,29 @@ func HasHashes() predicate.ExternalReference {
 func HasHashesWith(preds ...predicate.HashesEntry) predicate.ExternalReference {
 	return predicate.ExternalReference(func(s *sql.Selector) {
 		step := newHashesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasDocuments applies the HasEdge predicate on the "documents" edge.
+func HasDocuments() predicate.ExternalReference {
+	return predicate.ExternalReference(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasDocumentsWith applies the HasEdge predicate on the "documents" edge with a given conditions (other predicates).
+func HasDocumentsWith(preds ...predicate.Document) predicate.ExternalReference {
+	return predicate.ExternalReference(func(s *sql.Selector) {
+		step := newDocumentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/backends/ent/hashesentry/hashesentry.go
+++ b/internal/backends/ent/hashesentry/hashesentry.go
@@ -21,27 +21,25 @@ const (
 	Label = "hashes_entry"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
-	// FieldDocumentID holds the string denoting the document_id field in the database.
-	FieldDocumentID = "document_id"
 	// FieldHashAlgorithm holds the string denoting the hash_algorithm field in the database.
 	FieldHashAlgorithm = "hash_algorithm"
 	// FieldHashData holds the string denoting the hash_data field in the database.
 	FieldHashData = "hash_data"
-	// EdgeDocument holds the string denoting the document edge name in mutations.
-	EdgeDocument = "document"
+	// EdgeDocuments holds the string denoting the documents edge name in mutations.
+	EdgeDocuments = "documents"
 	// EdgeExternalReferences holds the string denoting the external_references edge name in mutations.
 	EdgeExternalReferences = "external_references"
 	// EdgeNodes holds the string denoting the nodes edge name in mutations.
 	EdgeNodes = "nodes"
+	// EdgeSourceData holds the string denoting the source_data edge name in mutations.
+	EdgeSourceData = "source_data"
 	// Table holds the table name of the hashesentry in the database.
 	Table = "hashes_entries"
-	// DocumentTable is the table that holds the document relation/edge.
-	DocumentTable = "hashes_entries"
-	// DocumentInverseTable is the table name for the Document entity.
+	// DocumentsTable is the table that holds the documents relation/edge. The primary key declared below.
+	DocumentsTable = "document_hashes"
+	// DocumentsInverseTable is the table name for the Document entity.
 	// It exists in this package in order to avoid circular dependency with the "document" package.
-	DocumentInverseTable = "documents"
-	// DocumentColumn is the table column denoting the document relation/edge.
-	DocumentColumn = "document_id"
+	DocumentsInverseTable = "documents"
 	// ExternalReferencesTable is the table that holds the external_references relation/edge. The primary key declared below.
 	ExternalReferencesTable = "ext_ref_hashes"
 	// ExternalReferencesInverseTable is the table name for the ExternalReference entity.
@@ -52,23 +50,33 @@ const (
 	// NodesInverseTable is the table name for the Node entity.
 	// It exists in this package in order to avoid circular dependency with the "node" package.
 	NodesInverseTable = "nodes"
+	// SourceDataTable is the table that holds the source_data relation/edge. The primary key declared below.
+	SourceDataTable = "source_data_hashes"
+	// SourceDataInverseTable is the table name for the SourceData entity.
+	// It exists in this package in order to avoid circular dependency with the "sourcedata" package.
+	SourceDataInverseTable = "source_data"
 )
 
 // Columns holds all SQL columns for hashesentry fields.
 var Columns = []string{
 	FieldID,
-	FieldDocumentID,
 	FieldHashAlgorithm,
 	FieldHashData,
 }
 
 var (
+	// DocumentsPrimaryKey and DocumentsColumn2 are the table columns denoting the
+	// primary key for the documents relation (M2M).
+	DocumentsPrimaryKey = []string{"document_id", "hashes_entry_id"}
 	// ExternalReferencesPrimaryKey and ExternalReferencesColumn2 are the table columns denoting the
 	// primary key for the external_references relation (M2M).
 	ExternalReferencesPrimaryKey = []string{"ext_ref_id", "hash_entry_id"}
 	// NodesPrimaryKey and NodesColumn2 are the table columns denoting the
 	// primary key for the nodes relation (M2M).
 	NodesPrimaryKey = []string{"node_id", "hash_entry_id"}
+	// SourceDataPrimaryKey and SourceDataColumn2 are the table columns denoting the
+	// primary key for the source_data relation (M2M).
+	SourceDataPrimaryKey = []string{"source_data_id", "hash_entry_id"}
 )
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -87,9 +95,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/protobom/storage/internal/backends/ent/runtime"
 var (
-	Hooks [1]ent.Hook
-	// DefaultDocumentID holds the default value on creation for the "document_id" field.
-	DefaultDocumentID func() uuid.UUID
+	Hooks [2]ent.Hook
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() uuid.UUID
 )
@@ -141,11 +147,6 @@ func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
-// ByDocumentID orders the results by the document_id field.
-func ByDocumentID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldDocumentID, opts...).ToFunc()
-}
-
 // ByHashAlgorithm orders the results by the hash_algorithm field.
 func ByHashAlgorithm(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldHashAlgorithm, opts...).ToFunc()
@@ -156,10 +157,17 @@ func ByHashData(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldHashData, opts...).ToFunc()
 }
 
-// ByDocumentField orders the results by document field.
-func ByDocumentField(field string, opts ...sql.OrderTermOption) OrderOption {
+// ByDocumentsCount orders the results by documents count.
+func ByDocumentsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newDocumentStep(), sql.OrderByField(field, opts...))
+		sqlgraph.OrderByNeighborsCount(s, newDocumentsStep(), opts...)
+	}
+}
+
+// ByDocuments orders the results by documents terms.
+func ByDocuments(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newDocumentsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
@@ -190,11 +198,25 @@ func ByNodes(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 		sqlgraph.OrderByNeighborTerms(s, newNodesStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
-func newDocumentStep() *sqlgraph.Step {
+
+// BySourceDataCount orders the results by source_data count.
+func BySourceDataCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newSourceDataStep(), opts...)
+	}
+}
+
+// BySourceData orders the results by source_data terms.
+func BySourceData(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newSourceDataStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newDocumentsStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(DocumentInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
+		sqlgraph.To(DocumentsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
 	)
 }
 func newExternalReferencesStep() *sqlgraph.Step {
@@ -209,5 +231,12 @@ func newNodesStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(NodesInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2M, true, NodesTable, NodesPrimaryKey...),
+	)
+}
+func newSourceDataStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(SourceDataInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, SourceDataTable, SourceDataPrimaryKey...),
 	)
 }

--- a/internal/backends/ent/hashesentry/where.go
+++ b/internal/backends/ent/hashesentry/where.go
@@ -59,44 +59,9 @@ func IDLTE(id uuid.UUID) predicate.HashesEntry {
 	return predicate.HashesEntry(sql.FieldLTE(FieldID, id))
 }
 
-// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
-func DocumentID(v uuid.UUID) predicate.HashesEntry {
-	return predicate.HashesEntry(sql.FieldEQ(FieldDocumentID, v))
-}
-
 // HashData applies equality check predicate on the "hash_data" field. It's identical to HashDataEQ.
 func HashData(v string) predicate.HashesEntry {
 	return predicate.HashesEntry(sql.FieldEQ(FieldHashData, v))
-}
-
-// DocumentIDEQ applies the EQ predicate on the "document_id" field.
-func DocumentIDEQ(v uuid.UUID) predicate.HashesEntry {
-	return predicate.HashesEntry(sql.FieldEQ(FieldDocumentID, v))
-}
-
-// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
-func DocumentIDNEQ(v uuid.UUID) predicate.HashesEntry {
-	return predicate.HashesEntry(sql.FieldNEQ(FieldDocumentID, v))
-}
-
-// DocumentIDIn applies the In predicate on the "document_id" field.
-func DocumentIDIn(vs ...uuid.UUID) predicate.HashesEntry {
-	return predicate.HashesEntry(sql.FieldIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
-func DocumentIDNotIn(vs ...uuid.UUID) predicate.HashesEntry {
-	return predicate.HashesEntry(sql.FieldNotIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDIsNil applies the IsNil predicate on the "document_id" field.
-func DocumentIDIsNil() predicate.HashesEntry {
-	return predicate.HashesEntry(sql.FieldIsNull(FieldDocumentID))
-}
-
-// DocumentIDNotNil applies the NotNil predicate on the "document_id" field.
-func DocumentIDNotNil() predicate.HashesEntry {
-	return predicate.HashesEntry(sql.FieldNotNull(FieldDocumentID))
 }
 
 // HashAlgorithmEQ applies the EQ predicate on the "hash_algorithm" field.
@@ -184,21 +149,21 @@ func HashDataContainsFold(v string) predicate.HashesEntry {
 	return predicate.HashesEntry(sql.FieldContainsFold(FieldHashData, v))
 }
 
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.HashesEntry {
+// HasDocuments applies the HasEdge predicate on the "documents" edge.
+func HasDocuments() predicate.HashesEntry {
 	return predicate.HashesEntry(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
 }
 
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.HashesEntry {
+// HasDocumentsWith applies the HasEdge predicate on the "documents" edge with a given conditions (other predicates).
+func HasDocumentsWith(preds ...predicate.Document) predicate.HashesEntry {
 	return predicate.HashesEntry(func(s *sql.Selector) {
-		step := newDocumentStep()
+		step := newDocumentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -245,6 +210,29 @@ func HasNodes() predicate.HashesEntry {
 func HasNodesWith(preds ...predicate.Node) predicate.HashesEntry {
 	return predicate.HashesEntry(func(s *sql.Selector) {
 		step := newNodesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasSourceData applies the HasEdge predicate on the "source_data" edge.
+func HasSourceData() predicate.HashesEntry {
+	return predicate.HashesEntry(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, SourceDataTable, SourceDataPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasSourceDataWith applies the HasEdge predicate on the "source_data" edge with a given conditions (other predicates).
+func HasSourceDataWith(preds ...predicate.SourceData) predicate.HashesEntry {
+	return predicate.HashesEntry(func(s *sql.Selector) {
+		step := newSourceDataStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/backends/ent/hashesentry_update.go
+++ b/internal/backends/ent/hashesentry_update.go
@@ -20,6 +20,7 @@ import (
 	"github.com/protobom/storage/internal/backends/ent/hashesentry"
 	"github.com/protobom/storage/internal/backends/ent/node"
 	"github.com/protobom/storage/internal/backends/ent/predicate"
+	"github.com/protobom/storage/internal/backends/ent/sourcedata"
 )
 
 // HashesEntryUpdate is the builder for updating HashesEntry entities.
@@ -93,6 +94,21 @@ func (heu *HashesEntryUpdate) AddNodes(n ...*Node) *HashesEntryUpdate {
 	return heu.AddNodeIDs(ids...)
 }
 
+// AddSourceDatumIDs adds the "source_data" edge to the SourceData entity by IDs.
+func (heu *HashesEntryUpdate) AddSourceDatumIDs(ids ...uuid.UUID) *HashesEntryUpdate {
+	heu.mutation.AddSourceDatumIDs(ids...)
+	return heu
+}
+
+// AddSourceData adds the "source_data" edges to the SourceData entity.
+func (heu *HashesEntryUpdate) AddSourceData(s ...*SourceData) *HashesEntryUpdate {
+	ids := make([]uuid.UUID, len(s))
+	for i := range s {
+		ids[i] = s[i].ID
+	}
+	return heu.AddSourceDatumIDs(ids...)
+}
+
 // Mutation returns the HashesEntryMutation object of the builder.
 func (heu *HashesEntryUpdate) Mutation() *HashesEntryMutation {
 	return heu.mutation
@@ -138,6 +154,27 @@ func (heu *HashesEntryUpdate) RemoveNodes(n ...*Node) *HashesEntryUpdate {
 		ids[i] = n[i].ID
 	}
 	return heu.RemoveNodeIDs(ids...)
+}
+
+// ClearSourceData clears all "source_data" edges to the SourceData entity.
+func (heu *HashesEntryUpdate) ClearSourceData() *HashesEntryUpdate {
+	heu.mutation.ClearSourceData()
+	return heu
+}
+
+// RemoveSourceDatumIDs removes the "source_data" edge to SourceData entities by IDs.
+func (heu *HashesEntryUpdate) RemoveSourceDatumIDs(ids ...uuid.UUID) *HashesEntryUpdate {
+	heu.mutation.RemoveSourceDatumIDs(ids...)
+	return heu
+}
+
+// RemoveSourceData removes "source_data" edges to SourceData entities.
+func (heu *HashesEntryUpdate) RemoveSourceData(s ...*SourceData) *HashesEntryUpdate {
+	ids := make([]uuid.UUID, len(s))
+	for i := range s {
+		ids[i] = s[i].ID
+	}
+	return heu.RemoveSourceDatumIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -285,6 +322,51 @@ func (heu *HashesEntryUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if heu.mutation.SourceDataCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   hashesentry.SourceDataTable,
+			Columns: hashesentry.SourceDataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := heu.mutation.RemovedSourceDataIDs(); len(nodes) > 0 && !heu.mutation.SourceDataCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   hashesentry.SourceDataTable,
+			Columns: hashesentry.SourceDataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := heu.mutation.SourceDataIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   hashesentry.SourceDataTable,
+			Columns: hashesentry.SourceDataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, heu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{hashesentry.Label}
@@ -363,6 +445,21 @@ func (heuo *HashesEntryUpdateOne) AddNodes(n ...*Node) *HashesEntryUpdateOne {
 	return heuo.AddNodeIDs(ids...)
 }
 
+// AddSourceDatumIDs adds the "source_data" edge to the SourceData entity by IDs.
+func (heuo *HashesEntryUpdateOne) AddSourceDatumIDs(ids ...uuid.UUID) *HashesEntryUpdateOne {
+	heuo.mutation.AddSourceDatumIDs(ids...)
+	return heuo
+}
+
+// AddSourceData adds the "source_data" edges to the SourceData entity.
+func (heuo *HashesEntryUpdateOne) AddSourceData(s ...*SourceData) *HashesEntryUpdateOne {
+	ids := make([]uuid.UUID, len(s))
+	for i := range s {
+		ids[i] = s[i].ID
+	}
+	return heuo.AddSourceDatumIDs(ids...)
+}
+
 // Mutation returns the HashesEntryMutation object of the builder.
 func (heuo *HashesEntryUpdateOne) Mutation() *HashesEntryMutation {
 	return heuo.mutation
@@ -408,6 +505,27 @@ func (heuo *HashesEntryUpdateOne) RemoveNodes(n ...*Node) *HashesEntryUpdateOne 
 		ids[i] = n[i].ID
 	}
 	return heuo.RemoveNodeIDs(ids...)
+}
+
+// ClearSourceData clears all "source_data" edges to the SourceData entity.
+func (heuo *HashesEntryUpdateOne) ClearSourceData() *HashesEntryUpdateOne {
+	heuo.mutation.ClearSourceData()
+	return heuo
+}
+
+// RemoveSourceDatumIDs removes the "source_data" edge to SourceData entities by IDs.
+func (heuo *HashesEntryUpdateOne) RemoveSourceDatumIDs(ids ...uuid.UUID) *HashesEntryUpdateOne {
+	heuo.mutation.RemoveSourceDatumIDs(ids...)
+	return heuo
+}
+
+// RemoveSourceData removes "source_data" edges to SourceData entities.
+func (heuo *HashesEntryUpdateOne) RemoveSourceData(s ...*SourceData) *HashesEntryUpdateOne {
+	ids := make([]uuid.UUID, len(s))
+	for i := range s {
+		ids[i] = s[i].ID
+	}
+	return heuo.RemoveSourceDatumIDs(ids...)
 }
 
 // Where appends a list predicates to the HashesEntryUpdate builder.
@@ -578,6 +696,51 @@ func (heuo *HashesEntryUpdateOne) sqlSave(ctx context.Context) (_node *HashesEnt
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if heuo.mutation.SourceDataCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   hashesentry.SourceDataTable,
+			Columns: hashesentry.SourceDataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := heuo.mutation.RemovedSourceDataIDs(); len(nodes) > 0 && !heuo.mutation.SourceDataCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   hashesentry.SourceDataTable,
+			Columns: hashesentry.SourceDataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := heuo.mutation.SourceDataIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   hashesentry.SourceDataTable,
+			Columns: hashesentry.SourceDataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/internal/backends/ent/identifiersentry.go
+++ b/internal/backends/ent/identifiersentry.go
@@ -15,7 +15,6 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"github.com/google/uuid"
-	"github.com/protobom/storage/internal/backends/ent/document"
 	"github.com/protobom/storage/internal/backends/ent/identifiersentry"
 )
 
@@ -24,8 +23,6 @@ type IdentifiersEntry struct {
 	config `json:"-"`
 	// ID of the ent.
 	ID uuid.UUID `json:"-"`
-	// DocumentID holds the value of the "document_id" field.
-	DocumentID uuid.UUID `json:"-"`
 	// Type holds the value of the "type" field.
 	Type identifiersentry.Type `json:"type,omitempty"`
 	// Value holds the value of the "value" field.
@@ -38,8 +35,8 @@ type IdentifiersEntry struct {
 
 // IdentifiersEntryEdges holds the relations/edges for other nodes in the graph.
 type IdentifiersEntryEdges struct {
-	// Document holds the value of the document edge.
-	Document *Document `json:"document,omitempty"`
+	// Documents holds the value of the documents edge.
+	Documents []*Document `json:"-"`
 	// Nodes holds the value of the nodes edge.
 	Nodes []*Node `json:"-"`
 	// loadedTypes holds the information for reporting if a
@@ -47,15 +44,13 @@ type IdentifiersEntryEdges struct {
 	loadedTypes [2]bool
 }
 
-// DocumentOrErr returns the Document value or an error if the edge
-// was not loaded in eager-loading, or loaded but was not found.
-func (e IdentifiersEntryEdges) DocumentOrErr() (*Document, error) {
-	if e.Document != nil {
-		return e.Document, nil
-	} else if e.loadedTypes[0] {
-		return nil, &NotFoundError{label: document.Label}
+// DocumentsOrErr returns the Documents value or an error if the edge
+// was not loaded in eager-loading.
+func (e IdentifiersEntryEdges) DocumentsOrErr() ([]*Document, error) {
+	if e.loadedTypes[0] {
+		return e.Documents, nil
 	}
-	return nil, &NotLoadedError{edge: "document"}
+	return nil, &NotLoadedError{edge: "documents"}
 }
 
 // NodesOrErr returns the Nodes value or an error if the edge
@@ -74,7 +69,7 @@ func (*IdentifiersEntry) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case identifiersentry.FieldType, identifiersentry.FieldValue:
 			values[i] = new(sql.NullString)
-		case identifiersentry.FieldID, identifiersentry.FieldDocumentID:
+		case identifiersentry.FieldID:
 			values[i] = new(uuid.UUID)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -96,12 +91,6 @@ func (ie *IdentifiersEntry) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field id", values[i])
 			} else if value != nil {
 				ie.ID = *value
-			}
-		case identifiersentry.FieldDocumentID:
-			if value, ok := values[i].(*uuid.UUID); !ok {
-				return fmt.Errorf("unexpected type %T for field document_id", values[i])
-			} else if value != nil {
-				ie.DocumentID = *value
 			}
 		case identifiersentry.FieldType:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -128,9 +117,9 @@ func (ie *IdentifiersEntry) GetValue(name string) (ent.Value, error) {
 	return ie.selectValues.Get(name)
 }
 
-// QueryDocument queries the "document" edge of the IdentifiersEntry entity.
-func (ie *IdentifiersEntry) QueryDocument() *DocumentQuery {
-	return NewIdentifiersEntryClient(ie.config).QueryDocument(ie)
+// QueryDocuments queries the "documents" edge of the IdentifiersEntry entity.
+func (ie *IdentifiersEntry) QueryDocuments() *DocumentQuery {
+	return NewIdentifiersEntryClient(ie.config).QueryDocuments(ie)
 }
 
 // QueryNodes queries the "nodes" edge of the IdentifiersEntry entity.
@@ -161,9 +150,6 @@ func (ie *IdentifiersEntry) String() string {
 	var builder strings.Builder
 	builder.WriteString("IdentifiersEntry(")
 	builder.WriteString(fmt.Sprintf("id=%v, ", ie.ID))
-	builder.WriteString("document_id=")
-	builder.WriteString(fmt.Sprintf("%v", ie.DocumentID))
-	builder.WriteString(", ")
 	builder.WriteString("type=")
 	builder.WriteString(fmt.Sprintf("%v", ie.Type))
 	builder.WriteString(", ")

--- a/internal/backends/ent/identifiersentry/where.go
+++ b/internal/backends/ent/identifiersentry/where.go
@@ -59,44 +59,9 @@ func IDLTE(id uuid.UUID) predicate.IdentifiersEntry {
 	return predicate.IdentifiersEntry(sql.FieldLTE(FieldID, id))
 }
 
-// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
-func DocumentID(v uuid.UUID) predicate.IdentifiersEntry {
-	return predicate.IdentifiersEntry(sql.FieldEQ(FieldDocumentID, v))
-}
-
 // Value applies equality check predicate on the "value" field. It's identical to ValueEQ.
 func Value(v string) predicate.IdentifiersEntry {
 	return predicate.IdentifiersEntry(sql.FieldEQ(FieldValue, v))
-}
-
-// DocumentIDEQ applies the EQ predicate on the "document_id" field.
-func DocumentIDEQ(v uuid.UUID) predicate.IdentifiersEntry {
-	return predicate.IdentifiersEntry(sql.FieldEQ(FieldDocumentID, v))
-}
-
-// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
-func DocumentIDNEQ(v uuid.UUID) predicate.IdentifiersEntry {
-	return predicate.IdentifiersEntry(sql.FieldNEQ(FieldDocumentID, v))
-}
-
-// DocumentIDIn applies the In predicate on the "document_id" field.
-func DocumentIDIn(vs ...uuid.UUID) predicate.IdentifiersEntry {
-	return predicate.IdentifiersEntry(sql.FieldIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
-func DocumentIDNotIn(vs ...uuid.UUID) predicate.IdentifiersEntry {
-	return predicate.IdentifiersEntry(sql.FieldNotIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDIsNil applies the IsNil predicate on the "document_id" field.
-func DocumentIDIsNil() predicate.IdentifiersEntry {
-	return predicate.IdentifiersEntry(sql.FieldIsNull(FieldDocumentID))
-}
-
-// DocumentIDNotNil applies the NotNil predicate on the "document_id" field.
-func DocumentIDNotNil() predicate.IdentifiersEntry {
-	return predicate.IdentifiersEntry(sql.FieldNotNull(FieldDocumentID))
 }
 
 // TypeEQ applies the EQ predicate on the "type" field.
@@ -184,21 +149,21 @@ func ValueContainsFold(v string) predicate.IdentifiersEntry {
 	return predicate.IdentifiersEntry(sql.FieldContainsFold(FieldValue, v))
 }
 
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.IdentifiersEntry {
+// HasDocuments applies the HasEdge predicate on the "documents" edge.
+func HasDocuments() predicate.IdentifiersEntry {
 	return predicate.IdentifiersEntry(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
 }
 
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.IdentifiersEntry {
+// HasDocumentsWith applies the HasEdge predicate on the "documents" edge with a given conditions (other predicates).
+func HasDocumentsWith(preds ...predicate.Document) predicate.IdentifiersEntry {
 	return predicate.IdentifiersEntry(func(s *sql.Selector) {
-		step := newDocumentStep()
+		step := newDocumentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/backends/ent/metadata/where.go
+++ b/internal/backends/ent/metadata/where.go
@@ -67,6 +67,11 @@ func ProtoMessage(v *sbom.Metadata) predicate.Metadata {
 	return predicate.Metadata(sql.FieldEQ(FieldProtoMessage, v))
 }
 
+// SourceDataID applies equality check predicate on the "source_data_id" field. It's identical to SourceDataIDEQ.
+func SourceDataID(v uuid.UUID) predicate.Metadata {
+	return predicate.Metadata(sql.FieldEQ(FieldSourceDataID, v))
+}
+
 // NativeID applies equality check predicate on the "native_id" field. It's identical to NativeIDEQ.
 func NativeID(v string) predicate.Metadata {
 	return predicate.Metadata(sql.FieldEQ(FieldNativeID, v))
@@ -130,6 +135,36 @@ func ProtoMessageLT(v *sbom.Metadata) predicate.Metadata {
 // ProtoMessageLTE applies the LTE predicate on the "proto_message" field.
 func ProtoMessageLTE(v *sbom.Metadata) predicate.Metadata {
 	return predicate.Metadata(sql.FieldLTE(FieldProtoMessage, v))
+}
+
+// SourceDataIDEQ applies the EQ predicate on the "source_data_id" field.
+func SourceDataIDEQ(v uuid.UUID) predicate.Metadata {
+	return predicate.Metadata(sql.FieldEQ(FieldSourceDataID, v))
+}
+
+// SourceDataIDNEQ applies the NEQ predicate on the "source_data_id" field.
+func SourceDataIDNEQ(v uuid.UUID) predicate.Metadata {
+	return predicate.Metadata(sql.FieldNEQ(FieldSourceDataID, v))
+}
+
+// SourceDataIDIn applies the In predicate on the "source_data_id" field.
+func SourceDataIDIn(vs ...uuid.UUID) predicate.Metadata {
+	return predicate.Metadata(sql.FieldIn(FieldSourceDataID, vs...))
+}
+
+// SourceDataIDNotIn applies the NotIn predicate on the "source_data_id" field.
+func SourceDataIDNotIn(vs ...uuid.UUID) predicate.Metadata {
+	return predicate.Metadata(sql.FieldNotIn(FieldSourceDataID, vs...))
+}
+
+// SourceDataIDIsNil applies the IsNil predicate on the "source_data_id" field.
+func SourceDataIDIsNil() predicate.Metadata {
+	return predicate.Metadata(sql.FieldIsNull(FieldSourceDataID))
+}
+
+// SourceDataIDNotNil applies the NotNil predicate on the "source_data_id" field.
+func SourceDataIDNotNil() predicate.Metadata {
+	return predicate.Metadata(sql.FieldNotNull(FieldSourceDataID))
 }
 
 // NativeIDEQ applies the EQ predicate on the "native_id" field.
@@ -432,35 +467,12 @@ func CommentContainsFold(v string) predicate.Metadata {
 	return predicate.Metadata(sql.FieldContainsFold(FieldComment, v))
 }
 
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.Metadata {
-	return predicate.Metadata(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, DocumentTable, DocumentColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.Metadata {
-	return predicate.Metadata(func(s *sql.Selector) {
-		step := newDocumentStep()
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
 // HasTools applies the HasEdge predicate on the "tools" edge.
 func HasTools() predicate.Metadata {
 	return predicate.Metadata(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, ToolsTable, ToolsColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, ToolsTable, ToolsPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -483,7 +495,7 @@ func HasAuthors() predicate.Metadata {
 	return predicate.Metadata(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, AuthorsTable, AuthorsColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, AuthorsTable, AuthorsPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -506,7 +518,7 @@ func HasDocumentTypes() predicate.Metadata {
 	return predicate.Metadata(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, DocumentTypesTable, DocumentTypesColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, DocumentTypesTable, DocumentTypesPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -529,7 +541,7 @@ func HasSourceData() predicate.Metadata {
 	return predicate.Metadata(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, SourceDataTable, SourceDataColumn),
+			sqlgraph.Edge(sqlgraph.M2O, false, SourceDataTable, SourceDataColumn),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -539,6 +551,29 @@ func HasSourceData() predicate.Metadata {
 func HasSourceDataWith(preds ...predicate.SourceData) predicate.Metadata {
 	return predicate.Metadata(func(s *sql.Selector) {
 		step := newSourceDataStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasDocuments applies the HasEdge predicate on the "documents" edge.
+func HasDocuments() predicate.Metadata {
+	return predicate.Metadata(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, true, DocumentsTable, DocumentsColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasDocumentsWith applies the HasEdge predicate on the "documents" edge with a given conditions (other predicates).
+func HasDocumentsWith(preds ...predicate.Document) predicate.Metadata {
+	return predicate.Metadata(func(s *sql.Selector) {
+		step := newDocumentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/backends/ent/metadata_update.go
+++ b/internal/backends/ent/metadata_update.go
@@ -38,6 +38,26 @@ func (mu *MetadataUpdate) Where(ps ...predicate.Metadata) *MetadataUpdate {
 	return mu
 }
 
+// SetSourceDataID sets the "source_data_id" field.
+func (mu *MetadataUpdate) SetSourceDataID(u uuid.UUID) *MetadataUpdate {
+	mu.mutation.SetSourceDataID(u)
+	return mu
+}
+
+// SetNillableSourceDataID sets the "source_data_id" field if the given value is not nil.
+func (mu *MetadataUpdate) SetNillableSourceDataID(u *uuid.UUID) *MetadataUpdate {
+	if u != nil {
+		mu.SetSourceDataID(*u)
+	}
+	return mu
+}
+
+// ClearSourceDataID clears the value of the "source_data_id" field.
+func (mu *MetadataUpdate) ClearSourceDataID() *MetadataUpdate {
+	mu.mutation.ClearSourceDataID()
+	return mu
+}
+
 // SetVersion sets the "version" field.
 func (mu *MetadataUpdate) SetVersion(s string) *MetadataUpdate {
 	mu.mutation.SetVersion(s)
@@ -139,19 +159,9 @@ func (mu *MetadataUpdate) AddDocumentTypes(d ...*DocumentType) *MetadataUpdate {
 	return mu.AddDocumentTypeIDs(ids...)
 }
 
-// AddSourceDatumIDs adds the "source_data" edge to the SourceData entity by IDs.
-func (mu *MetadataUpdate) AddSourceDatumIDs(ids ...uuid.UUID) *MetadataUpdate {
-	mu.mutation.AddSourceDatumIDs(ids...)
-	return mu
-}
-
-// AddSourceData adds the "source_data" edges to the SourceData entity.
-func (mu *MetadataUpdate) AddSourceData(s ...*SourceData) *MetadataUpdate {
-	ids := make([]uuid.UUID, len(s))
-	for i := range s {
-		ids[i] = s[i].ID
-	}
-	return mu.AddSourceDatumIDs(ids...)
+// SetSourceData sets the "source_data" edge to the SourceData entity.
+func (mu *MetadataUpdate) SetSourceData(s *SourceData) *MetadataUpdate {
+	return mu.SetSourceDataID(s.ID)
 }
 
 // Mutation returns the MetadataMutation object of the builder.
@@ -222,25 +232,10 @@ func (mu *MetadataUpdate) RemoveDocumentTypes(d ...*DocumentType) *MetadataUpdat
 	return mu.RemoveDocumentTypeIDs(ids...)
 }
 
-// ClearSourceData clears all "source_data" edges to the SourceData entity.
+// ClearSourceData clears the "source_data" edge to the SourceData entity.
 func (mu *MetadataUpdate) ClearSourceData() *MetadataUpdate {
 	mu.mutation.ClearSourceData()
 	return mu
-}
-
-// RemoveSourceDatumIDs removes the "source_data" edge to SourceData entities by IDs.
-func (mu *MetadataUpdate) RemoveSourceDatumIDs(ids ...uuid.UUID) *MetadataUpdate {
-	mu.mutation.RemoveSourceDatumIDs(ids...)
-	return mu
-}
-
-// RemoveSourceData removes "source_data" edges to SourceData entities.
-func (mu *MetadataUpdate) RemoveSourceData(s ...*SourceData) *MetadataUpdate {
-	ids := make([]uuid.UUID, len(s))
-	for i := range s {
-		ids[i] = s[i].ID
-	}
-	return mu.RemoveSourceDatumIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -270,18 +265,7 @@ func (mu *MetadataUpdate) ExecX(ctx context.Context) {
 	}
 }
 
-// check runs all checks and user-defined validators on the builder.
-func (mu *MetadataUpdate) check() error {
-	if mu.mutation.DocumentCleared() && len(mu.mutation.DocumentIDs()) > 0 {
-		return errors.New(`ent: clearing a required unique edge "Metadata.document"`)
-	}
-	return nil
-}
-
 func (mu *MetadataUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	if err := mu.check(); err != nil {
-		return n, err
-	}
 	_spec := sqlgraph.NewUpdateSpec(metadata.Table, metadata.Columns, sqlgraph.NewFieldSpec(metadata.FieldID, field.TypeUUID))
 	if ps := mu.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
@@ -304,10 +288,10 @@ func (mu *MetadataUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if mu.mutation.ToolsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.ToolsTable,
-			Columns: []string{metadata.ToolsColumn},
+			Columns: metadata.ToolsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID),
@@ -317,10 +301,10 @@ func (mu *MetadataUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := mu.mutation.RemovedToolsIDs(); len(nodes) > 0 && !mu.mutation.ToolsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.ToolsTable,
-			Columns: []string{metadata.ToolsColumn},
+			Columns: metadata.ToolsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID),
@@ -333,10 +317,10 @@ func (mu *MetadataUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := mu.mutation.ToolsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.ToolsTable,
-			Columns: []string{metadata.ToolsColumn},
+			Columns: metadata.ToolsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID),
@@ -349,10 +333,10 @@ func (mu *MetadataUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if mu.mutation.AuthorsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.AuthorsTable,
-			Columns: []string{metadata.AuthorsColumn},
+			Columns: metadata.AuthorsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -362,10 +346,10 @@ func (mu *MetadataUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := mu.mutation.RemovedAuthorsIDs(); len(nodes) > 0 && !mu.mutation.AuthorsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.AuthorsTable,
-			Columns: []string{metadata.AuthorsColumn},
+			Columns: metadata.AuthorsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -378,10 +362,10 @@ func (mu *MetadataUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := mu.mutation.AuthorsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.AuthorsTable,
-			Columns: []string{metadata.AuthorsColumn},
+			Columns: metadata.AuthorsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -394,10 +378,10 @@ func (mu *MetadataUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if mu.mutation.DocumentTypesCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.DocumentTypesTable,
-			Columns: []string{metadata.DocumentTypesColumn},
+			Columns: metadata.DocumentTypesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(documenttype.FieldID, field.TypeUUID),
@@ -407,10 +391,10 @@ func (mu *MetadataUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := mu.mutation.RemovedDocumentTypesIDs(); len(nodes) > 0 && !mu.mutation.DocumentTypesCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.DocumentTypesTable,
-			Columns: []string{metadata.DocumentTypesColumn},
+			Columns: metadata.DocumentTypesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(documenttype.FieldID, field.TypeUUID),
@@ -423,10 +407,10 @@ func (mu *MetadataUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := mu.mutation.DocumentTypesIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.DocumentTypesTable,
-			Columns: []string{metadata.DocumentTypesColumn},
+			Columns: metadata.DocumentTypesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(documenttype.FieldID, field.TypeUUID),
@@ -439,7 +423,7 @@ func (mu *MetadataUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if mu.mutation.SourceDataCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2O,
 			Inverse: false,
 			Table:   metadata.SourceDataTable,
 			Columns: []string{metadata.SourceDataColumn},
@@ -447,28 +431,12 @@ func (mu *MetadataUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
 			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := mu.mutation.RemovedSourceDataIDs(); len(nodes) > 0 && !mu.mutation.SourceDataCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: false,
-			Table:   metadata.SourceDataTable,
-			Columns: []string{metadata.SourceDataColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := mu.mutation.SourceDataIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2O,
 			Inverse: false,
 			Table:   metadata.SourceDataTable,
 			Columns: []string{metadata.SourceDataColumn},
@@ -500,6 +468,26 @@ type MetadataUpdateOne struct {
 	fields   []string
 	hooks    []Hook
 	mutation *MetadataMutation
+}
+
+// SetSourceDataID sets the "source_data_id" field.
+func (muo *MetadataUpdateOne) SetSourceDataID(u uuid.UUID) *MetadataUpdateOne {
+	muo.mutation.SetSourceDataID(u)
+	return muo
+}
+
+// SetNillableSourceDataID sets the "source_data_id" field if the given value is not nil.
+func (muo *MetadataUpdateOne) SetNillableSourceDataID(u *uuid.UUID) *MetadataUpdateOne {
+	if u != nil {
+		muo.SetSourceDataID(*u)
+	}
+	return muo
+}
+
+// ClearSourceDataID clears the value of the "source_data_id" field.
+func (muo *MetadataUpdateOne) ClearSourceDataID() *MetadataUpdateOne {
+	muo.mutation.ClearSourceDataID()
+	return muo
 }
 
 // SetVersion sets the "version" field.
@@ -603,19 +591,9 @@ func (muo *MetadataUpdateOne) AddDocumentTypes(d ...*DocumentType) *MetadataUpda
 	return muo.AddDocumentTypeIDs(ids...)
 }
 
-// AddSourceDatumIDs adds the "source_data" edge to the SourceData entity by IDs.
-func (muo *MetadataUpdateOne) AddSourceDatumIDs(ids ...uuid.UUID) *MetadataUpdateOne {
-	muo.mutation.AddSourceDatumIDs(ids...)
-	return muo
-}
-
-// AddSourceData adds the "source_data" edges to the SourceData entity.
-func (muo *MetadataUpdateOne) AddSourceData(s ...*SourceData) *MetadataUpdateOne {
-	ids := make([]uuid.UUID, len(s))
-	for i := range s {
-		ids[i] = s[i].ID
-	}
-	return muo.AddSourceDatumIDs(ids...)
+// SetSourceData sets the "source_data" edge to the SourceData entity.
+func (muo *MetadataUpdateOne) SetSourceData(s *SourceData) *MetadataUpdateOne {
+	return muo.SetSourceDataID(s.ID)
 }
 
 // Mutation returns the MetadataMutation object of the builder.
@@ -686,25 +664,10 @@ func (muo *MetadataUpdateOne) RemoveDocumentTypes(d ...*DocumentType) *MetadataU
 	return muo.RemoveDocumentTypeIDs(ids...)
 }
 
-// ClearSourceData clears all "source_data" edges to the SourceData entity.
+// ClearSourceData clears the "source_data" edge to the SourceData entity.
 func (muo *MetadataUpdateOne) ClearSourceData() *MetadataUpdateOne {
 	muo.mutation.ClearSourceData()
 	return muo
-}
-
-// RemoveSourceDatumIDs removes the "source_data" edge to SourceData entities by IDs.
-func (muo *MetadataUpdateOne) RemoveSourceDatumIDs(ids ...uuid.UUID) *MetadataUpdateOne {
-	muo.mutation.RemoveSourceDatumIDs(ids...)
-	return muo
-}
-
-// RemoveSourceData removes "source_data" edges to SourceData entities.
-func (muo *MetadataUpdateOne) RemoveSourceData(s ...*SourceData) *MetadataUpdateOne {
-	ids := make([]uuid.UUID, len(s))
-	for i := range s {
-		ids[i] = s[i].ID
-	}
-	return muo.RemoveSourceDatumIDs(ids...)
 }
 
 // Where appends a list predicates to the MetadataUpdate builder.
@@ -747,18 +710,7 @@ func (muo *MetadataUpdateOne) ExecX(ctx context.Context) {
 	}
 }
 
-// check runs all checks and user-defined validators on the builder.
-func (muo *MetadataUpdateOne) check() error {
-	if muo.mutation.DocumentCleared() && len(muo.mutation.DocumentIDs()) > 0 {
-		return errors.New(`ent: clearing a required unique edge "Metadata.document"`)
-	}
-	return nil
-}
-
 func (muo *MetadataUpdateOne) sqlSave(ctx context.Context) (_node *Metadata, err error) {
-	if err := muo.check(); err != nil {
-		return _node, err
-	}
 	_spec := sqlgraph.NewUpdateSpec(metadata.Table, metadata.Columns, sqlgraph.NewFieldSpec(metadata.FieldID, field.TypeUUID))
 	id, ok := muo.mutation.ID()
 	if !ok {
@@ -798,10 +750,10 @@ func (muo *MetadataUpdateOne) sqlSave(ctx context.Context) (_node *Metadata, err
 	}
 	if muo.mutation.ToolsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.ToolsTable,
-			Columns: []string{metadata.ToolsColumn},
+			Columns: metadata.ToolsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID),
@@ -811,10 +763,10 @@ func (muo *MetadataUpdateOne) sqlSave(ctx context.Context) (_node *Metadata, err
 	}
 	if nodes := muo.mutation.RemovedToolsIDs(); len(nodes) > 0 && !muo.mutation.ToolsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.ToolsTable,
-			Columns: []string{metadata.ToolsColumn},
+			Columns: metadata.ToolsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID),
@@ -827,10 +779,10 @@ func (muo *MetadataUpdateOne) sqlSave(ctx context.Context) (_node *Metadata, err
 	}
 	if nodes := muo.mutation.ToolsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.ToolsTable,
-			Columns: []string{metadata.ToolsColumn},
+			Columns: metadata.ToolsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(tool.FieldID, field.TypeUUID),
@@ -843,10 +795,10 @@ func (muo *MetadataUpdateOne) sqlSave(ctx context.Context) (_node *Metadata, err
 	}
 	if muo.mutation.AuthorsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.AuthorsTable,
-			Columns: []string{metadata.AuthorsColumn},
+			Columns: metadata.AuthorsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -856,10 +808,10 @@ func (muo *MetadataUpdateOne) sqlSave(ctx context.Context) (_node *Metadata, err
 	}
 	if nodes := muo.mutation.RemovedAuthorsIDs(); len(nodes) > 0 && !muo.mutation.AuthorsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.AuthorsTable,
-			Columns: []string{metadata.AuthorsColumn},
+			Columns: metadata.AuthorsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -872,10 +824,10 @@ func (muo *MetadataUpdateOne) sqlSave(ctx context.Context) (_node *Metadata, err
 	}
 	if nodes := muo.mutation.AuthorsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.AuthorsTable,
-			Columns: []string{metadata.AuthorsColumn},
+			Columns: metadata.AuthorsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -888,10 +840,10 @@ func (muo *MetadataUpdateOne) sqlSave(ctx context.Context) (_node *Metadata, err
 	}
 	if muo.mutation.DocumentTypesCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.DocumentTypesTable,
-			Columns: []string{metadata.DocumentTypesColumn},
+			Columns: metadata.DocumentTypesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(documenttype.FieldID, field.TypeUUID),
@@ -901,10 +853,10 @@ func (muo *MetadataUpdateOne) sqlSave(ctx context.Context) (_node *Metadata, err
 	}
 	if nodes := muo.mutation.RemovedDocumentTypesIDs(); len(nodes) > 0 && !muo.mutation.DocumentTypesCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.DocumentTypesTable,
-			Columns: []string{metadata.DocumentTypesColumn},
+			Columns: metadata.DocumentTypesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(documenttype.FieldID, field.TypeUUID),
@@ -917,10 +869,10 @@ func (muo *MetadataUpdateOne) sqlSave(ctx context.Context) (_node *Metadata, err
 	}
 	if nodes := muo.mutation.DocumentTypesIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   metadata.DocumentTypesTable,
-			Columns: []string{metadata.DocumentTypesColumn},
+			Columns: metadata.DocumentTypesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(documenttype.FieldID, field.TypeUUID),
@@ -933,7 +885,7 @@ func (muo *MetadataUpdateOne) sqlSave(ctx context.Context) (_node *Metadata, err
 	}
 	if muo.mutation.SourceDataCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2O,
 			Inverse: false,
 			Table:   metadata.SourceDataTable,
 			Columns: []string{metadata.SourceDataColumn},
@@ -941,28 +893,12 @@ func (muo *MetadataUpdateOne) sqlSave(ctx context.Context) (_node *Metadata, err
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
 			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := muo.mutation.RemovedSourceDataIDs(); len(nodes) > 0 && !muo.mutation.SourceDataCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: false,
-			Table:   metadata.SourceDataTable,
-			Columns: []string{metadata.SourceDataColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(sourcedata.FieldID, field.TypeUUID),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := muo.mutation.SourceDataIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2O,
 			Inverse: false,
 			Table:   metadata.SourceDataTable,
 			Columns: []string{metadata.SourceDataColumn},

--- a/internal/backends/ent/migrate/migrations/20250121182342_non_unique_inverse_edges.sql
+++ b/internal/backends/ent/migrate/migrations/20250121182342_non_unique_inverse_edges.sql
@@ -1,0 +1,416 @@
+-- Disable the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = off;
+-- Create "new_nodes" table
+CREATE TABLE `new_nodes` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `native_id` text NOT NULL,
+  `type` text NOT NULL,
+  `name` text NOT NULL,
+  `version` text NOT NULL,
+  `file_name` text NOT NULL,
+  `url_home` text NOT NULL,
+  `url_download` text NOT NULL,
+  `licenses` json NOT NULL,
+  `license_concluded` text NOT NULL,
+  `license_comments` text NOT NULL,
+  `copyright` text NOT NULL,
+  `source_info` text NOT NULL,
+  `comment` text NOT NULL,
+  `summary` text NOT NULL,
+  `description` text NOT NULL,
+  `release_date` datetime NOT NULL,
+  `build_date` datetime NOT NULL,
+  `valid_until_date` datetime NOT NULL,
+  `attribution` json NOT NULL,
+  `file_types` json NOT NULL,
+  PRIMARY KEY (`id`)
+);
+-- Copy rows from old table "nodes" to new temporary table "new_nodes"
+INSERT INTO `new_nodes` (`id`, `proto_message`, `native_id`, `type`, `name`, `version`, `file_name`, `url_home`, `url_download`, `licenses`, `license_concluded`, `license_comments`, `copyright`, `source_info`, `comment`, `summary`, `description`, `release_date`, `build_date`, `valid_until_date`, `attribution`, `file_types`) SELECT `id`, `proto_message`, `native_id`, `type`, `name`, `version`, `file_name`, `url_home`, `url_download`, `licenses`, `license_concluded`, `license_comments`, `copyright`, `source_info`, `comment`, `summary`, `description`, `release_date`, `build_date`, `valid_until_date`, `attribution`, `file_types` FROM `nodes`;
+-- Drop "nodes" table after copying rows
+DROP TABLE `nodes`;
+-- Rename temporary table "new_nodes" to "nodes"
+ALTER TABLE `new_nodes` RENAME TO `nodes`;
+-- Create index "nodes_proto_message_key" to table: "nodes"
+CREATE UNIQUE INDEX `nodes_proto_message_key` ON `nodes` (`proto_message`);
+-- Create "new_persons" table
+CREATE TABLE `new_persons` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `name` text NOT NULL,
+  `is_org` bool NOT NULL,
+  `email` text NOT NULL,
+  `url` text NOT NULL,
+  `phone` text NOT NULL,
+  PRIMARY KEY (`id`)
+);
+-- Copy rows from old table "persons" to new temporary table "new_persons"
+INSERT INTO `new_persons` (`id`, `proto_message`, `name`, `is_org`, `email`, `url`, `phone`) SELECT `id`, `proto_message`, `name`, `is_org`, `email`, `url`, `phone` FROM `persons`;
+-- Drop "persons" table after copying rows
+DROP TABLE `persons`;
+-- Rename temporary table "new_persons" to "persons"
+ALTER TABLE `new_persons` RENAME TO `persons`;
+-- Create index "persons_proto_message_key" to table: "persons"
+CREATE UNIQUE INDEX `persons_proto_message_key` ON `persons` (`proto_message`);
+-- Create index "idx_persons" to table: "persons"
+CREATE UNIQUE INDEX `idx_persons` ON `persons` (`name`, `is_org`, `email`, `url`, `phone`);
+-- Create "new_source_data" table
+CREATE TABLE `new_source_data` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `format` text NOT NULL,
+  `size` integer NOT NULL,
+  `uri` text NULL,
+  PRIMARY KEY (`id`)
+);
+-- Copy rows from old table "source_data" to new temporary table "new_source_data"
+INSERT INTO `new_source_data` (`id`, `proto_message`, `format`, `size`, `uri`) SELECT `id`, `proto_message`, `format`, `size`, `uri` FROM `source_data`;
+-- Drop "source_data" table after copying rows
+DROP TABLE `source_data`;
+-- Rename temporary table "new_source_data" to "source_data"
+ALTER TABLE `new_source_data` RENAME TO `source_data`;
+-- Create index "source_data_proto_message_key" to table: "source_data"
+CREATE UNIQUE INDEX `source_data_proto_message_key` ON `source_data` (`proto_message`);
+-- Create index "idx_source_data" to table: "source_data"
+CREATE UNIQUE INDEX `idx_source_data` ON `source_data` (`format`, `size`, `uri`);
+-- Create "new_edge_types" table
+CREATE TABLE `new_edge_types` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `type` text NOT NULL,
+  `node_id` uuid NOT NULL,
+  `to_node_id` uuid NOT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `edge_types_nodes_from` FOREIGN KEY (`node_id`) REFERENCES `nodes` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `edge_types_nodes_to` FOREIGN KEY (`to_node_id`) REFERENCES `nodes` (`id`) ON DELETE CASCADE
+);
+-- Copy rows from old table "edge_types" to new temporary table "new_edge_types"
+INSERT INTO `new_edge_types` (`id`, `proto_message`, `type`, `node_id`, `to_node_id`) SELECT `id`, `proto_message`, `type`, `node_id`, `to_node_id` FROM `edge_types`;
+-- Drop "edge_types" table after copying rows
+DROP TABLE `edge_types`;
+-- Rename temporary table "new_edge_types" to "edge_types"
+ALTER TABLE `new_edge_types` RENAME TO `edge_types`;
+-- Create index "edge_types_proto_message_key" to table: "edge_types"
+CREATE UNIQUE INDEX `edge_types_proto_message_key` ON `edge_types` (`proto_message`);
+-- Create index "idx_edge_types" to table: "edge_types"
+CREATE UNIQUE INDEX `idx_edge_types` ON `edge_types` (`type`, `node_id`, `to_node_id`);
+-- Create index "edgetype_node_id_to_node_id" to table: "edge_types"
+CREATE UNIQUE INDEX `edgetype_node_id_to_node_id` ON `edge_types` (`node_id`, `to_node_id`);
+-- Create "new_hashes_entries" table
+CREATE TABLE `new_hashes_entries` (
+  `id` uuid NOT NULL,
+  `hash_algorithm` text NOT NULL,
+  `hash_data` text NOT NULL,
+  PRIMARY KEY (`id`)
+);
+-- Copy rows from old table "hashes_entries" to new temporary table "new_hashes_entries"
+INSERT INTO `new_hashes_entries` (`id`, `hash_algorithm`, `hash_data`) SELECT `id`, `hash_algorithm`, `hash_data` FROM `hashes_entries`;
+-- Drop "hashes_entries" table after copying rows
+DROP TABLE `hashes_entries`;
+-- Rename temporary table "new_hashes_entries" to "hashes_entries"
+ALTER TABLE `new_hashes_entries` RENAME TO `hashes_entries`;
+-- Create index "idx_hashes" to table: "hashes_entries"
+CREATE UNIQUE INDEX `idx_hashes` ON `hashes_entries` (`hash_algorithm`, `hash_data`);
+-- Create "new_external_references" table
+CREATE TABLE `new_external_references` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `url` text NOT NULL,
+  `comment` text NOT NULL,
+  `authority` text NULL,
+  `type` text NOT NULL,
+  PRIMARY KEY (`id`)
+);
+-- Copy rows from old table "external_references" to new temporary table "new_external_references"
+INSERT INTO `new_external_references` (`id`, `proto_message`, `url`, `comment`, `authority`, `type`) SELECT `id`, `proto_message`, `url`, `comment`, `authority`, `type` FROM `external_references`;
+-- Drop "external_references" table after copying rows
+DROP TABLE `external_references`;
+-- Rename temporary table "new_external_references" to "external_references"
+ALTER TABLE `new_external_references` RENAME TO `external_references`;
+-- Create index "external_references_proto_message_key" to table: "external_references"
+CREATE UNIQUE INDEX `external_references_proto_message_key` ON `external_references` (`proto_message`);
+-- Create "new_identifiers_entries" table
+CREATE TABLE `new_identifiers_entries` (
+  `id` uuid NOT NULL,
+  `type` text NOT NULL,
+  `value` text NOT NULL,
+  PRIMARY KEY (`id`)
+);
+-- Copy rows from old table "identifiers_entries" to new temporary table "new_identifiers_entries"
+INSERT INTO `new_identifiers_entries` (`id`, `type`, `value`) SELECT `id`, `type`, `value` FROM `identifiers_entries`;
+-- Drop "identifiers_entries" table after copying rows
+DROP TABLE `identifiers_entries`;
+-- Rename temporary table "new_identifiers_entries" to "identifiers_entries"
+ALTER TABLE `new_identifiers_entries` RENAME TO `identifiers_entries`;
+-- Create index "idx_identifiers" to table: "identifiers_entries"
+CREATE UNIQUE INDEX `idx_identifiers` ON `identifiers_entries` (`type`, `value`);
+-- Create "new_metadata" table
+CREATE TABLE `new_metadata` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `native_id` text NOT NULL,
+  `version` text NOT NULL,
+  `name` text NOT NULL,
+  `date` datetime NOT NULL,
+  `comment` text NOT NULL,
+  `source_data_id` uuid NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `metadata_source_data_source_data` FOREIGN KEY (`source_data_id`) REFERENCES `source_data` (`id`) ON DELETE CASCADE
+);
+-- Copy rows from old table "metadata" to new temporary table "new_metadata"
+INSERT INTO `new_metadata` (`id`, `proto_message`, `native_id`, `version`, `name`, `date`, `comment`) SELECT `id`, `proto_message`, `native_id`, `version`, `name`, `date`, `comment` FROM `metadata`;
+-- Drop "metadata" table after copying rows
+DROP TABLE `metadata`;
+-- Rename temporary table "new_metadata" to "metadata"
+ALTER TABLE `new_metadata` RENAME TO `metadata`;
+-- Create index "metadata_proto_message_key" to table: "metadata"
+CREATE UNIQUE INDEX `metadata_proto_message_key` ON `metadata` (`proto_message`);
+-- Create "new_documents" table
+CREATE TABLE `new_documents` (
+  `id` uuid NOT NULL,
+  `metadata_id` uuid NULL,
+  `node_list_id` uuid NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `documents_metadata_metadata` FOREIGN KEY (`metadata_id`) REFERENCES `metadata` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `documents_node_lists_node_list` FOREIGN KEY (`node_list_id`) REFERENCES `node_lists` (`id`) ON DELETE CASCADE
+);
+-- Copy rows from old table "documents" to new temporary table "new_documents"
+INSERT INTO `new_documents` (`id`, `metadata_id`, `node_list_id`) SELECT `id`, `metadata_id`, `node_list_id` FROM `documents`;
+-- Drop "documents" table after copying rows
+DROP TABLE `documents`;
+-- Rename temporary table "new_documents" to "documents"
+ALTER TABLE `new_documents` RENAME TO `documents`;
+-- Create index "idx_documents_metadata_id" to table: "documents"
+CREATE INDEX `idx_documents_metadata_id` ON `documents` (`metadata_id`);
+-- Create index "idx_documents_node_list_id" to table: "documents"
+CREATE INDEX `idx_documents_node_list_id` ON `documents` (`node_list_id`);
+-- Create "new_document_types" table
+CREATE TABLE `new_document_types` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `type` text NULL,
+  `name` text NULL,
+  `description` text NULL,
+  PRIMARY KEY (`id`)
+);
+-- Copy rows from old table "document_types" to new temporary table "new_document_types"
+INSERT INTO `new_document_types` (`id`, `proto_message`, `type`, `name`, `description`) SELECT `id`, `proto_message`, `type`, `name`, `description` FROM `document_types`;
+-- Drop "document_types" table after copying rows
+DROP TABLE `document_types`;
+-- Rename temporary table "new_document_types" to "document_types"
+ALTER TABLE `new_document_types` RENAME TO `document_types`;
+-- Create index "document_types_proto_message_key" to table: "document_types"
+CREATE UNIQUE INDEX `document_types_proto_message_key` ON `document_types` (`proto_message`);
+-- Create index "idx_document_types" to table: "document_types"
+CREATE UNIQUE INDEX `idx_document_types` ON `document_types` (`type`, `name`, `description`);
+-- Create "new_purposes" table
+CREATE TABLE `new_purposes` (
+  `id` integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `primary_purpose` text NOT NULL
+);
+-- Copy rows from old table "purposes" to new temporary table "new_purposes"
+INSERT INTO `new_purposes` (`id`, `primary_purpose`) SELECT `id`, `primary_purpose` FROM `purposes`;
+-- Drop "purposes" table after copying rows
+DROP TABLE `purposes`;
+-- Rename temporary table "new_purposes" to "purposes"
+ALTER TABLE `new_purposes` RENAME TO `purposes`;
+-- Create "new_tools" table
+CREATE TABLE `new_tools` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `name` text NOT NULL,
+  `version` text NOT NULL,
+  `vendor` text NOT NULL,
+  PRIMARY KEY (`id`)
+);
+-- Copy rows from old table "tools" to new temporary table "new_tools"
+INSERT INTO `new_tools` (`id`, `proto_message`, `name`, `version`, `vendor`) SELECT `id`, `proto_message`, `name`, `version`, `vendor` FROM `tools`;
+-- Drop "tools" table after copying rows
+DROP TABLE `tools`;
+-- Rename temporary table "new_tools" to "tools"
+ALTER TABLE `new_tools` RENAME TO `tools`;
+-- Create index "tools_proto_message_key" to table: "tools"
+CREATE UNIQUE INDEX `tools_proto_message_key` ON `tools` (`proto_message`);
+-- Create index "idx_tools" to table: "tools"
+CREATE UNIQUE INDEX `idx_tools` ON `tools` (`name`, `version`, `vendor`);
+-- Create "new_properties" table
+CREATE TABLE `new_properties` (
+  `id` uuid NOT NULL,
+  `proto_message` blob NOT NULL,
+  `name` text NOT NULL,
+  `data` text NOT NULL,
+  PRIMARY KEY (`id`)
+);
+-- Copy rows from old table "properties" to new temporary table "new_properties"
+INSERT INTO `new_properties` (`id`, `proto_message`, `name`, `data`) SELECT `id`, `proto_message`, `name`, `data` FROM `properties`;
+-- Drop "properties" table after copying rows
+DROP TABLE `properties`;
+-- Rename temporary table "new_properties" to "properties"
+ALTER TABLE `new_properties` RENAME TO `properties`;
+-- Create index "properties_proto_message_key" to table: "properties"
+CREATE UNIQUE INDEX `properties_proto_message_key` ON `properties` (`proto_message`);
+-- Create index "idx_property" to table: "properties"
+CREATE UNIQUE INDEX `idx_property` ON `properties` (`name`, `data`);
+-- Create "document_document_types" table
+CREATE TABLE `document_document_types` (
+  `document_id` uuid NOT NULL,
+  `document_type_id` uuid NOT NULL,
+  PRIMARY KEY (`document_id`, `document_type_id`),
+  CONSTRAINT `document_document_types_document_id` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `document_document_types_document_type_id` FOREIGN KEY (`document_type_id`) REFERENCES `document_types` (`id`) ON DELETE CASCADE
+);
+-- Create "document_edge_types" table
+CREATE TABLE `document_edge_types` (
+  `document_id` uuid NOT NULL,
+  `edge_type_id` uuid NOT NULL,
+  PRIMARY KEY (`document_id`, `edge_type_id`),
+  CONSTRAINT `document_edge_types_document_id` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `document_edge_types_edge_type_id` FOREIGN KEY (`edge_type_id`) REFERENCES `edge_types` (`id`) ON DELETE CASCADE
+);
+-- Create "document_external_references" table
+CREATE TABLE `document_external_references` (
+  `document_id` uuid NOT NULL,
+  `external_reference_id` uuid NOT NULL,
+  PRIMARY KEY (`document_id`, `external_reference_id`),
+  CONSTRAINT `document_external_references_document_id` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `document_external_references_external_reference_id` FOREIGN KEY (`external_reference_id`) REFERENCES `external_references` (`id`) ON DELETE CASCADE
+);
+-- Create "document_hashes" table
+CREATE TABLE `document_hashes` (
+  `document_id` uuid NOT NULL,
+  `hashes_entry_id` uuid NOT NULL,
+  PRIMARY KEY (`document_id`, `hashes_entry_id`),
+  CONSTRAINT `document_hashes_document_id` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `document_hashes_hashes_entry_id` FOREIGN KEY (`hashes_entry_id`) REFERENCES `hashes_entries` (`id`) ON DELETE CASCADE
+);
+-- Create "document_identifiers" table
+CREATE TABLE `document_identifiers` (
+  `document_id` uuid NOT NULL,
+  `identifiers_entry_id` uuid NOT NULL,
+  PRIMARY KEY (`document_id`, `identifiers_entry_id`),
+  CONSTRAINT `document_identifiers_document_id` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `document_identifiers_identifiers_entry_id` FOREIGN KEY (`identifiers_entry_id`) REFERENCES `identifiers_entries` (`id`) ON DELETE CASCADE
+);
+-- Create "document_nodes" table
+CREATE TABLE `document_nodes` (
+  `document_id` uuid NOT NULL,
+  `node_id` uuid NOT NULL,
+  PRIMARY KEY (`document_id`, `node_id`),
+  CONSTRAINT `document_nodes_document_id` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `document_nodes_node_id` FOREIGN KEY (`node_id`) REFERENCES `nodes` (`id`) ON DELETE CASCADE
+);
+-- Create "document_persons" table
+CREATE TABLE `document_persons` (
+  `document_id` uuid NOT NULL,
+  `person_id` uuid NOT NULL,
+  PRIMARY KEY (`document_id`, `person_id`),
+  CONSTRAINT `document_persons_document_id` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `document_persons_person_id` FOREIGN KEY (`person_id`) REFERENCES `persons` (`id`) ON DELETE CASCADE
+);
+-- Create "document_properties" table
+CREATE TABLE `document_properties` (
+  `document_id` uuid NOT NULL,
+  `property_id` uuid NOT NULL,
+  PRIMARY KEY (`document_id`, `property_id`),
+  CONSTRAINT `document_properties_document_id` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `document_properties_property_id` FOREIGN KEY (`property_id`) REFERENCES `properties` (`id`) ON DELETE CASCADE
+);
+-- Create "document_purposes" table
+CREATE TABLE `document_purposes` (
+  `document_id` uuid NOT NULL,
+  `purpose_id` integer NOT NULL,
+  PRIMARY KEY (`document_id`, `purpose_id`),
+  CONSTRAINT `document_purposes_document_id` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `document_purposes_purpose_id` FOREIGN KEY (`purpose_id`) REFERENCES `purposes` (`id`) ON DELETE CASCADE
+);
+-- Create "document_source_data" table
+CREATE TABLE `document_source_data` (
+  `document_id` uuid NOT NULL,
+  `source_data_id` uuid NOT NULL,
+  PRIMARY KEY (`document_id`, `source_data_id`),
+  CONSTRAINT `document_source_data_document_id` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `document_source_data_source_data_id` FOREIGN KEY (`source_data_id`) REFERENCES `source_data` (`id`) ON DELETE CASCADE
+);
+-- Create "document_tools" table
+CREATE TABLE `document_tools` (
+  `document_id` uuid NOT NULL,
+  `tool_id` uuid NOT NULL,
+  PRIMARY KEY (`document_id`, `tool_id`),
+  CONSTRAINT `document_tools_document_id` FOREIGN KEY (`document_id`) REFERENCES `documents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `document_tools_tool_id` FOREIGN KEY (`tool_id`) REFERENCES `tools` (`id`) ON DELETE CASCADE
+);
+-- Create "metadata_tools" table
+CREATE TABLE `metadata_tools` (
+  `metadata_id` uuid NOT NULL,
+  `tool_id` uuid NOT NULL,
+  PRIMARY KEY (`metadata_id`, `tool_id`),
+  CONSTRAINT `metadata_tools_metadata_id` FOREIGN KEY (`metadata_id`) REFERENCES `metadata` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `metadata_tools_tool_id` FOREIGN KEY (`tool_id`) REFERENCES `tools` (`id`) ON DELETE CASCADE
+);
+-- Create "metadata_authors" table
+CREATE TABLE `metadata_authors` (
+  `metadata_id` uuid NOT NULL,
+  `person_id` uuid NOT NULL,
+  PRIMARY KEY (`metadata_id`, `person_id`),
+  CONSTRAINT `metadata_authors_metadata_id` FOREIGN KEY (`metadata_id`) REFERENCES `metadata` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `metadata_authors_person_id` FOREIGN KEY (`person_id`) REFERENCES `persons` (`id`) ON DELETE CASCADE
+);
+-- Create "metadata_document_types" table
+CREATE TABLE `metadata_document_types` (
+  `metadata_id` uuid NOT NULL,
+  `document_type_id` uuid NOT NULL,
+  PRIMARY KEY (`metadata_id`, `document_type_id`),
+  CONSTRAINT `metadata_document_types_metadata_id` FOREIGN KEY (`metadata_id`) REFERENCES `metadata` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `metadata_document_types_document_type_id` FOREIGN KEY (`document_type_id`) REFERENCES `document_types` (`id`) ON DELETE CASCADE
+);
+-- Create "node_suppliers" table
+CREATE TABLE `node_suppliers` (
+  `node_id` uuid NOT NULL,
+  `person_id` uuid NOT NULL,
+  PRIMARY KEY (`node_id`, `person_id`),
+  CONSTRAINT `node_suppliers_node_id` FOREIGN KEY (`node_id`) REFERENCES `nodes` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `node_suppliers_person_id` FOREIGN KEY (`person_id`) REFERENCES `persons` (`id`) ON DELETE CASCADE
+);
+-- Create "node_originators" table
+CREATE TABLE `node_originators` (
+  `node_id` uuid NOT NULL,
+  `person_id` uuid NOT NULL,
+  PRIMARY KEY (`node_id`, `person_id`),
+  CONSTRAINT `node_originators_node_id` FOREIGN KEY (`node_id`) REFERENCES `nodes` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `node_originators_person_id` FOREIGN KEY (`person_id`) REFERENCES `persons` (`id`) ON DELETE CASCADE
+);
+-- Create "node_primary_purposes" table
+CREATE TABLE `node_primary_purposes` (
+  `node_id` uuid NOT NULL,
+  `purpose_id` integer NOT NULL,
+  PRIMARY KEY (`node_id`, `purpose_id`),
+  CONSTRAINT `node_primary_purposes_node_id` FOREIGN KEY (`node_id`) REFERENCES `nodes` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `node_primary_purposes_purpose_id` FOREIGN KEY (`purpose_id`) REFERENCES `purposes` (`id`) ON DELETE CASCADE
+);
+-- Create "node_properties" table
+CREATE TABLE `node_properties` (
+  `node_id` uuid NOT NULL,
+  `property_id` uuid NOT NULL,
+  PRIMARY KEY (`node_id`, `property_id`),
+  CONSTRAINT `node_properties_node_id` FOREIGN KEY (`node_id`) REFERENCES `nodes` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `node_properties_property_id` FOREIGN KEY (`property_id`) REFERENCES `properties` (`id`) ON DELETE CASCADE
+);
+-- Create "person_contacts" table
+CREATE TABLE `person_contacts` (
+  `person_id` uuid NOT NULL,
+  `contact_owner_id` uuid NOT NULL,
+  PRIMARY KEY (`person_id`, `contact_owner_id`),
+  CONSTRAINT `person_contacts_person_id` FOREIGN KEY (`person_id`) REFERENCES `persons` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `person_contacts_contact_owner_id` FOREIGN KEY (`contact_owner_id`) REFERENCES `persons` (`id`) ON DELETE CASCADE
+);
+-- Create "source_data_hashes" table
+CREATE TABLE `source_data_hashes` (
+  `source_data_id` uuid NOT NULL,
+  `hash_entry_id` uuid NOT NULL,
+  PRIMARY KEY (`source_data_id`, `hash_entry_id`),
+  CONSTRAINT `source_data_hashes_source_data_id` FOREIGN KEY (`source_data_id`) REFERENCES `source_data` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `source_data_hashes_hash_entry_id` FOREIGN KEY (`hash_entry_id`) REFERENCES `hashes_entries` (`id`) ON DELETE CASCADE
+);
+-- Enable back the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = on;

--- a/internal/backends/ent/migrate/migrations/atlas.sum
+++ b/internal/backends/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:wllKMNgozTa+73uaYDnl1dIrxia7UfyFF80Tt9cl+JM=
+h1:mQQJ9xBZRsSII37q/VHg2Xffm3Jla2uPxQqbcCEddjU=
 20241016141529_initial.sql h1:cZ5Nr+1kj075buwWNz8SHKlRSFaV3L0dzpT9htnXQY4=
 20241101155047_store_protos.sql h1:ALraUjMTZaPGDf+y7IXSLp/LRVWXP3rG6kKQb3ZJf5I=
 20241109194036_ext_ref_type_fix.sql h1:hvLOKWxV23ea20Po7TLLx0VVfevihIQmR2Ft9nX2Nis=
@@ -11,3 +11,4 @@ h1:wllKMNgozTa+73uaYDnl1dIrxia7UfyFF80Tt9cl+JM=
 20250116171940_annotations_nillable_document_id.sql h1:m7rHNc6tZKrgqTH2QWYJ6x7cZheeS1r3pihYyHATV8U=
 20250116180706_embed_uuid_mixin.sql h1:ZYkxRXC/nkJslenl3XH2yGfeqWPyFuzLMsIImlOOOok=
 20250121151156_required_inverse_edges.sql h1:pCYwsp9BZ2rohlhGkOXCk89r5jwW5l/nFJ+OdeSaL94=
+20250121182342_non_unique_inverse_edges.sql h1:eCzMWYvvQ2a9dWEKXb72tzLQp3PMYC+q/lUVGZwwkOk=

--- a/internal/backends/ent/mutation.go
+++ b/internal/backends/ent/mutation.go
@@ -748,20 +748,53 @@ func (m *AnnotationMutation) ResetEdge(name string) error {
 // DocumentMutation represents an operation that mutates the Document nodes in the graph.
 type DocumentMutation struct {
 	config
-	op                 Op
-	typ                string
-	id                 *uuid.UUID
-	clearedFields      map[string]struct{}
-	annotations        map[int]struct{}
-	removedannotations map[int]struct{}
-	clearedannotations bool
-	metadata           *uuid.UUID
-	clearedmetadata    bool
-	node_list          *uuid.UUID
-	clearednode_list   bool
-	done               bool
-	oldValue           func(context.Context) (*Document, error)
-	predicates         []predicate.Document
+	op                         Op
+	typ                        string
+	id                         *uuid.UUID
+	clearedFields              map[string]struct{}
+	annotations                map[int]struct{}
+	removedannotations         map[int]struct{}
+	clearedannotations         bool
+	metadata                   *uuid.UUID
+	clearedmetadata            bool
+	node_list                  *uuid.UUID
+	clearednode_list           bool
+	document_types             map[uuid.UUID]struct{}
+	removeddocument_types      map[uuid.UUID]struct{}
+	cleareddocument_types      bool
+	edge_types                 map[uuid.UUID]struct{}
+	removededge_types          map[uuid.UUID]struct{}
+	clearededge_types          bool
+	external_references        map[uuid.UUID]struct{}
+	removedexternal_references map[uuid.UUID]struct{}
+	clearedexternal_references bool
+	hashes                     map[uuid.UUID]struct{}
+	removedhashes              map[uuid.UUID]struct{}
+	clearedhashes              bool
+	identifiers                map[uuid.UUID]struct{}
+	removedidentifiers         map[uuid.UUID]struct{}
+	clearedidentifiers         bool
+	nodes                      map[uuid.UUID]struct{}
+	removednodes               map[uuid.UUID]struct{}
+	clearednodes               bool
+	persons                    map[uuid.UUID]struct{}
+	removedpersons             map[uuid.UUID]struct{}
+	clearedpersons             bool
+	properties                 map[uuid.UUID]struct{}
+	removedproperties          map[uuid.UUID]struct{}
+	clearedproperties          bool
+	purposes                   map[int]struct{}
+	removedpurposes            map[int]struct{}
+	clearedpurposes            bool
+	source_data                map[uuid.UUID]struct{}
+	removedsource_data         map[uuid.UUID]struct{}
+	clearedsource_data         bool
+	tools                      map[uuid.UUID]struct{}
+	removedtools               map[uuid.UUID]struct{}
+	clearedtools               bool
+	done                       bool
+	oldValue                   func(context.Context) (*Document, error)
+	predicates                 []predicate.Document
 }
 
 var _ ent.Mutation = (*DocumentMutation)(nil)
@@ -1074,6 +1107,600 @@ func (m *DocumentMutation) ResetNodeList() {
 	m.clearednode_list = false
 }
 
+// AddDocumentTypeIDs adds the "document_types" edge to the DocumentType entity by ids.
+func (m *DocumentMutation) AddDocumentTypeIDs(ids ...uuid.UUID) {
+	if m.document_types == nil {
+		m.document_types = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.document_types[ids[i]] = struct{}{}
+	}
+}
+
+// ClearDocumentTypes clears the "document_types" edge to the DocumentType entity.
+func (m *DocumentMutation) ClearDocumentTypes() {
+	m.cleareddocument_types = true
+}
+
+// DocumentTypesCleared reports if the "document_types" edge to the DocumentType entity was cleared.
+func (m *DocumentMutation) DocumentTypesCleared() bool {
+	return m.cleareddocument_types
+}
+
+// RemoveDocumentTypeIDs removes the "document_types" edge to the DocumentType entity by IDs.
+func (m *DocumentMutation) RemoveDocumentTypeIDs(ids ...uuid.UUID) {
+	if m.removeddocument_types == nil {
+		m.removeddocument_types = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.document_types, ids[i])
+		m.removeddocument_types[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocumentTypes returns the removed IDs of the "document_types" edge to the DocumentType entity.
+func (m *DocumentMutation) RemovedDocumentTypesIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocument_types {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// DocumentTypesIDs returns the "document_types" edge IDs in the mutation.
+func (m *DocumentMutation) DocumentTypesIDs() (ids []uuid.UUID) {
+	for id := range m.document_types {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetDocumentTypes resets all changes to the "document_types" edge.
+func (m *DocumentMutation) ResetDocumentTypes() {
+	m.document_types = nil
+	m.cleareddocument_types = false
+	m.removeddocument_types = nil
+}
+
+// AddEdgeTypeIDs adds the "edge_types" edge to the EdgeType entity by ids.
+func (m *DocumentMutation) AddEdgeTypeIDs(ids ...uuid.UUID) {
+	if m.edge_types == nil {
+		m.edge_types = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.edge_types[ids[i]] = struct{}{}
+	}
+}
+
+// ClearEdgeTypes clears the "edge_types" edge to the EdgeType entity.
+func (m *DocumentMutation) ClearEdgeTypes() {
+	m.clearededge_types = true
+}
+
+// EdgeTypesCleared reports if the "edge_types" edge to the EdgeType entity was cleared.
+func (m *DocumentMutation) EdgeTypesCleared() bool {
+	return m.clearededge_types
+}
+
+// RemoveEdgeTypeIDs removes the "edge_types" edge to the EdgeType entity by IDs.
+func (m *DocumentMutation) RemoveEdgeTypeIDs(ids ...uuid.UUID) {
+	if m.removededge_types == nil {
+		m.removededge_types = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.edge_types, ids[i])
+		m.removededge_types[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedEdgeTypes returns the removed IDs of the "edge_types" edge to the EdgeType entity.
+func (m *DocumentMutation) RemovedEdgeTypesIDs() (ids []uuid.UUID) {
+	for id := range m.removededge_types {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// EdgeTypesIDs returns the "edge_types" edge IDs in the mutation.
+func (m *DocumentMutation) EdgeTypesIDs() (ids []uuid.UUID) {
+	for id := range m.edge_types {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetEdgeTypes resets all changes to the "edge_types" edge.
+func (m *DocumentMutation) ResetEdgeTypes() {
+	m.edge_types = nil
+	m.clearededge_types = false
+	m.removededge_types = nil
+}
+
+// AddExternalReferenceIDs adds the "external_references" edge to the ExternalReference entity by ids.
+func (m *DocumentMutation) AddExternalReferenceIDs(ids ...uuid.UUID) {
+	if m.external_references == nil {
+		m.external_references = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.external_references[ids[i]] = struct{}{}
+	}
+}
+
+// ClearExternalReferences clears the "external_references" edge to the ExternalReference entity.
+func (m *DocumentMutation) ClearExternalReferences() {
+	m.clearedexternal_references = true
+}
+
+// ExternalReferencesCleared reports if the "external_references" edge to the ExternalReference entity was cleared.
+func (m *DocumentMutation) ExternalReferencesCleared() bool {
+	return m.clearedexternal_references
+}
+
+// RemoveExternalReferenceIDs removes the "external_references" edge to the ExternalReference entity by IDs.
+func (m *DocumentMutation) RemoveExternalReferenceIDs(ids ...uuid.UUID) {
+	if m.removedexternal_references == nil {
+		m.removedexternal_references = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.external_references, ids[i])
+		m.removedexternal_references[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedExternalReferences returns the removed IDs of the "external_references" edge to the ExternalReference entity.
+func (m *DocumentMutation) RemovedExternalReferencesIDs() (ids []uuid.UUID) {
+	for id := range m.removedexternal_references {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ExternalReferencesIDs returns the "external_references" edge IDs in the mutation.
+func (m *DocumentMutation) ExternalReferencesIDs() (ids []uuid.UUID) {
+	for id := range m.external_references {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetExternalReferences resets all changes to the "external_references" edge.
+func (m *DocumentMutation) ResetExternalReferences() {
+	m.external_references = nil
+	m.clearedexternal_references = false
+	m.removedexternal_references = nil
+}
+
+// AddHashIDs adds the "hashes" edge to the HashesEntry entity by ids.
+func (m *DocumentMutation) AddHashIDs(ids ...uuid.UUID) {
+	if m.hashes == nil {
+		m.hashes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.hashes[ids[i]] = struct{}{}
+	}
+}
+
+// ClearHashes clears the "hashes" edge to the HashesEntry entity.
+func (m *DocumentMutation) ClearHashes() {
+	m.clearedhashes = true
+}
+
+// HashesCleared reports if the "hashes" edge to the HashesEntry entity was cleared.
+func (m *DocumentMutation) HashesCleared() bool {
+	return m.clearedhashes
+}
+
+// RemoveHashIDs removes the "hashes" edge to the HashesEntry entity by IDs.
+func (m *DocumentMutation) RemoveHashIDs(ids ...uuid.UUID) {
+	if m.removedhashes == nil {
+		m.removedhashes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.hashes, ids[i])
+		m.removedhashes[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedHashes returns the removed IDs of the "hashes" edge to the HashesEntry entity.
+func (m *DocumentMutation) RemovedHashesIDs() (ids []uuid.UUID) {
+	for id := range m.removedhashes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// HashesIDs returns the "hashes" edge IDs in the mutation.
+func (m *DocumentMutation) HashesIDs() (ids []uuid.UUID) {
+	for id := range m.hashes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetHashes resets all changes to the "hashes" edge.
+func (m *DocumentMutation) ResetHashes() {
+	m.hashes = nil
+	m.clearedhashes = false
+	m.removedhashes = nil
+}
+
+// AddIdentifierIDs adds the "identifiers" edge to the IdentifiersEntry entity by ids.
+func (m *DocumentMutation) AddIdentifierIDs(ids ...uuid.UUID) {
+	if m.identifiers == nil {
+		m.identifiers = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.identifiers[ids[i]] = struct{}{}
+	}
+}
+
+// ClearIdentifiers clears the "identifiers" edge to the IdentifiersEntry entity.
+func (m *DocumentMutation) ClearIdentifiers() {
+	m.clearedidentifiers = true
+}
+
+// IdentifiersCleared reports if the "identifiers" edge to the IdentifiersEntry entity was cleared.
+func (m *DocumentMutation) IdentifiersCleared() bool {
+	return m.clearedidentifiers
+}
+
+// RemoveIdentifierIDs removes the "identifiers" edge to the IdentifiersEntry entity by IDs.
+func (m *DocumentMutation) RemoveIdentifierIDs(ids ...uuid.UUID) {
+	if m.removedidentifiers == nil {
+		m.removedidentifiers = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.identifiers, ids[i])
+		m.removedidentifiers[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedIdentifiers returns the removed IDs of the "identifiers" edge to the IdentifiersEntry entity.
+func (m *DocumentMutation) RemovedIdentifiersIDs() (ids []uuid.UUID) {
+	for id := range m.removedidentifiers {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// IdentifiersIDs returns the "identifiers" edge IDs in the mutation.
+func (m *DocumentMutation) IdentifiersIDs() (ids []uuid.UUID) {
+	for id := range m.identifiers {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetIdentifiers resets all changes to the "identifiers" edge.
+func (m *DocumentMutation) ResetIdentifiers() {
+	m.identifiers = nil
+	m.clearedidentifiers = false
+	m.removedidentifiers = nil
+}
+
+// AddNodeIDs adds the "nodes" edge to the Node entity by ids.
+func (m *DocumentMutation) AddNodeIDs(ids ...uuid.UUID) {
+	if m.nodes == nil {
+		m.nodes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.nodes[ids[i]] = struct{}{}
+	}
+}
+
+// ClearNodes clears the "nodes" edge to the Node entity.
+func (m *DocumentMutation) ClearNodes() {
+	m.clearednodes = true
+}
+
+// NodesCleared reports if the "nodes" edge to the Node entity was cleared.
+func (m *DocumentMutation) NodesCleared() bool {
+	return m.clearednodes
+}
+
+// RemoveNodeIDs removes the "nodes" edge to the Node entity by IDs.
+func (m *DocumentMutation) RemoveNodeIDs(ids ...uuid.UUID) {
+	if m.removednodes == nil {
+		m.removednodes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.nodes, ids[i])
+		m.removednodes[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedNodes returns the removed IDs of the "nodes" edge to the Node entity.
+func (m *DocumentMutation) RemovedNodesIDs() (ids []uuid.UUID) {
+	for id := range m.removednodes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// NodesIDs returns the "nodes" edge IDs in the mutation.
+func (m *DocumentMutation) NodesIDs() (ids []uuid.UUID) {
+	for id := range m.nodes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetNodes resets all changes to the "nodes" edge.
+func (m *DocumentMutation) ResetNodes() {
+	m.nodes = nil
+	m.clearednodes = false
+	m.removednodes = nil
+}
+
+// AddPersonIDs adds the "persons" edge to the Person entity by ids.
+func (m *DocumentMutation) AddPersonIDs(ids ...uuid.UUID) {
+	if m.persons == nil {
+		m.persons = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.persons[ids[i]] = struct{}{}
+	}
+}
+
+// ClearPersons clears the "persons" edge to the Person entity.
+func (m *DocumentMutation) ClearPersons() {
+	m.clearedpersons = true
+}
+
+// PersonsCleared reports if the "persons" edge to the Person entity was cleared.
+func (m *DocumentMutation) PersonsCleared() bool {
+	return m.clearedpersons
+}
+
+// RemovePersonIDs removes the "persons" edge to the Person entity by IDs.
+func (m *DocumentMutation) RemovePersonIDs(ids ...uuid.UUID) {
+	if m.removedpersons == nil {
+		m.removedpersons = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.persons, ids[i])
+		m.removedpersons[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedPersons returns the removed IDs of the "persons" edge to the Person entity.
+func (m *DocumentMutation) RemovedPersonsIDs() (ids []uuid.UUID) {
+	for id := range m.removedpersons {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// PersonsIDs returns the "persons" edge IDs in the mutation.
+func (m *DocumentMutation) PersonsIDs() (ids []uuid.UUID) {
+	for id := range m.persons {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetPersons resets all changes to the "persons" edge.
+func (m *DocumentMutation) ResetPersons() {
+	m.persons = nil
+	m.clearedpersons = false
+	m.removedpersons = nil
+}
+
+// AddPropertyIDs adds the "properties" edge to the Property entity by ids.
+func (m *DocumentMutation) AddPropertyIDs(ids ...uuid.UUID) {
+	if m.properties == nil {
+		m.properties = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.properties[ids[i]] = struct{}{}
+	}
+}
+
+// ClearProperties clears the "properties" edge to the Property entity.
+func (m *DocumentMutation) ClearProperties() {
+	m.clearedproperties = true
+}
+
+// PropertiesCleared reports if the "properties" edge to the Property entity was cleared.
+func (m *DocumentMutation) PropertiesCleared() bool {
+	return m.clearedproperties
+}
+
+// RemovePropertyIDs removes the "properties" edge to the Property entity by IDs.
+func (m *DocumentMutation) RemovePropertyIDs(ids ...uuid.UUID) {
+	if m.removedproperties == nil {
+		m.removedproperties = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.properties, ids[i])
+		m.removedproperties[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedProperties returns the removed IDs of the "properties" edge to the Property entity.
+func (m *DocumentMutation) RemovedPropertiesIDs() (ids []uuid.UUID) {
+	for id := range m.removedproperties {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// PropertiesIDs returns the "properties" edge IDs in the mutation.
+func (m *DocumentMutation) PropertiesIDs() (ids []uuid.UUID) {
+	for id := range m.properties {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetProperties resets all changes to the "properties" edge.
+func (m *DocumentMutation) ResetProperties() {
+	m.properties = nil
+	m.clearedproperties = false
+	m.removedproperties = nil
+}
+
+// AddPurposeIDs adds the "purposes" edge to the Purpose entity by ids.
+func (m *DocumentMutation) AddPurposeIDs(ids ...int) {
+	if m.purposes == nil {
+		m.purposes = make(map[int]struct{})
+	}
+	for i := range ids {
+		m.purposes[ids[i]] = struct{}{}
+	}
+}
+
+// ClearPurposes clears the "purposes" edge to the Purpose entity.
+func (m *DocumentMutation) ClearPurposes() {
+	m.clearedpurposes = true
+}
+
+// PurposesCleared reports if the "purposes" edge to the Purpose entity was cleared.
+func (m *DocumentMutation) PurposesCleared() bool {
+	return m.clearedpurposes
+}
+
+// RemovePurposeIDs removes the "purposes" edge to the Purpose entity by IDs.
+func (m *DocumentMutation) RemovePurposeIDs(ids ...int) {
+	if m.removedpurposes == nil {
+		m.removedpurposes = make(map[int]struct{})
+	}
+	for i := range ids {
+		delete(m.purposes, ids[i])
+		m.removedpurposes[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedPurposes returns the removed IDs of the "purposes" edge to the Purpose entity.
+func (m *DocumentMutation) RemovedPurposesIDs() (ids []int) {
+	for id := range m.removedpurposes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// PurposesIDs returns the "purposes" edge IDs in the mutation.
+func (m *DocumentMutation) PurposesIDs() (ids []int) {
+	for id := range m.purposes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetPurposes resets all changes to the "purposes" edge.
+func (m *DocumentMutation) ResetPurposes() {
+	m.purposes = nil
+	m.clearedpurposes = false
+	m.removedpurposes = nil
+}
+
+// AddSourceDatumIDs adds the "source_data" edge to the SourceData entity by ids.
+func (m *DocumentMutation) AddSourceDatumIDs(ids ...uuid.UUID) {
+	if m.source_data == nil {
+		m.source_data = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.source_data[ids[i]] = struct{}{}
+	}
+}
+
+// ClearSourceData clears the "source_data" edge to the SourceData entity.
+func (m *DocumentMutation) ClearSourceData() {
+	m.clearedsource_data = true
+}
+
+// SourceDataCleared reports if the "source_data" edge to the SourceData entity was cleared.
+func (m *DocumentMutation) SourceDataCleared() bool {
+	return m.clearedsource_data
+}
+
+// RemoveSourceDatumIDs removes the "source_data" edge to the SourceData entity by IDs.
+func (m *DocumentMutation) RemoveSourceDatumIDs(ids ...uuid.UUID) {
+	if m.removedsource_data == nil {
+		m.removedsource_data = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.source_data, ids[i])
+		m.removedsource_data[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedSourceData returns the removed IDs of the "source_data" edge to the SourceData entity.
+func (m *DocumentMutation) RemovedSourceDataIDs() (ids []uuid.UUID) {
+	for id := range m.removedsource_data {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// SourceDataIDs returns the "source_data" edge IDs in the mutation.
+func (m *DocumentMutation) SourceDataIDs() (ids []uuid.UUID) {
+	for id := range m.source_data {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetSourceData resets all changes to the "source_data" edge.
+func (m *DocumentMutation) ResetSourceData() {
+	m.source_data = nil
+	m.clearedsource_data = false
+	m.removedsource_data = nil
+}
+
+// AddToolIDs adds the "tools" edge to the Tool entity by ids.
+func (m *DocumentMutation) AddToolIDs(ids ...uuid.UUID) {
+	if m.tools == nil {
+		m.tools = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.tools[ids[i]] = struct{}{}
+	}
+}
+
+// ClearTools clears the "tools" edge to the Tool entity.
+func (m *DocumentMutation) ClearTools() {
+	m.clearedtools = true
+}
+
+// ToolsCleared reports if the "tools" edge to the Tool entity was cleared.
+func (m *DocumentMutation) ToolsCleared() bool {
+	return m.clearedtools
+}
+
+// RemoveToolIDs removes the "tools" edge to the Tool entity by IDs.
+func (m *DocumentMutation) RemoveToolIDs(ids ...uuid.UUID) {
+	if m.removedtools == nil {
+		m.removedtools = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.tools, ids[i])
+		m.removedtools[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedTools returns the removed IDs of the "tools" edge to the Tool entity.
+func (m *DocumentMutation) RemovedToolsIDs() (ids []uuid.UUID) {
+	for id := range m.removedtools {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ToolsIDs returns the "tools" edge IDs in the mutation.
+func (m *DocumentMutation) ToolsIDs() (ids []uuid.UUID) {
+	for id := range m.tools {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetTools resets all changes to the "tools" edge.
+func (m *DocumentMutation) ResetTools() {
+	m.tools = nil
+	m.clearedtools = false
+	m.removedtools = nil
+}
+
 // Where appends a list predicates to the DocumentMutation builder.
 func (m *DocumentMutation) Where(ps ...predicate.Document) {
 	m.predicates = append(m.predicates, ps...)
@@ -1239,7 +1866,7 @@ func (m *DocumentMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *DocumentMutation) AddedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 14)
 	if m.annotations != nil {
 		edges = append(edges, document.EdgeAnnotations)
 	}
@@ -1248,6 +1875,39 @@ func (m *DocumentMutation) AddedEdges() []string {
 	}
 	if m.node_list != nil {
 		edges = append(edges, document.EdgeNodeList)
+	}
+	if m.document_types != nil {
+		edges = append(edges, document.EdgeDocumentTypes)
+	}
+	if m.edge_types != nil {
+		edges = append(edges, document.EdgeEdgeTypes)
+	}
+	if m.external_references != nil {
+		edges = append(edges, document.EdgeExternalReferences)
+	}
+	if m.hashes != nil {
+		edges = append(edges, document.EdgeHashes)
+	}
+	if m.identifiers != nil {
+		edges = append(edges, document.EdgeIdentifiers)
+	}
+	if m.nodes != nil {
+		edges = append(edges, document.EdgeNodes)
+	}
+	if m.persons != nil {
+		edges = append(edges, document.EdgePersons)
+	}
+	if m.properties != nil {
+		edges = append(edges, document.EdgeProperties)
+	}
+	if m.purposes != nil {
+		edges = append(edges, document.EdgePurposes)
+	}
+	if m.source_data != nil {
+		edges = append(edges, document.EdgeSourceData)
+	}
+	if m.tools != nil {
+		edges = append(edges, document.EdgeTools)
 	}
 	return edges
 }
@@ -1270,15 +1930,114 @@ func (m *DocumentMutation) AddedIDs(name string) []ent.Value {
 		if id := m.node_list; id != nil {
 			return []ent.Value{*id}
 		}
+	case document.EdgeDocumentTypes:
+		ids := make([]ent.Value, 0, len(m.document_types))
+		for id := range m.document_types {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeEdgeTypes:
+		ids := make([]ent.Value, 0, len(m.edge_types))
+		for id := range m.edge_types {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeExternalReferences:
+		ids := make([]ent.Value, 0, len(m.external_references))
+		for id := range m.external_references {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeHashes:
+		ids := make([]ent.Value, 0, len(m.hashes))
+		for id := range m.hashes {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeIdentifiers:
+		ids := make([]ent.Value, 0, len(m.identifiers))
+		for id := range m.identifiers {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeNodes:
+		ids := make([]ent.Value, 0, len(m.nodes))
+		for id := range m.nodes {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgePersons:
+		ids := make([]ent.Value, 0, len(m.persons))
+		for id := range m.persons {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeProperties:
+		ids := make([]ent.Value, 0, len(m.properties))
+		for id := range m.properties {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgePurposes:
+		ids := make([]ent.Value, 0, len(m.purposes))
+		for id := range m.purposes {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeSourceData:
+		ids := make([]ent.Value, 0, len(m.source_data))
+		for id := range m.source_data {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeTools:
+		ids := make([]ent.Value, 0, len(m.tools))
+		for id := range m.tools {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *DocumentMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 14)
 	if m.removedannotations != nil {
 		edges = append(edges, document.EdgeAnnotations)
+	}
+	if m.removeddocument_types != nil {
+		edges = append(edges, document.EdgeDocumentTypes)
+	}
+	if m.removededge_types != nil {
+		edges = append(edges, document.EdgeEdgeTypes)
+	}
+	if m.removedexternal_references != nil {
+		edges = append(edges, document.EdgeExternalReferences)
+	}
+	if m.removedhashes != nil {
+		edges = append(edges, document.EdgeHashes)
+	}
+	if m.removedidentifiers != nil {
+		edges = append(edges, document.EdgeIdentifiers)
+	}
+	if m.removednodes != nil {
+		edges = append(edges, document.EdgeNodes)
+	}
+	if m.removedpersons != nil {
+		edges = append(edges, document.EdgePersons)
+	}
+	if m.removedproperties != nil {
+		edges = append(edges, document.EdgeProperties)
+	}
+	if m.removedpurposes != nil {
+		edges = append(edges, document.EdgePurposes)
+	}
+	if m.removedsource_data != nil {
+		edges = append(edges, document.EdgeSourceData)
+	}
+	if m.removedtools != nil {
+		edges = append(edges, document.EdgeTools)
 	}
 	return edges
 }
@@ -1293,13 +2052,79 @@ func (m *DocumentMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case document.EdgeDocumentTypes:
+		ids := make([]ent.Value, 0, len(m.removeddocument_types))
+		for id := range m.removeddocument_types {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeEdgeTypes:
+		ids := make([]ent.Value, 0, len(m.removededge_types))
+		for id := range m.removededge_types {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeExternalReferences:
+		ids := make([]ent.Value, 0, len(m.removedexternal_references))
+		for id := range m.removedexternal_references {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeHashes:
+		ids := make([]ent.Value, 0, len(m.removedhashes))
+		for id := range m.removedhashes {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeIdentifiers:
+		ids := make([]ent.Value, 0, len(m.removedidentifiers))
+		for id := range m.removedidentifiers {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeNodes:
+		ids := make([]ent.Value, 0, len(m.removednodes))
+		for id := range m.removednodes {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgePersons:
+		ids := make([]ent.Value, 0, len(m.removedpersons))
+		for id := range m.removedpersons {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeProperties:
+		ids := make([]ent.Value, 0, len(m.removedproperties))
+		for id := range m.removedproperties {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgePurposes:
+		ids := make([]ent.Value, 0, len(m.removedpurposes))
+		for id := range m.removedpurposes {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeSourceData:
+		ids := make([]ent.Value, 0, len(m.removedsource_data))
+		for id := range m.removedsource_data {
+			ids = append(ids, id)
+		}
+		return ids
+	case document.EdgeTools:
+		ids := make([]ent.Value, 0, len(m.removedtools))
+		for id := range m.removedtools {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *DocumentMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 14)
 	if m.clearedannotations {
 		edges = append(edges, document.EdgeAnnotations)
 	}
@@ -1308,6 +2133,39 @@ func (m *DocumentMutation) ClearedEdges() []string {
 	}
 	if m.clearednode_list {
 		edges = append(edges, document.EdgeNodeList)
+	}
+	if m.cleareddocument_types {
+		edges = append(edges, document.EdgeDocumentTypes)
+	}
+	if m.clearededge_types {
+		edges = append(edges, document.EdgeEdgeTypes)
+	}
+	if m.clearedexternal_references {
+		edges = append(edges, document.EdgeExternalReferences)
+	}
+	if m.clearedhashes {
+		edges = append(edges, document.EdgeHashes)
+	}
+	if m.clearedidentifiers {
+		edges = append(edges, document.EdgeIdentifiers)
+	}
+	if m.clearednodes {
+		edges = append(edges, document.EdgeNodes)
+	}
+	if m.clearedpersons {
+		edges = append(edges, document.EdgePersons)
+	}
+	if m.clearedproperties {
+		edges = append(edges, document.EdgeProperties)
+	}
+	if m.clearedpurposes {
+		edges = append(edges, document.EdgePurposes)
+	}
+	if m.clearedsource_data {
+		edges = append(edges, document.EdgeSourceData)
+	}
+	if m.clearedtools {
+		edges = append(edges, document.EdgeTools)
 	}
 	return edges
 }
@@ -1322,6 +2180,28 @@ func (m *DocumentMutation) EdgeCleared(name string) bool {
 		return m.clearedmetadata
 	case document.EdgeNodeList:
 		return m.clearednode_list
+	case document.EdgeDocumentTypes:
+		return m.cleareddocument_types
+	case document.EdgeEdgeTypes:
+		return m.clearededge_types
+	case document.EdgeExternalReferences:
+		return m.clearedexternal_references
+	case document.EdgeHashes:
+		return m.clearedhashes
+	case document.EdgeIdentifiers:
+		return m.clearedidentifiers
+	case document.EdgeNodes:
+		return m.clearednodes
+	case document.EdgePersons:
+		return m.clearedpersons
+	case document.EdgeProperties:
+		return m.clearedproperties
+	case document.EdgePurposes:
+		return m.clearedpurposes
+	case document.EdgeSourceData:
+		return m.clearedsource_data
+	case document.EdgeTools:
+		return m.clearedtools
 	}
 	return false
 }
@@ -1353,6 +2233,39 @@ func (m *DocumentMutation) ResetEdge(name string) error {
 	case document.EdgeNodeList:
 		m.ResetNodeList()
 		return nil
+	case document.EdgeDocumentTypes:
+		m.ResetDocumentTypes()
+		return nil
+	case document.EdgeEdgeTypes:
+		m.ResetEdgeTypes()
+		return nil
+	case document.EdgeExternalReferences:
+		m.ResetExternalReferences()
+		return nil
+	case document.EdgeHashes:
+		m.ResetHashes()
+		return nil
+	case document.EdgeIdentifiers:
+		m.ResetIdentifiers()
+		return nil
+	case document.EdgeNodes:
+		m.ResetNodes()
+		return nil
+	case document.EdgePersons:
+		m.ResetPersons()
+		return nil
+	case document.EdgeProperties:
+		m.ResetProperties()
+		return nil
+	case document.EdgePurposes:
+		m.ResetPurposes()
+		return nil
+	case document.EdgeSourceData:
+		m.ResetSourceData()
+		return nil
+	case document.EdgeTools:
+		m.ResetTools()
+		return nil
 	}
 	return fmt.Errorf("unknown Document edge %s", name)
 }
@@ -1360,21 +2273,23 @@ func (m *DocumentMutation) ResetEdge(name string) error {
 // DocumentTypeMutation represents an operation that mutates the DocumentType nodes in the graph.
 type DocumentTypeMutation struct {
 	config
-	op              Op
-	typ             string
-	id              *uuid.UUID
-	proto_message   **sbom.DocumentType
-	_type           *documenttype.Type
-	name            *string
-	description     *string
-	clearedFields   map[string]struct{}
-	document        *uuid.UUID
-	cleareddocument bool
-	metadata        *uuid.UUID
-	clearedmetadata bool
-	done            bool
-	oldValue        func(context.Context) (*DocumentType, error)
-	predicates      []predicate.DocumentType
+	op               Op
+	typ              string
+	id               *uuid.UUID
+	proto_message    **sbom.DocumentType
+	_type            *documenttype.Type
+	name             *string
+	description      *string
+	clearedFields    map[string]struct{}
+	documents        map[uuid.UUID]struct{}
+	removeddocuments map[uuid.UUID]struct{}
+	cleareddocuments bool
+	metadata         map[uuid.UUID]struct{}
+	removedmetadata  map[uuid.UUID]struct{}
+	clearedmetadata  bool
+	done             bool
+	oldValue         func(context.Context) (*DocumentType, error)
+	predicates       []predicate.DocumentType
 }
 
 var _ ent.Mutation = (*DocumentTypeMutation)(nil)
@@ -1481,55 +2396,6 @@ func (m *DocumentTypeMutation) IDs(ctx context.Context) ([]uuid.UUID, error) {
 	}
 }
 
-// SetDocumentID sets the "document_id" field.
-func (m *DocumentTypeMutation) SetDocumentID(u uuid.UUID) {
-	m.document = &u
-}
-
-// DocumentID returns the value of the "document_id" field in the mutation.
-func (m *DocumentTypeMutation) DocumentID() (r uuid.UUID, exists bool) {
-	v := m.document
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDocumentID returns the old "document_id" field's value of the DocumentType entity.
-// If the DocumentType object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *DocumentTypeMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDocumentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
-	}
-	return oldValue.DocumentID, nil
-}
-
-// ClearDocumentID clears the value of the "document_id" field.
-func (m *DocumentTypeMutation) ClearDocumentID() {
-	m.document = nil
-	m.clearedFields[documenttype.FieldDocumentID] = struct{}{}
-}
-
-// DocumentIDCleared returns if the "document_id" field was cleared in this mutation.
-func (m *DocumentTypeMutation) DocumentIDCleared() bool {
-	_, ok := m.clearedFields[documenttype.FieldDocumentID]
-	return ok
-}
-
-// ResetDocumentID resets all changes to the "document_id" field.
-func (m *DocumentTypeMutation) ResetDocumentID() {
-	m.document = nil
-	delete(m.clearedFields, documenttype.FieldDocumentID)
-}
-
 // SetProtoMessage sets the "proto_message" field.
 func (m *DocumentTypeMutation) SetProtoMessage(st *sbom.DocumentType) {
 	m.proto_message = &st
@@ -1564,42 +2430,6 @@ func (m *DocumentTypeMutation) OldProtoMessage(ctx context.Context) (v *sbom.Doc
 // ResetProtoMessage resets all changes to the "proto_message" field.
 func (m *DocumentTypeMutation) ResetProtoMessage() {
 	m.proto_message = nil
-}
-
-// SetMetadataID sets the "metadata_id" field.
-func (m *DocumentTypeMutation) SetMetadataID(u uuid.UUID) {
-	m.metadata = &u
-}
-
-// MetadataID returns the value of the "metadata_id" field in the mutation.
-func (m *DocumentTypeMutation) MetadataID() (r uuid.UUID, exists bool) {
-	v := m.metadata
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldMetadataID returns the old "metadata_id" field's value of the DocumentType entity.
-// If the DocumentType object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *DocumentTypeMutation) OldMetadataID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldMetadataID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldMetadataID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldMetadataID: %w", err)
-	}
-	return oldValue.MetadataID, nil
-}
-
-// ResetMetadataID resets all changes to the "metadata_id" field.
-func (m *DocumentTypeMutation) ResetMetadataID() {
-	m.metadata = nil
 }
 
 // SetType sets the "type" field.
@@ -1749,37 +2579,73 @@ func (m *DocumentTypeMutation) ResetDescription() {
 	delete(m.clearedFields, documenttype.FieldDescription)
 }
 
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *DocumentTypeMutation) ClearDocument() {
-	m.cleareddocument = true
-	m.clearedFields[documenttype.FieldDocumentID] = struct{}{}
+// AddDocumentIDs adds the "documents" edge to the Document entity by ids.
+func (m *DocumentTypeMutation) AddDocumentIDs(ids ...uuid.UUID) {
+	if m.documents == nil {
+		m.documents = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.documents[ids[i]] = struct{}{}
+	}
 }
 
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *DocumentTypeMutation) DocumentCleared() bool {
-	return m.DocumentIDCleared() || m.cleareddocument
+// ClearDocuments clears the "documents" edge to the Document entity.
+func (m *DocumentTypeMutation) ClearDocuments() {
+	m.cleareddocuments = true
 }
 
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *DocumentTypeMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
+// DocumentsCleared reports if the "documents" edge to the Document entity was cleared.
+func (m *DocumentTypeMutation) DocumentsCleared() bool {
+	return m.cleareddocuments
+}
+
+// RemoveDocumentIDs removes the "documents" edge to the Document entity by IDs.
+func (m *DocumentTypeMutation) RemoveDocumentIDs(ids ...uuid.UUID) {
+	if m.removeddocuments == nil {
+		m.removeddocuments = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.documents, ids[i])
+		m.removeddocuments[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocuments returns the removed IDs of the "documents" edge to the Document entity.
+func (m *DocumentTypeMutation) RemovedDocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocuments {
+		ids = append(ids, id)
 	}
 	return
 }
 
-// ResetDocument resets all changes to the "document" edge.
-func (m *DocumentTypeMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
+// DocumentsIDs returns the "documents" edge IDs in the mutation.
+func (m *DocumentTypeMutation) DocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.documents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetDocuments resets all changes to the "documents" edge.
+func (m *DocumentTypeMutation) ResetDocuments() {
+	m.documents = nil
+	m.cleareddocuments = false
+	m.removeddocuments = nil
+}
+
+// AddMetadatumIDs adds the "metadata" edge to the Metadata entity by ids.
+func (m *DocumentTypeMutation) AddMetadatumIDs(ids ...uuid.UUID) {
+	if m.metadata == nil {
+		m.metadata = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.metadata[ids[i]] = struct{}{}
+	}
 }
 
 // ClearMetadata clears the "metadata" edge to the Metadata entity.
 func (m *DocumentTypeMutation) ClearMetadata() {
 	m.clearedmetadata = true
-	m.clearedFields[documenttype.FieldMetadataID] = struct{}{}
 }
 
 // MetadataCleared reports if the "metadata" edge to the Metadata entity was cleared.
@@ -1787,12 +2653,29 @@ func (m *DocumentTypeMutation) MetadataCleared() bool {
 	return m.clearedmetadata
 }
 
+// RemoveMetadatumIDs removes the "metadata" edge to the Metadata entity by IDs.
+func (m *DocumentTypeMutation) RemoveMetadatumIDs(ids ...uuid.UUID) {
+	if m.removedmetadata == nil {
+		m.removedmetadata = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.metadata, ids[i])
+		m.removedmetadata[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedMetadata returns the removed IDs of the "metadata" edge to the Metadata entity.
+func (m *DocumentTypeMutation) RemovedMetadataIDs() (ids []uuid.UUID) {
+	for id := range m.removedmetadata {
+		ids = append(ids, id)
+	}
+	return
+}
+
 // MetadataIDs returns the "metadata" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// MetadataID instead. It exists only for internal usage by the builders.
 func (m *DocumentTypeMutation) MetadataIDs() (ids []uuid.UUID) {
-	if id := m.metadata; id != nil {
-		ids = append(ids, *id)
+	for id := range m.metadata {
+		ids = append(ids, id)
 	}
 	return
 }
@@ -1801,6 +2684,7 @@ func (m *DocumentTypeMutation) MetadataIDs() (ids []uuid.UUID) {
 func (m *DocumentTypeMutation) ResetMetadata() {
 	m.metadata = nil
 	m.clearedmetadata = false
+	m.removedmetadata = nil
 }
 
 // Where appends a list predicates to the DocumentTypeMutation builder.
@@ -1837,15 +2721,9 @@ func (m *DocumentTypeMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *DocumentTypeMutation) Fields() []string {
-	fields := make([]string, 0, 6)
-	if m.document != nil {
-		fields = append(fields, documenttype.FieldDocumentID)
-	}
+	fields := make([]string, 0, 4)
 	if m.proto_message != nil {
 		fields = append(fields, documenttype.FieldProtoMessage)
-	}
-	if m.metadata != nil {
-		fields = append(fields, documenttype.FieldMetadataID)
 	}
 	if m._type != nil {
 		fields = append(fields, documenttype.FieldType)
@@ -1864,12 +2742,8 @@ func (m *DocumentTypeMutation) Fields() []string {
 // schema.
 func (m *DocumentTypeMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case documenttype.FieldDocumentID:
-		return m.DocumentID()
 	case documenttype.FieldProtoMessage:
 		return m.ProtoMessage()
-	case documenttype.FieldMetadataID:
-		return m.MetadataID()
 	case documenttype.FieldType:
 		return m.GetType()
 	case documenttype.FieldName:
@@ -1885,12 +2759,8 @@ func (m *DocumentTypeMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *DocumentTypeMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case documenttype.FieldDocumentID:
-		return m.OldDocumentID(ctx)
 	case documenttype.FieldProtoMessage:
 		return m.OldProtoMessage(ctx)
-	case documenttype.FieldMetadataID:
-		return m.OldMetadataID(ctx)
 	case documenttype.FieldType:
 		return m.OldType(ctx)
 	case documenttype.FieldName:
@@ -1906,26 +2776,12 @@ func (m *DocumentTypeMutation) OldField(ctx context.Context, name string) (ent.V
 // type.
 func (m *DocumentTypeMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case documenttype.FieldDocumentID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDocumentID(v)
-		return nil
 	case documenttype.FieldProtoMessage:
 		v, ok := value.(*sbom.DocumentType)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetProtoMessage(v)
-		return nil
-	case documenttype.FieldMetadataID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetMetadataID(v)
 		return nil
 	case documenttype.FieldType:
 		v, ok := value.(documenttype.Type)
@@ -1978,9 +2834,6 @@ func (m *DocumentTypeMutation) AddField(name string, value ent.Value) error {
 // mutation.
 func (m *DocumentTypeMutation) ClearedFields() []string {
 	var fields []string
-	if m.FieldCleared(documenttype.FieldDocumentID) {
-		fields = append(fields, documenttype.FieldDocumentID)
-	}
 	if m.FieldCleared(documenttype.FieldType) {
 		fields = append(fields, documenttype.FieldType)
 	}
@@ -2004,9 +2857,6 @@ func (m *DocumentTypeMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *DocumentTypeMutation) ClearField(name string) error {
 	switch name {
-	case documenttype.FieldDocumentID:
-		m.ClearDocumentID()
-		return nil
 	case documenttype.FieldType:
 		m.ClearType()
 		return nil
@@ -2024,14 +2874,8 @@ func (m *DocumentTypeMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *DocumentTypeMutation) ResetField(name string) error {
 	switch name {
-	case documenttype.FieldDocumentID:
-		m.ResetDocumentID()
-		return nil
 	case documenttype.FieldProtoMessage:
 		m.ResetProtoMessage()
-		return nil
-	case documenttype.FieldMetadataID:
-		m.ResetMetadataID()
 		return nil
 	case documenttype.FieldType:
 		m.ResetType()
@@ -2049,8 +2893,8 @@ func (m *DocumentTypeMutation) ResetField(name string) error {
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *DocumentTypeMutation) AddedEdges() []string {
 	edges := make([]string, 0, 2)
-	if m.document != nil {
-		edges = append(edges, documenttype.EdgeDocument)
+	if m.documents != nil {
+		edges = append(edges, documenttype.EdgeDocuments)
 	}
 	if m.metadata != nil {
 		edges = append(edges, documenttype.EdgeMetadata)
@@ -2062,14 +2906,18 @@ func (m *DocumentTypeMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *DocumentTypeMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case documenttype.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
+	case documenttype.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.documents))
+		for id := range m.documents {
+			ids = append(ids, id)
 		}
+		return ids
 	case documenttype.EdgeMetadata:
-		if id := m.metadata; id != nil {
-			return []ent.Value{*id}
+		ids := make([]ent.Value, 0, len(m.metadata))
+		for id := range m.metadata {
+			ids = append(ids, id)
 		}
+		return ids
 	}
 	return nil
 }
@@ -2077,20 +2925,40 @@ func (m *DocumentTypeMutation) AddedIDs(name string) []ent.Value {
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *DocumentTypeMutation) RemovedEdges() []string {
 	edges := make([]string, 0, 2)
+	if m.removeddocuments != nil {
+		edges = append(edges, documenttype.EdgeDocuments)
+	}
+	if m.removedmetadata != nil {
+		edges = append(edges, documenttype.EdgeMetadata)
+	}
 	return edges
 }
 
 // RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
 // the given name in this mutation.
 func (m *DocumentTypeMutation) RemovedIDs(name string) []ent.Value {
+	switch name {
+	case documenttype.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.removeddocuments))
+		for id := range m.removeddocuments {
+			ids = append(ids, id)
+		}
+		return ids
+	case documenttype.EdgeMetadata:
+		ids := make([]ent.Value, 0, len(m.removedmetadata))
+		for id := range m.removedmetadata {
+			ids = append(ids, id)
+		}
+		return ids
+	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *DocumentTypeMutation) ClearedEdges() []string {
 	edges := make([]string, 0, 2)
-	if m.cleareddocument {
-		edges = append(edges, documenttype.EdgeDocument)
+	if m.cleareddocuments {
+		edges = append(edges, documenttype.EdgeDocuments)
 	}
 	if m.clearedmetadata {
 		edges = append(edges, documenttype.EdgeMetadata)
@@ -2102,8 +2970,8 @@ func (m *DocumentTypeMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *DocumentTypeMutation) EdgeCleared(name string) bool {
 	switch name {
-	case documenttype.EdgeDocument:
-		return m.cleareddocument
+	case documenttype.EdgeDocuments:
+		return m.cleareddocuments
 	case documenttype.EdgeMetadata:
 		return m.clearedmetadata
 	}
@@ -2114,12 +2982,6 @@ func (m *DocumentTypeMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *DocumentTypeMutation) ClearEdge(name string) error {
 	switch name {
-	case documenttype.EdgeDocument:
-		m.ClearDocument()
-		return nil
-	case documenttype.EdgeMetadata:
-		m.ClearMetadata()
-		return nil
 	}
 	return fmt.Errorf("unknown DocumentType unique edge %s", name)
 }
@@ -2128,8 +2990,8 @@ func (m *DocumentTypeMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *DocumentTypeMutation) ResetEdge(name string) error {
 	switch name {
-	case documenttype.EdgeDocument:
-		m.ResetDocument()
+	case documenttype.EdgeDocuments:
+		m.ResetDocuments()
 		return nil
 	case documenttype.EdgeMetadata:
 		m.ResetMetadata()
@@ -2147,12 +3009,13 @@ type EdgeTypeMutation struct {
 	proto_message     **sbom.Edge
 	_type             *edgetype.Type
 	clearedFields     map[string]struct{}
-	document          *uuid.UUID
-	cleareddocument   bool
 	from              *uuid.UUID
 	clearedfrom       bool
 	to                *uuid.UUID
 	clearedto         bool
+	documents         map[uuid.UUID]struct{}
+	removeddocuments  map[uuid.UUID]struct{}
+	cleareddocuments  bool
 	node_lists        map[uuid.UUID]struct{}
 	removednode_lists map[uuid.UUID]struct{}
 	clearednode_lists bool
@@ -2263,55 +3126,6 @@ func (m *EdgeTypeMutation) IDs(ctx context.Context) ([]uuid.UUID, error) {
 	default:
 		return nil, fmt.Errorf("IDs is not allowed on %s operations", m.op)
 	}
-}
-
-// SetDocumentID sets the "document_id" field.
-func (m *EdgeTypeMutation) SetDocumentID(u uuid.UUID) {
-	m.document = &u
-}
-
-// DocumentID returns the value of the "document_id" field in the mutation.
-func (m *EdgeTypeMutation) DocumentID() (r uuid.UUID, exists bool) {
-	v := m.document
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDocumentID returns the old "document_id" field's value of the EdgeType entity.
-// If the EdgeType object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *EdgeTypeMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDocumentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
-	}
-	return oldValue.DocumentID, nil
-}
-
-// ClearDocumentID clears the value of the "document_id" field.
-func (m *EdgeTypeMutation) ClearDocumentID() {
-	m.document = nil
-	m.clearedFields[edgetype.FieldDocumentID] = struct{}{}
-}
-
-// DocumentIDCleared returns if the "document_id" field was cleared in this mutation.
-func (m *EdgeTypeMutation) DocumentIDCleared() bool {
-	_, ok := m.clearedFields[edgetype.FieldDocumentID]
-	return ok
-}
-
-// ResetDocumentID resets all changes to the "document_id" field.
-func (m *EdgeTypeMutation) ResetDocumentID() {
-	m.document = nil
-	delete(m.clearedFields, edgetype.FieldDocumentID)
 }
 
 // SetProtoMessage sets the "proto_message" field.
@@ -2458,33 +3272,6 @@ func (m *EdgeTypeMutation) ResetToNodeID() {
 	m.to = nil
 }
 
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *EdgeTypeMutation) ClearDocument() {
-	m.cleareddocument = true
-	m.clearedFields[edgetype.FieldDocumentID] = struct{}{}
-}
-
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *EdgeTypeMutation) DocumentCleared() bool {
-	return m.DocumentIDCleared() || m.cleareddocument
-}
-
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *EdgeTypeMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
-	}
-	return
-}
-
-// ResetDocument resets all changes to the "document" edge.
-func (m *EdgeTypeMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
-}
-
 // SetFromID sets the "from" edge to the Node entity by id.
 func (m *EdgeTypeMutation) SetFromID(id uuid.UUID) {
 	m.from = &id
@@ -2563,6 +3350,60 @@ func (m *EdgeTypeMutation) ToIDs() (ids []uuid.UUID) {
 func (m *EdgeTypeMutation) ResetTo() {
 	m.to = nil
 	m.clearedto = false
+}
+
+// AddDocumentIDs adds the "documents" edge to the Document entity by ids.
+func (m *EdgeTypeMutation) AddDocumentIDs(ids ...uuid.UUID) {
+	if m.documents == nil {
+		m.documents = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.documents[ids[i]] = struct{}{}
+	}
+}
+
+// ClearDocuments clears the "documents" edge to the Document entity.
+func (m *EdgeTypeMutation) ClearDocuments() {
+	m.cleareddocuments = true
+}
+
+// DocumentsCleared reports if the "documents" edge to the Document entity was cleared.
+func (m *EdgeTypeMutation) DocumentsCleared() bool {
+	return m.cleareddocuments
+}
+
+// RemoveDocumentIDs removes the "documents" edge to the Document entity by IDs.
+func (m *EdgeTypeMutation) RemoveDocumentIDs(ids ...uuid.UUID) {
+	if m.removeddocuments == nil {
+		m.removeddocuments = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.documents, ids[i])
+		m.removeddocuments[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocuments returns the removed IDs of the "documents" edge to the Document entity.
+func (m *EdgeTypeMutation) RemovedDocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocuments {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// DocumentsIDs returns the "documents" edge IDs in the mutation.
+func (m *EdgeTypeMutation) DocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.documents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetDocuments resets all changes to the "documents" edge.
+func (m *EdgeTypeMutation) ResetDocuments() {
+	m.documents = nil
+	m.cleareddocuments = false
+	m.removeddocuments = nil
 }
 
 // AddNodeListIDs adds the "node_lists" edge to the NodeList entity by ids.
@@ -2653,10 +3494,7 @@ func (m *EdgeTypeMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *EdgeTypeMutation) Fields() []string {
-	fields := make([]string, 0, 5)
-	if m.document != nil {
-		fields = append(fields, edgetype.FieldDocumentID)
-	}
+	fields := make([]string, 0, 4)
 	if m.proto_message != nil {
 		fields = append(fields, edgetype.FieldProtoMessage)
 	}
@@ -2677,8 +3515,6 @@ func (m *EdgeTypeMutation) Fields() []string {
 // schema.
 func (m *EdgeTypeMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case edgetype.FieldDocumentID:
-		return m.DocumentID()
 	case edgetype.FieldProtoMessage:
 		return m.ProtoMessage()
 	case edgetype.FieldType:
@@ -2696,8 +3532,6 @@ func (m *EdgeTypeMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *EdgeTypeMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case edgetype.FieldDocumentID:
-		return m.OldDocumentID(ctx)
 	case edgetype.FieldProtoMessage:
 		return m.OldProtoMessage(ctx)
 	case edgetype.FieldType:
@@ -2715,13 +3549,6 @@ func (m *EdgeTypeMutation) OldField(ctx context.Context, name string) (ent.Value
 // type.
 func (m *EdgeTypeMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case edgetype.FieldDocumentID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDocumentID(v)
-		return nil
 	case edgetype.FieldProtoMessage:
 		v, ok := value.(*sbom.Edge)
 		if !ok {
@@ -2779,11 +3606,7 @@ func (m *EdgeTypeMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *EdgeTypeMutation) ClearedFields() []string {
-	var fields []string
-	if m.FieldCleared(edgetype.FieldDocumentID) {
-		fields = append(fields, edgetype.FieldDocumentID)
-	}
-	return fields
+	return nil
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -2796,11 +3619,6 @@ func (m *EdgeTypeMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *EdgeTypeMutation) ClearField(name string) error {
-	switch name {
-	case edgetype.FieldDocumentID:
-		m.ClearDocumentID()
-		return nil
-	}
 	return fmt.Errorf("unknown EdgeType nullable field %s", name)
 }
 
@@ -2808,9 +3626,6 @@ func (m *EdgeTypeMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *EdgeTypeMutation) ResetField(name string) error {
 	switch name {
-	case edgetype.FieldDocumentID:
-		m.ResetDocumentID()
-		return nil
 	case edgetype.FieldProtoMessage:
 		m.ResetProtoMessage()
 		return nil
@@ -2830,14 +3645,14 @@ func (m *EdgeTypeMutation) ResetField(name string) error {
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *EdgeTypeMutation) AddedEdges() []string {
 	edges := make([]string, 0, 4)
-	if m.document != nil {
-		edges = append(edges, edgetype.EdgeDocument)
-	}
 	if m.from != nil {
 		edges = append(edges, edgetype.EdgeFrom)
 	}
 	if m.to != nil {
 		edges = append(edges, edgetype.EdgeTo)
+	}
+	if m.documents != nil {
+		edges = append(edges, edgetype.EdgeDocuments)
 	}
 	if m.node_lists != nil {
 		edges = append(edges, edgetype.EdgeNodeLists)
@@ -2849,10 +3664,6 @@ func (m *EdgeTypeMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *EdgeTypeMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case edgetype.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
-		}
 	case edgetype.EdgeFrom:
 		if id := m.from; id != nil {
 			return []ent.Value{*id}
@@ -2861,6 +3672,12 @@ func (m *EdgeTypeMutation) AddedIDs(name string) []ent.Value {
 		if id := m.to; id != nil {
 			return []ent.Value{*id}
 		}
+	case edgetype.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.documents))
+		for id := range m.documents {
+			ids = append(ids, id)
+		}
+		return ids
 	case edgetype.EdgeNodeLists:
 		ids := make([]ent.Value, 0, len(m.node_lists))
 		for id := range m.node_lists {
@@ -2874,6 +3691,9 @@ func (m *EdgeTypeMutation) AddedIDs(name string) []ent.Value {
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *EdgeTypeMutation) RemovedEdges() []string {
 	edges := make([]string, 0, 4)
+	if m.removeddocuments != nil {
+		edges = append(edges, edgetype.EdgeDocuments)
+	}
 	if m.removednode_lists != nil {
 		edges = append(edges, edgetype.EdgeNodeLists)
 	}
@@ -2884,6 +3704,12 @@ func (m *EdgeTypeMutation) RemovedEdges() []string {
 // the given name in this mutation.
 func (m *EdgeTypeMutation) RemovedIDs(name string) []ent.Value {
 	switch name {
+	case edgetype.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.removeddocuments))
+		for id := range m.removeddocuments {
+			ids = append(ids, id)
+		}
+		return ids
 	case edgetype.EdgeNodeLists:
 		ids := make([]ent.Value, 0, len(m.removednode_lists))
 		for id := range m.removednode_lists {
@@ -2897,14 +3723,14 @@ func (m *EdgeTypeMutation) RemovedIDs(name string) []ent.Value {
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *EdgeTypeMutation) ClearedEdges() []string {
 	edges := make([]string, 0, 4)
-	if m.cleareddocument {
-		edges = append(edges, edgetype.EdgeDocument)
-	}
 	if m.clearedfrom {
 		edges = append(edges, edgetype.EdgeFrom)
 	}
 	if m.clearedto {
 		edges = append(edges, edgetype.EdgeTo)
+	}
+	if m.cleareddocuments {
+		edges = append(edges, edgetype.EdgeDocuments)
 	}
 	if m.clearednode_lists {
 		edges = append(edges, edgetype.EdgeNodeLists)
@@ -2916,12 +3742,12 @@ func (m *EdgeTypeMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *EdgeTypeMutation) EdgeCleared(name string) bool {
 	switch name {
-	case edgetype.EdgeDocument:
-		return m.cleareddocument
 	case edgetype.EdgeFrom:
 		return m.clearedfrom
 	case edgetype.EdgeTo:
 		return m.clearedto
+	case edgetype.EdgeDocuments:
+		return m.cleareddocuments
 	case edgetype.EdgeNodeLists:
 		return m.clearednode_lists
 	}
@@ -2932,9 +3758,6 @@ func (m *EdgeTypeMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *EdgeTypeMutation) ClearEdge(name string) error {
 	switch name {
-	case edgetype.EdgeDocument:
-		m.ClearDocument()
-		return nil
 	case edgetype.EdgeFrom:
 		m.ClearFrom()
 		return nil
@@ -2949,14 +3772,14 @@ func (m *EdgeTypeMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *EdgeTypeMutation) ResetEdge(name string) error {
 	switch name {
-	case edgetype.EdgeDocument:
-		m.ResetDocument()
-		return nil
 	case edgetype.EdgeFrom:
 		m.ResetFrom()
 		return nil
 	case edgetype.EdgeTo:
 		m.ResetTo()
+		return nil
+	case edgetype.EdgeDocuments:
+		m.ResetDocuments()
 		return nil
 	case edgetype.EdgeNodeLists:
 		m.ResetNodeLists()
@@ -2968,26 +3791,27 @@ func (m *EdgeTypeMutation) ResetEdge(name string) error {
 // ExternalReferenceMutation represents an operation that mutates the ExternalReference nodes in the graph.
 type ExternalReferenceMutation struct {
 	config
-	op              Op
-	typ             string
-	id              *uuid.UUID
-	proto_message   **sbom.ExternalReference
-	url             *string
-	comment         *string
-	authority       *string
-	_type           *externalreference.Type
-	clearedFields   map[string]struct{}
-	document        *uuid.UUID
-	cleareddocument bool
-	hashes          map[uuid.UUID]struct{}
-	removedhashes   map[uuid.UUID]struct{}
-	clearedhashes   bool
-	nodes           map[uuid.UUID]struct{}
-	removednodes    map[uuid.UUID]struct{}
-	clearednodes    bool
-	done            bool
-	oldValue        func(context.Context) (*ExternalReference, error)
-	predicates      []predicate.ExternalReference
+	op               Op
+	typ              string
+	id               *uuid.UUID
+	proto_message    **sbom.ExternalReference
+	url              *string
+	comment          *string
+	authority        *string
+	_type            *externalreference.Type
+	clearedFields    map[string]struct{}
+	hashes           map[uuid.UUID]struct{}
+	removedhashes    map[uuid.UUID]struct{}
+	clearedhashes    bool
+	documents        map[uuid.UUID]struct{}
+	removeddocuments map[uuid.UUID]struct{}
+	cleareddocuments bool
+	nodes            map[uuid.UUID]struct{}
+	removednodes     map[uuid.UUID]struct{}
+	clearednodes     bool
+	done             bool
+	oldValue         func(context.Context) (*ExternalReference, error)
+	predicates       []predicate.ExternalReference
 }
 
 var _ ent.Mutation = (*ExternalReferenceMutation)(nil)
@@ -3092,55 +3916,6 @@ func (m *ExternalReferenceMutation) IDs(ctx context.Context) ([]uuid.UUID, error
 	default:
 		return nil, fmt.Errorf("IDs is not allowed on %s operations", m.op)
 	}
-}
-
-// SetDocumentID sets the "document_id" field.
-func (m *ExternalReferenceMutation) SetDocumentID(u uuid.UUID) {
-	m.document = &u
-}
-
-// DocumentID returns the value of the "document_id" field in the mutation.
-func (m *ExternalReferenceMutation) DocumentID() (r uuid.UUID, exists bool) {
-	v := m.document
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDocumentID returns the old "document_id" field's value of the ExternalReference entity.
-// If the ExternalReference object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ExternalReferenceMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDocumentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
-	}
-	return oldValue.DocumentID, nil
-}
-
-// ClearDocumentID clears the value of the "document_id" field.
-func (m *ExternalReferenceMutation) ClearDocumentID() {
-	m.document = nil
-	m.clearedFields[externalreference.FieldDocumentID] = struct{}{}
-}
-
-// DocumentIDCleared returns if the "document_id" field was cleared in this mutation.
-func (m *ExternalReferenceMutation) DocumentIDCleared() bool {
-	_, ok := m.clearedFields[externalreference.FieldDocumentID]
-	return ok
-}
-
-// ResetDocumentID resets all changes to the "document_id" field.
-func (m *ExternalReferenceMutation) ResetDocumentID() {
-	m.document = nil
-	delete(m.clearedFields, externalreference.FieldDocumentID)
 }
 
 // SetProtoMessage sets the "proto_message" field.
@@ -3336,33 +4111,6 @@ func (m *ExternalReferenceMutation) ResetType() {
 	m._type = nil
 }
 
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *ExternalReferenceMutation) ClearDocument() {
-	m.cleareddocument = true
-	m.clearedFields[externalreference.FieldDocumentID] = struct{}{}
-}
-
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *ExternalReferenceMutation) DocumentCleared() bool {
-	return m.DocumentIDCleared() || m.cleareddocument
-}
-
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *ExternalReferenceMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
-	}
-	return
-}
-
-// ResetDocument resets all changes to the "document" edge.
-func (m *ExternalReferenceMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
-}
-
 // AddHashIDs adds the "hashes" edge to the HashesEntry entity by ids.
 func (m *ExternalReferenceMutation) AddHashIDs(ids ...uuid.UUID) {
 	if m.hashes == nil {
@@ -3415,6 +4163,60 @@ func (m *ExternalReferenceMutation) ResetHashes() {
 	m.hashes = nil
 	m.clearedhashes = false
 	m.removedhashes = nil
+}
+
+// AddDocumentIDs adds the "documents" edge to the Document entity by ids.
+func (m *ExternalReferenceMutation) AddDocumentIDs(ids ...uuid.UUID) {
+	if m.documents == nil {
+		m.documents = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.documents[ids[i]] = struct{}{}
+	}
+}
+
+// ClearDocuments clears the "documents" edge to the Document entity.
+func (m *ExternalReferenceMutation) ClearDocuments() {
+	m.cleareddocuments = true
+}
+
+// DocumentsCleared reports if the "documents" edge to the Document entity was cleared.
+func (m *ExternalReferenceMutation) DocumentsCleared() bool {
+	return m.cleareddocuments
+}
+
+// RemoveDocumentIDs removes the "documents" edge to the Document entity by IDs.
+func (m *ExternalReferenceMutation) RemoveDocumentIDs(ids ...uuid.UUID) {
+	if m.removeddocuments == nil {
+		m.removeddocuments = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.documents, ids[i])
+		m.removeddocuments[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocuments returns the removed IDs of the "documents" edge to the Document entity.
+func (m *ExternalReferenceMutation) RemovedDocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocuments {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// DocumentsIDs returns the "documents" edge IDs in the mutation.
+func (m *ExternalReferenceMutation) DocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.documents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetDocuments resets all changes to the "documents" edge.
+func (m *ExternalReferenceMutation) ResetDocuments() {
+	m.documents = nil
+	m.cleareddocuments = false
+	m.removeddocuments = nil
 }
 
 // AddNodeIDs adds the "nodes" edge to the Node entity by ids.
@@ -3505,10 +4307,7 @@ func (m *ExternalReferenceMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ExternalReferenceMutation) Fields() []string {
-	fields := make([]string, 0, 6)
-	if m.document != nil {
-		fields = append(fields, externalreference.FieldDocumentID)
-	}
+	fields := make([]string, 0, 5)
 	if m.proto_message != nil {
 		fields = append(fields, externalreference.FieldProtoMessage)
 	}
@@ -3532,8 +4331,6 @@ func (m *ExternalReferenceMutation) Fields() []string {
 // schema.
 func (m *ExternalReferenceMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case externalreference.FieldDocumentID:
-		return m.DocumentID()
 	case externalreference.FieldProtoMessage:
 		return m.ProtoMessage()
 	case externalreference.FieldURL:
@@ -3553,8 +4350,6 @@ func (m *ExternalReferenceMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *ExternalReferenceMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case externalreference.FieldDocumentID:
-		return m.OldDocumentID(ctx)
 	case externalreference.FieldProtoMessage:
 		return m.OldProtoMessage(ctx)
 	case externalreference.FieldURL:
@@ -3574,13 +4369,6 @@ func (m *ExternalReferenceMutation) OldField(ctx context.Context, name string) (
 // type.
 func (m *ExternalReferenceMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case externalreference.FieldDocumentID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDocumentID(v)
-		return nil
 	case externalreference.FieldProtoMessage:
 		v, ok := value.(*sbom.ExternalReference)
 		if !ok {
@@ -3646,9 +4434,6 @@ func (m *ExternalReferenceMutation) AddField(name string, value ent.Value) error
 // mutation.
 func (m *ExternalReferenceMutation) ClearedFields() []string {
 	var fields []string
-	if m.FieldCleared(externalreference.FieldDocumentID) {
-		fields = append(fields, externalreference.FieldDocumentID)
-	}
 	if m.FieldCleared(externalreference.FieldAuthority) {
 		fields = append(fields, externalreference.FieldAuthority)
 	}
@@ -3666,9 +4451,6 @@ func (m *ExternalReferenceMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *ExternalReferenceMutation) ClearField(name string) error {
 	switch name {
-	case externalreference.FieldDocumentID:
-		m.ClearDocumentID()
-		return nil
 	case externalreference.FieldAuthority:
 		m.ClearAuthority()
 		return nil
@@ -3680,9 +4462,6 @@ func (m *ExternalReferenceMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *ExternalReferenceMutation) ResetField(name string) error {
 	switch name {
-	case externalreference.FieldDocumentID:
-		m.ResetDocumentID()
-		return nil
 	case externalreference.FieldProtoMessage:
 		m.ResetProtoMessage()
 		return nil
@@ -3705,11 +4484,11 @@ func (m *ExternalReferenceMutation) ResetField(name string) error {
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *ExternalReferenceMutation) AddedEdges() []string {
 	edges := make([]string, 0, 3)
-	if m.document != nil {
-		edges = append(edges, externalreference.EdgeDocument)
-	}
 	if m.hashes != nil {
 		edges = append(edges, externalreference.EdgeHashes)
+	}
+	if m.documents != nil {
+		edges = append(edges, externalreference.EdgeDocuments)
 	}
 	if m.nodes != nil {
 		edges = append(edges, externalreference.EdgeNodes)
@@ -3721,13 +4500,15 @@ func (m *ExternalReferenceMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *ExternalReferenceMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case externalreference.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
-		}
 	case externalreference.EdgeHashes:
 		ids := make([]ent.Value, 0, len(m.hashes))
 		for id := range m.hashes {
+			ids = append(ids, id)
+		}
+		return ids
+	case externalreference.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.documents))
+		for id := range m.documents {
 			ids = append(ids, id)
 		}
 		return ids
@@ -3747,6 +4528,9 @@ func (m *ExternalReferenceMutation) RemovedEdges() []string {
 	if m.removedhashes != nil {
 		edges = append(edges, externalreference.EdgeHashes)
 	}
+	if m.removeddocuments != nil {
+		edges = append(edges, externalreference.EdgeDocuments)
+	}
 	if m.removednodes != nil {
 		edges = append(edges, externalreference.EdgeNodes)
 	}
@@ -3763,6 +4547,12 @@ func (m *ExternalReferenceMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case externalreference.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.removeddocuments))
+		for id := range m.removeddocuments {
+			ids = append(ids, id)
+		}
+		return ids
 	case externalreference.EdgeNodes:
 		ids := make([]ent.Value, 0, len(m.removednodes))
 		for id := range m.removednodes {
@@ -3776,11 +4566,11 @@ func (m *ExternalReferenceMutation) RemovedIDs(name string) []ent.Value {
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *ExternalReferenceMutation) ClearedEdges() []string {
 	edges := make([]string, 0, 3)
-	if m.cleareddocument {
-		edges = append(edges, externalreference.EdgeDocument)
-	}
 	if m.clearedhashes {
 		edges = append(edges, externalreference.EdgeHashes)
+	}
+	if m.cleareddocuments {
+		edges = append(edges, externalreference.EdgeDocuments)
 	}
 	if m.clearednodes {
 		edges = append(edges, externalreference.EdgeNodes)
@@ -3792,10 +4582,10 @@ func (m *ExternalReferenceMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *ExternalReferenceMutation) EdgeCleared(name string) bool {
 	switch name {
-	case externalreference.EdgeDocument:
-		return m.cleareddocument
 	case externalreference.EdgeHashes:
 		return m.clearedhashes
+	case externalreference.EdgeDocuments:
+		return m.cleareddocuments
 	case externalreference.EdgeNodes:
 		return m.clearednodes
 	}
@@ -3806,9 +4596,6 @@ func (m *ExternalReferenceMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *ExternalReferenceMutation) ClearEdge(name string) error {
 	switch name {
-	case externalreference.EdgeDocument:
-		m.ClearDocument()
-		return nil
 	}
 	return fmt.Errorf("unknown ExternalReference unique edge %s", name)
 }
@@ -3817,11 +4604,11 @@ func (m *ExternalReferenceMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *ExternalReferenceMutation) ResetEdge(name string) error {
 	switch name {
-	case externalreference.EdgeDocument:
-		m.ResetDocument()
-		return nil
 	case externalreference.EdgeHashes:
 		m.ResetHashes()
+		return nil
+	case externalreference.EdgeDocuments:
+		m.ResetDocuments()
 		return nil
 	case externalreference.EdgeNodes:
 		m.ResetNodes()
@@ -3839,14 +4626,18 @@ type HashesEntryMutation struct {
 	hash_algorithm             *hashesentry.HashAlgorithm
 	hash_data                  *string
 	clearedFields              map[string]struct{}
-	document                   *uuid.UUID
-	cleareddocument            bool
+	documents                  map[uuid.UUID]struct{}
+	removeddocuments           map[uuid.UUID]struct{}
+	cleareddocuments           bool
 	external_references        map[uuid.UUID]struct{}
 	removedexternal_references map[uuid.UUID]struct{}
 	clearedexternal_references bool
 	nodes                      map[uuid.UUID]struct{}
 	removednodes               map[uuid.UUID]struct{}
 	clearednodes               bool
+	source_data                map[uuid.UUID]struct{}
+	removedsource_data         map[uuid.UUID]struct{}
+	clearedsource_data         bool
 	done                       bool
 	oldValue                   func(context.Context) (*HashesEntry, error)
 	predicates                 []predicate.HashesEntry
@@ -3956,55 +4747,6 @@ func (m *HashesEntryMutation) IDs(ctx context.Context) ([]uuid.UUID, error) {
 	}
 }
 
-// SetDocumentID sets the "document_id" field.
-func (m *HashesEntryMutation) SetDocumentID(u uuid.UUID) {
-	m.document = &u
-}
-
-// DocumentID returns the value of the "document_id" field in the mutation.
-func (m *HashesEntryMutation) DocumentID() (r uuid.UUID, exists bool) {
-	v := m.document
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDocumentID returns the old "document_id" field's value of the HashesEntry entity.
-// If the HashesEntry object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *HashesEntryMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDocumentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
-	}
-	return oldValue.DocumentID, nil
-}
-
-// ClearDocumentID clears the value of the "document_id" field.
-func (m *HashesEntryMutation) ClearDocumentID() {
-	m.document = nil
-	m.clearedFields[hashesentry.FieldDocumentID] = struct{}{}
-}
-
-// DocumentIDCleared returns if the "document_id" field was cleared in this mutation.
-func (m *HashesEntryMutation) DocumentIDCleared() bool {
-	_, ok := m.clearedFields[hashesentry.FieldDocumentID]
-	return ok
-}
-
-// ResetDocumentID resets all changes to the "document_id" field.
-func (m *HashesEntryMutation) ResetDocumentID() {
-	m.document = nil
-	delete(m.clearedFields, hashesentry.FieldDocumentID)
-}
-
 // SetHashAlgorithm sets the "hash_algorithm" field.
 func (m *HashesEntryMutation) SetHashAlgorithm(ha hashesentry.HashAlgorithm) {
 	m.hash_algorithm = &ha
@@ -4077,31 +4819,58 @@ func (m *HashesEntryMutation) ResetHashData() {
 	m.hash_data = nil
 }
 
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *HashesEntryMutation) ClearDocument() {
-	m.cleareddocument = true
-	m.clearedFields[hashesentry.FieldDocumentID] = struct{}{}
+// AddDocumentIDs adds the "documents" edge to the Document entity by ids.
+func (m *HashesEntryMutation) AddDocumentIDs(ids ...uuid.UUID) {
+	if m.documents == nil {
+		m.documents = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.documents[ids[i]] = struct{}{}
+	}
 }
 
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *HashesEntryMutation) DocumentCleared() bool {
-	return m.DocumentIDCleared() || m.cleareddocument
+// ClearDocuments clears the "documents" edge to the Document entity.
+func (m *HashesEntryMutation) ClearDocuments() {
+	m.cleareddocuments = true
 }
 
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *HashesEntryMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
+// DocumentsCleared reports if the "documents" edge to the Document entity was cleared.
+func (m *HashesEntryMutation) DocumentsCleared() bool {
+	return m.cleareddocuments
+}
+
+// RemoveDocumentIDs removes the "documents" edge to the Document entity by IDs.
+func (m *HashesEntryMutation) RemoveDocumentIDs(ids ...uuid.UUID) {
+	if m.removeddocuments == nil {
+		m.removeddocuments = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.documents, ids[i])
+		m.removeddocuments[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocuments returns the removed IDs of the "documents" edge to the Document entity.
+func (m *HashesEntryMutation) RemovedDocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocuments {
+		ids = append(ids, id)
 	}
 	return
 }
 
-// ResetDocument resets all changes to the "document" edge.
-func (m *HashesEntryMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
+// DocumentsIDs returns the "documents" edge IDs in the mutation.
+func (m *HashesEntryMutation) DocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.documents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetDocuments resets all changes to the "documents" edge.
+func (m *HashesEntryMutation) ResetDocuments() {
+	m.documents = nil
+	m.cleareddocuments = false
+	m.removeddocuments = nil
 }
 
 // AddExternalReferenceIDs adds the "external_references" edge to the ExternalReference entity by ids.
@@ -4212,6 +4981,60 @@ func (m *HashesEntryMutation) ResetNodes() {
 	m.removednodes = nil
 }
 
+// AddSourceDatumIDs adds the "source_data" edge to the SourceData entity by ids.
+func (m *HashesEntryMutation) AddSourceDatumIDs(ids ...uuid.UUID) {
+	if m.source_data == nil {
+		m.source_data = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.source_data[ids[i]] = struct{}{}
+	}
+}
+
+// ClearSourceData clears the "source_data" edge to the SourceData entity.
+func (m *HashesEntryMutation) ClearSourceData() {
+	m.clearedsource_data = true
+}
+
+// SourceDataCleared reports if the "source_data" edge to the SourceData entity was cleared.
+func (m *HashesEntryMutation) SourceDataCleared() bool {
+	return m.clearedsource_data
+}
+
+// RemoveSourceDatumIDs removes the "source_data" edge to the SourceData entity by IDs.
+func (m *HashesEntryMutation) RemoveSourceDatumIDs(ids ...uuid.UUID) {
+	if m.removedsource_data == nil {
+		m.removedsource_data = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.source_data, ids[i])
+		m.removedsource_data[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedSourceData returns the removed IDs of the "source_data" edge to the SourceData entity.
+func (m *HashesEntryMutation) RemovedSourceDataIDs() (ids []uuid.UUID) {
+	for id := range m.removedsource_data {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// SourceDataIDs returns the "source_data" edge IDs in the mutation.
+func (m *HashesEntryMutation) SourceDataIDs() (ids []uuid.UUID) {
+	for id := range m.source_data {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetSourceData resets all changes to the "source_data" edge.
+func (m *HashesEntryMutation) ResetSourceData() {
+	m.source_data = nil
+	m.clearedsource_data = false
+	m.removedsource_data = nil
+}
+
 // Where appends a list predicates to the HashesEntryMutation builder.
 func (m *HashesEntryMutation) Where(ps ...predicate.HashesEntry) {
 	m.predicates = append(m.predicates, ps...)
@@ -4246,10 +5069,7 @@ func (m *HashesEntryMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *HashesEntryMutation) Fields() []string {
-	fields := make([]string, 0, 3)
-	if m.document != nil {
-		fields = append(fields, hashesentry.FieldDocumentID)
-	}
+	fields := make([]string, 0, 2)
 	if m.hash_algorithm != nil {
 		fields = append(fields, hashesentry.FieldHashAlgorithm)
 	}
@@ -4264,8 +5084,6 @@ func (m *HashesEntryMutation) Fields() []string {
 // schema.
 func (m *HashesEntryMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case hashesentry.FieldDocumentID:
-		return m.DocumentID()
 	case hashesentry.FieldHashAlgorithm:
 		return m.HashAlgorithm()
 	case hashesentry.FieldHashData:
@@ -4279,8 +5097,6 @@ func (m *HashesEntryMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *HashesEntryMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case hashesentry.FieldDocumentID:
-		return m.OldDocumentID(ctx)
 	case hashesentry.FieldHashAlgorithm:
 		return m.OldHashAlgorithm(ctx)
 	case hashesentry.FieldHashData:
@@ -4294,13 +5110,6 @@ func (m *HashesEntryMutation) OldField(ctx context.Context, name string) (ent.Va
 // type.
 func (m *HashesEntryMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case hashesentry.FieldDocumentID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDocumentID(v)
-		return nil
 	case hashesentry.FieldHashAlgorithm:
 		v, ok := value.(hashesentry.HashAlgorithm)
 		if !ok {
@@ -4344,11 +5153,7 @@ func (m *HashesEntryMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *HashesEntryMutation) ClearedFields() []string {
-	var fields []string
-	if m.FieldCleared(hashesentry.FieldDocumentID) {
-		fields = append(fields, hashesentry.FieldDocumentID)
-	}
-	return fields
+	return nil
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -4361,11 +5166,6 @@ func (m *HashesEntryMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *HashesEntryMutation) ClearField(name string) error {
-	switch name {
-	case hashesentry.FieldDocumentID:
-		m.ClearDocumentID()
-		return nil
-	}
 	return fmt.Errorf("unknown HashesEntry nullable field %s", name)
 }
 
@@ -4373,9 +5173,6 @@ func (m *HashesEntryMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *HashesEntryMutation) ResetField(name string) error {
 	switch name {
-	case hashesentry.FieldDocumentID:
-		m.ResetDocumentID()
-		return nil
 	case hashesentry.FieldHashAlgorithm:
 		m.ResetHashAlgorithm()
 		return nil
@@ -4388,15 +5185,18 @@ func (m *HashesEntryMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *HashesEntryMutation) AddedEdges() []string {
-	edges := make([]string, 0, 3)
-	if m.document != nil {
-		edges = append(edges, hashesentry.EdgeDocument)
+	edges := make([]string, 0, 4)
+	if m.documents != nil {
+		edges = append(edges, hashesentry.EdgeDocuments)
 	}
 	if m.external_references != nil {
 		edges = append(edges, hashesentry.EdgeExternalReferences)
 	}
 	if m.nodes != nil {
 		edges = append(edges, hashesentry.EdgeNodes)
+	}
+	if m.source_data != nil {
+		edges = append(edges, hashesentry.EdgeSourceData)
 	}
 	return edges
 }
@@ -4405,10 +5205,12 @@ func (m *HashesEntryMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *HashesEntryMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case hashesentry.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
+	case hashesentry.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.documents))
+		for id := range m.documents {
+			ids = append(ids, id)
 		}
+		return ids
 	case hashesentry.EdgeExternalReferences:
 		ids := make([]ent.Value, 0, len(m.external_references))
 		for id := range m.external_references {
@@ -4421,18 +5223,30 @@ func (m *HashesEntryMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case hashesentry.EdgeSourceData:
+		ids := make([]ent.Value, 0, len(m.source_data))
+		for id := range m.source_data {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *HashesEntryMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 4)
+	if m.removeddocuments != nil {
+		edges = append(edges, hashesentry.EdgeDocuments)
+	}
 	if m.removedexternal_references != nil {
 		edges = append(edges, hashesentry.EdgeExternalReferences)
 	}
 	if m.removednodes != nil {
 		edges = append(edges, hashesentry.EdgeNodes)
+	}
+	if m.removedsource_data != nil {
+		edges = append(edges, hashesentry.EdgeSourceData)
 	}
 	return edges
 }
@@ -4441,6 +5255,12 @@ func (m *HashesEntryMutation) RemovedEdges() []string {
 // the given name in this mutation.
 func (m *HashesEntryMutation) RemovedIDs(name string) []ent.Value {
 	switch name {
+	case hashesentry.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.removeddocuments))
+		for id := range m.removeddocuments {
+			ids = append(ids, id)
+		}
+		return ids
 	case hashesentry.EdgeExternalReferences:
 		ids := make([]ent.Value, 0, len(m.removedexternal_references))
 		for id := range m.removedexternal_references {
@@ -4453,21 +5273,30 @@ func (m *HashesEntryMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case hashesentry.EdgeSourceData:
+		ids := make([]ent.Value, 0, len(m.removedsource_data))
+		for id := range m.removedsource_data {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *HashesEntryMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 3)
-	if m.cleareddocument {
-		edges = append(edges, hashesentry.EdgeDocument)
+	edges := make([]string, 0, 4)
+	if m.cleareddocuments {
+		edges = append(edges, hashesentry.EdgeDocuments)
 	}
 	if m.clearedexternal_references {
 		edges = append(edges, hashesentry.EdgeExternalReferences)
 	}
 	if m.clearednodes {
 		edges = append(edges, hashesentry.EdgeNodes)
+	}
+	if m.clearedsource_data {
+		edges = append(edges, hashesentry.EdgeSourceData)
 	}
 	return edges
 }
@@ -4476,12 +5305,14 @@ func (m *HashesEntryMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *HashesEntryMutation) EdgeCleared(name string) bool {
 	switch name {
-	case hashesentry.EdgeDocument:
-		return m.cleareddocument
+	case hashesentry.EdgeDocuments:
+		return m.cleareddocuments
 	case hashesentry.EdgeExternalReferences:
 		return m.clearedexternal_references
 	case hashesentry.EdgeNodes:
 		return m.clearednodes
+	case hashesentry.EdgeSourceData:
+		return m.clearedsource_data
 	}
 	return false
 }
@@ -4490,9 +5321,6 @@ func (m *HashesEntryMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *HashesEntryMutation) ClearEdge(name string) error {
 	switch name {
-	case hashesentry.EdgeDocument:
-		m.ClearDocument()
-		return nil
 	}
 	return fmt.Errorf("unknown HashesEntry unique edge %s", name)
 }
@@ -4501,14 +5329,17 @@ func (m *HashesEntryMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *HashesEntryMutation) ResetEdge(name string) error {
 	switch name {
-	case hashesentry.EdgeDocument:
-		m.ResetDocument()
+	case hashesentry.EdgeDocuments:
+		m.ResetDocuments()
 		return nil
 	case hashesentry.EdgeExternalReferences:
 		m.ResetExternalReferences()
 		return nil
 	case hashesentry.EdgeNodes:
 		m.ResetNodes()
+		return nil
+	case hashesentry.EdgeSourceData:
+		m.ResetSourceData()
 		return nil
 	}
 	return fmt.Errorf("unknown HashesEntry edge %s", name)
@@ -4517,20 +5348,21 @@ func (m *HashesEntryMutation) ResetEdge(name string) error {
 // IdentifiersEntryMutation represents an operation that mutates the IdentifiersEntry nodes in the graph.
 type IdentifiersEntryMutation struct {
 	config
-	op              Op
-	typ             string
-	id              *uuid.UUID
-	_type           *identifiersentry.Type
-	value           *string
-	clearedFields   map[string]struct{}
-	document        *uuid.UUID
-	cleareddocument bool
-	nodes           map[uuid.UUID]struct{}
-	removednodes    map[uuid.UUID]struct{}
-	clearednodes    bool
-	done            bool
-	oldValue        func(context.Context) (*IdentifiersEntry, error)
-	predicates      []predicate.IdentifiersEntry
+	op               Op
+	typ              string
+	id               *uuid.UUID
+	_type            *identifiersentry.Type
+	value            *string
+	clearedFields    map[string]struct{}
+	documents        map[uuid.UUID]struct{}
+	removeddocuments map[uuid.UUID]struct{}
+	cleareddocuments bool
+	nodes            map[uuid.UUID]struct{}
+	removednodes     map[uuid.UUID]struct{}
+	clearednodes     bool
+	done             bool
+	oldValue         func(context.Context) (*IdentifiersEntry, error)
+	predicates       []predicate.IdentifiersEntry
 }
 
 var _ ent.Mutation = (*IdentifiersEntryMutation)(nil)
@@ -4637,55 +5469,6 @@ func (m *IdentifiersEntryMutation) IDs(ctx context.Context) ([]uuid.UUID, error)
 	}
 }
 
-// SetDocumentID sets the "document_id" field.
-func (m *IdentifiersEntryMutation) SetDocumentID(u uuid.UUID) {
-	m.document = &u
-}
-
-// DocumentID returns the value of the "document_id" field in the mutation.
-func (m *IdentifiersEntryMutation) DocumentID() (r uuid.UUID, exists bool) {
-	v := m.document
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDocumentID returns the old "document_id" field's value of the IdentifiersEntry entity.
-// If the IdentifiersEntry object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *IdentifiersEntryMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDocumentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
-	}
-	return oldValue.DocumentID, nil
-}
-
-// ClearDocumentID clears the value of the "document_id" field.
-func (m *IdentifiersEntryMutation) ClearDocumentID() {
-	m.document = nil
-	m.clearedFields[identifiersentry.FieldDocumentID] = struct{}{}
-}
-
-// DocumentIDCleared returns if the "document_id" field was cleared in this mutation.
-func (m *IdentifiersEntryMutation) DocumentIDCleared() bool {
-	_, ok := m.clearedFields[identifiersentry.FieldDocumentID]
-	return ok
-}
-
-// ResetDocumentID resets all changes to the "document_id" field.
-func (m *IdentifiersEntryMutation) ResetDocumentID() {
-	m.document = nil
-	delete(m.clearedFields, identifiersentry.FieldDocumentID)
-}
-
 // SetType sets the "type" field.
 func (m *IdentifiersEntryMutation) SetType(i identifiersentry.Type) {
 	m._type = &i
@@ -4758,31 +5541,58 @@ func (m *IdentifiersEntryMutation) ResetValue() {
 	m.value = nil
 }
 
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *IdentifiersEntryMutation) ClearDocument() {
-	m.cleareddocument = true
-	m.clearedFields[identifiersentry.FieldDocumentID] = struct{}{}
+// AddDocumentIDs adds the "documents" edge to the Document entity by ids.
+func (m *IdentifiersEntryMutation) AddDocumentIDs(ids ...uuid.UUID) {
+	if m.documents == nil {
+		m.documents = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.documents[ids[i]] = struct{}{}
+	}
 }
 
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *IdentifiersEntryMutation) DocumentCleared() bool {
-	return m.DocumentIDCleared() || m.cleareddocument
+// ClearDocuments clears the "documents" edge to the Document entity.
+func (m *IdentifiersEntryMutation) ClearDocuments() {
+	m.cleareddocuments = true
 }
 
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *IdentifiersEntryMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
+// DocumentsCleared reports if the "documents" edge to the Document entity was cleared.
+func (m *IdentifiersEntryMutation) DocumentsCleared() bool {
+	return m.cleareddocuments
+}
+
+// RemoveDocumentIDs removes the "documents" edge to the Document entity by IDs.
+func (m *IdentifiersEntryMutation) RemoveDocumentIDs(ids ...uuid.UUID) {
+	if m.removeddocuments == nil {
+		m.removeddocuments = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.documents, ids[i])
+		m.removeddocuments[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocuments returns the removed IDs of the "documents" edge to the Document entity.
+func (m *IdentifiersEntryMutation) RemovedDocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocuments {
+		ids = append(ids, id)
 	}
 	return
 }
 
-// ResetDocument resets all changes to the "document" edge.
-func (m *IdentifiersEntryMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
+// DocumentsIDs returns the "documents" edge IDs in the mutation.
+func (m *IdentifiersEntryMutation) DocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.documents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetDocuments resets all changes to the "documents" edge.
+func (m *IdentifiersEntryMutation) ResetDocuments() {
+	m.documents = nil
+	m.cleareddocuments = false
+	m.removeddocuments = nil
 }
 
 // AddNodeIDs adds the "nodes" edge to the Node entity by ids.
@@ -4873,10 +5683,7 @@ func (m *IdentifiersEntryMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *IdentifiersEntryMutation) Fields() []string {
-	fields := make([]string, 0, 3)
-	if m.document != nil {
-		fields = append(fields, identifiersentry.FieldDocumentID)
-	}
+	fields := make([]string, 0, 2)
 	if m._type != nil {
 		fields = append(fields, identifiersentry.FieldType)
 	}
@@ -4891,8 +5698,6 @@ func (m *IdentifiersEntryMutation) Fields() []string {
 // schema.
 func (m *IdentifiersEntryMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case identifiersentry.FieldDocumentID:
-		return m.DocumentID()
 	case identifiersentry.FieldType:
 		return m.GetType()
 	case identifiersentry.FieldValue:
@@ -4906,8 +5711,6 @@ func (m *IdentifiersEntryMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *IdentifiersEntryMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case identifiersentry.FieldDocumentID:
-		return m.OldDocumentID(ctx)
 	case identifiersentry.FieldType:
 		return m.OldType(ctx)
 	case identifiersentry.FieldValue:
@@ -4921,13 +5724,6 @@ func (m *IdentifiersEntryMutation) OldField(ctx context.Context, name string) (e
 // type.
 func (m *IdentifiersEntryMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case identifiersentry.FieldDocumentID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDocumentID(v)
-		return nil
 	case identifiersentry.FieldType:
 		v, ok := value.(identifiersentry.Type)
 		if !ok {
@@ -4971,11 +5767,7 @@ func (m *IdentifiersEntryMutation) AddField(name string, value ent.Value) error 
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *IdentifiersEntryMutation) ClearedFields() []string {
-	var fields []string
-	if m.FieldCleared(identifiersentry.FieldDocumentID) {
-		fields = append(fields, identifiersentry.FieldDocumentID)
-	}
-	return fields
+	return nil
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -4988,11 +5780,6 @@ func (m *IdentifiersEntryMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *IdentifiersEntryMutation) ClearField(name string) error {
-	switch name {
-	case identifiersentry.FieldDocumentID:
-		m.ClearDocumentID()
-		return nil
-	}
 	return fmt.Errorf("unknown IdentifiersEntry nullable field %s", name)
 }
 
@@ -5000,9 +5787,6 @@ func (m *IdentifiersEntryMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *IdentifiersEntryMutation) ResetField(name string) error {
 	switch name {
-	case identifiersentry.FieldDocumentID:
-		m.ResetDocumentID()
-		return nil
 	case identifiersentry.FieldType:
 		m.ResetType()
 		return nil
@@ -5016,8 +5800,8 @@ func (m *IdentifiersEntryMutation) ResetField(name string) error {
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *IdentifiersEntryMutation) AddedEdges() []string {
 	edges := make([]string, 0, 2)
-	if m.document != nil {
-		edges = append(edges, identifiersentry.EdgeDocument)
+	if m.documents != nil {
+		edges = append(edges, identifiersentry.EdgeDocuments)
 	}
 	if m.nodes != nil {
 		edges = append(edges, identifiersentry.EdgeNodes)
@@ -5029,10 +5813,12 @@ func (m *IdentifiersEntryMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *IdentifiersEntryMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case identifiersentry.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
+	case identifiersentry.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.documents))
+		for id := range m.documents {
+			ids = append(ids, id)
 		}
+		return ids
 	case identifiersentry.EdgeNodes:
 		ids := make([]ent.Value, 0, len(m.nodes))
 		for id := range m.nodes {
@@ -5046,6 +5832,9 @@ func (m *IdentifiersEntryMutation) AddedIDs(name string) []ent.Value {
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *IdentifiersEntryMutation) RemovedEdges() []string {
 	edges := make([]string, 0, 2)
+	if m.removeddocuments != nil {
+		edges = append(edges, identifiersentry.EdgeDocuments)
+	}
 	if m.removednodes != nil {
 		edges = append(edges, identifiersentry.EdgeNodes)
 	}
@@ -5056,6 +5845,12 @@ func (m *IdentifiersEntryMutation) RemovedEdges() []string {
 // the given name in this mutation.
 func (m *IdentifiersEntryMutation) RemovedIDs(name string) []ent.Value {
 	switch name {
+	case identifiersentry.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.removeddocuments))
+		for id := range m.removeddocuments {
+			ids = append(ids, id)
+		}
+		return ids
 	case identifiersentry.EdgeNodes:
 		ids := make([]ent.Value, 0, len(m.removednodes))
 		for id := range m.removednodes {
@@ -5069,8 +5864,8 @@ func (m *IdentifiersEntryMutation) RemovedIDs(name string) []ent.Value {
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *IdentifiersEntryMutation) ClearedEdges() []string {
 	edges := make([]string, 0, 2)
-	if m.cleareddocument {
-		edges = append(edges, identifiersentry.EdgeDocument)
+	if m.cleareddocuments {
+		edges = append(edges, identifiersentry.EdgeDocuments)
 	}
 	if m.clearednodes {
 		edges = append(edges, identifiersentry.EdgeNodes)
@@ -5082,8 +5877,8 @@ func (m *IdentifiersEntryMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *IdentifiersEntryMutation) EdgeCleared(name string) bool {
 	switch name {
-	case identifiersentry.EdgeDocument:
-		return m.cleareddocument
+	case identifiersentry.EdgeDocuments:
+		return m.cleareddocuments
 	case identifiersentry.EdgeNodes:
 		return m.clearednodes
 	}
@@ -5094,9 +5889,6 @@ func (m *IdentifiersEntryMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *IdentifiersEntryMutation) ClearEdge(name string) error {
 	switch name {
-	case identifiersentry.EdgeDocument:
-		m.ClearDocument()
-		return nil
 	}
 	return fmt.Errorf("unknown IdentifiersEntry unique edge %s", name)
 }
@@ -5105,8 +5897,8 @@ func (m *IdentifiersEntryMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *IdentifiersEntryMutation) ResetEdge(name string) error {
 	switch name {
-	case identifiersentry.EdgeDocument:
-		m.ResetDocument()
+	case identifiersentry.EdgeDocuments:
+		m.ResetDocuments()
 		return nil
 	case identifiersentry.EdgeNodes:
 		m.ResetNodes()
@@ -5128,8 +5920,6 @@ type MetadataMutation struct {
 	date                  *time.Time
 	comment               *string
 	clearedFields         map[string]struct{}
-	document              *uuid.UUID
-	cleareddocument       bool
 	tools                 map[uuid.UUID]struct{}
 	removedtools          map[uuid.UUID]struct{}
 	clearedtools          bool
@@ -5139,9 +5929,11 @@ type MetadataMutation struct {
 	document_types        map[uuid.UUID]struct{}
 	removeddocument_types map[uuid.UUID]struct{}
 	cleareddocument_types bool
-	source_data           map[uuid.UUID]struct{}
-	removedsource_data    map[uuid.UUID]struct{}
+	source_data           *uuid.UUID
 	clearedsource_data    bool
+	documents             map[uuid.UUID]struct{}
+	removeddocuments      map[uuid.UUID]struct{}
+	cleareddocuments      bool
 	done                  bool
 	oldValue              func(context.Context) (*Metadata, error)
 	predicates            []predicate.Metadata
@@ -5285,6 +6077,55 @@ func (m *MetadataMutation) OldProtoMessage(ctx context.Context) (v *sbom.Metadat
 // ResetProtoMessage resets all changes to the "proto_message" field.
 func (m *MetadataMutation) ResetProtoMessage() {
 	m.proto_message = nil
+}
+
+// SetSourceDataID sets the "source_data_id" field.
+func (m *MetadataMutation) SetSourceDataID(u uuid.UUID) {
+	m.source_data = &u
+}
+
+// SourceDataID returns the value of the "source_data_id" field in the mutation.
+func (m *MetadataMutation) SourceDataID() (r uuid.UUID, exists bool) {
+	v := m.source_data
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSourceDataID returns the old "source_data_id" field's value of the Metadata entity.
+// If the Metadata object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *MetadataMutation) OldSourceDataID(ctx context.Context) (v uuid.UUID, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSourceDataID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSourceDataID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSourceDataID: %w", err)
+	}
+	return oldValue.SourceDataID, nil
+}
+
+// ClearSourceDataID clears the value of the "source_data_id" field.
+func (m *MetadataMutation) ClearSourceDataID() {
+	m.source_data = nil
+	m.clearedFields[metadata.FieldSourceDataID] = struct{}{}
+}
+
+// SourceDataIDCleared returns if the "source_data_id" field was cleared in this mutation.
+func (m *MetadataMutation) SourceDataIDCleared() bool {
+	_, ok := m.clearedFields[metadata.FieldSourceDataID]
+	return ok
+}
+
+// ResetSourceDataID resets all changes to the "source_data_id" field.
+func (m *MetadataMutation) ResetSourceDataID() {
+	m.source_data = nil
+	delete(m.clearedFields, metadata.FieldSourceDataID)
 }
 
 // SetNativeID sets the "native_id" field.
@@ -5467,45 +6308,6 @@ func (m *MetadataMutation) ResetComment() {
 	m.comment = nil
 }
 
-// SetDocumentID sets the "document" edge to the Document entity by id.
-func (m *MetadataMutation) SetDocumentID(id uuid.UUID) {
-	m.document = &id
-}
-
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *MetadataMutation) ClearDocument() {
-	m.cleareddocument = true
-}
-
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *MetadataMutation) DocumentCleared() bool {
-	return m.cleareddocument
-}
-
-// DocumentID returns the "document" edge ID in the mutation.
-func (m *MetadataMutation) DocumentID() (id uuid.UUID, exists bool) {
-	if m.document != nil {
-		return *m.document, true
-	}
-	return
-}
-
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *MetadataMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
-	}
-	return
-}
-
-// ResetDocument resets all changes to the "document" edge.
-func (m *MetadataMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
-}
-
 // AddToolIDs adds the "tools" edge to the Tool entity by ids.
 func (m *MetadataMutation) AddToolIDs(ids ...uuid.UUID) {
 	if m.tools == nil {
@@ -5668,49 +6470,23 @@ func (m *MetadataMutation) ResetDocumentTypes() {
 	m.removeddocument_types = nil
 }
 
-// AddSourceDatumIDs adds the "source_data" edge to the SourceData entity by ids.
-func (m *MetadataMutation) AddSourceDatumIDs(ids ...uuid.UUID) {
-	if m.source_data == nil {
-		m.source_data = make(map[uuid.UUID]struct{})
-	}
-	for i := range ids {
-		m.source_data[ids[i]] = struct{}{}
-	}
-}
-
 // ClearSourceData clears the "source_data" edge to the SourceData entity.
 func (m *MetadataMutation) ClearSourceData() {
 	m.clearedsource_data = true
+	m.clearedFields[metadata.FieldSourceDataID] = struct{}{}
 }
 
 // SourceDataCleared reports if the "source_data" edge to the SourceData entity was cleared.
 func (m *MetadataMutation) SourceDataCleared() bool {
-	return m.clearedsource_data
-}
-
-// RemoveSourceDatumIDs removes the "source_data" edge to the SourceData entity by IDs.
-func (m *MetadataMutation) RemoveSourceDatumIDs(ids ...uuid.UUID) {
-	if m.removedsource_data == nil {
-		m.removedsource_data = make(map[uuid.UUID]struct{})
-	}
-	for i := range ids {
-		delete(m.source_data, ids[i])
-		m.removedsource_data[ids[i]] = struct{}{}
-	}
-}
-
-// RemovedSourceData returns the removed IDs of the "source_data" edge to the SourceData entity.
-func (m *MetadataMutation) RemovedSourceDataIDs() (ids []uuid.UUID) {
-	for id := range m.removedsource_data {
-		ids = append(ids, id)
-	}
-	return
+	return m.SourceDataIDCleared() || m.clearedsource_data
 }
 
 // SourceDataIDs returns the "source_data" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// SourceDataID instead. It exists only for internal usage by the builders.
 func (m *MetadataMutation) SourceDataIDs() (ids []uuid.UUID) {
-	for id := range m.source_data {
-		ids = append(ids, id)
+	if id := m.source_data; id != nil {
+		ids = append(ids, *id)
 	}
 	return
 }
@@ -5719,7 +6495,60 @@ func (m *MetadataMutation) SourceDataIDs() (ids []uuid.UUID) {
 func (m *MetadataMutation) ResetSourceData() {
 	m.source_data = nil
 	m.clearedsource_data = false
-	m.removedsource_data = nil
+}
+
+// AddDocumentIDs adds the "documents" edge to the Document entity by ids.
+func (m *MetadataMutation) AddDocumentIDs(ids ...uuid.UUID) {
+	if m.documents == nil {
+		m.documents = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.documents[ids[i]] = struct{}{}
+	}
+}
+
+// ClearDocuments clears the "documents" edge to the Document entity.
+func (m *MetadataMutation) ClearDocuments() {
+	m.cleareddocuments = true
+}
+
+// DocumentsCleared reports if the "documents" edge to the Document entity was cleared.
+func (m *MetadataMutation) DocumentsCleared() bool {
+	return m.cleareddocuments
+}
+
+// RemoveDocumentIDs removes the "documents" edge to the Document entity by IDs.
+func (m *MetadataMutation) RemoveDocumentIDs(ids ...uuid.UUID) {
+	if m.removeddocuments == nil {
+		m.removeddocuments = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.documents, ids[i])
+		m.removeddocuments[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocuments returns the removed IDs of the "documents" edge to the Document entity.
+func (m *MetadataMutation) RemovedDocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocuments {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// DocumentsIDs returns the "documents" edge IDs in the mutation.
+func (m *MetadataMutation) DocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.documents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetDocuments resets all changes to the "documents" edge.
+func (m *MetadataMutation) ResetDocuments() {
+	m.documents = nil
+	m.cleareddocuments = false
+	m.removeddocuments = nil
 }
 
 // Where appends a list predicates to the MetadataMutation builder.
@@ -5756,9 +6585,12 @@ func (m *MetadataMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *MetadataMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.proto_message != nil {
 		fields = append(fields, metadata.FieldProtoMessage)
+	}
+	if m.source_data != nil {
+		fields = append(fields, metadata.FieldSourceDataID)
 	}
 	if m.native_id != nil {
 		fields = append(fields, metadata.FieldNativeID)
@@ -5785,6 +6617,8 @@ func (m *MetadataMutation) Field(name string) (ent.Value, bool) {
 	switch name {
 	case metadata.FieldProtoMessage:
 		return m.ProtoMessage()
+	case metadata.FieldSourceDataID:
+		return m.SourceDataID()
 	case metadata.FieldNativeID:
 		return m.NativeID()
 	case metadata.FieldVersion:
@@ -5806,6 +6640,8 @@ func (m *MetadataMutation) OldField(ctx context.Context, name string) (ent.Value
 	switch name {
 	case metadata.FieldProtoMessage:
 		return m.OldProtoMessage(ctx)
+	case metadata.FieldSourceDataID:
+		return m.OldSourceDataID(ctx)
 	case metadata.FieldNativeID:
 		return m.OldNativeID(ctx)
 	case metadata.FieldVersion:
@@ -5831,6 +6667,13 @@ func (m *MetadataMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetProtoMessage(v)
+		return nil
+	case metadata.FieldSourceDataID:
+		v, ok := value.(uuid.UUID)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSourceDataID(v)
 		return nil
 	case metadata.FieldNativeID:
 		v, ok := value.(string)
@@ -5896,7 +6739,11 @@ func (m *MetadataMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *MetadataMutation) ClearedFields() []string {
-	return nil
+	var fields []string
+	if m.FieldCleared(metadata.FieldSourceDataID) {
+		fields = append(fields, metadata.FieldSourceDataID)
+	}
+	return fields
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -5909,6 +6756,11 @@ func (m *MetadataMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *MetadataMutation) ClearField(name string) error {
+	switch name {
+	case metadata.FieldSourceDataID:
+		m.ClearSourceDataID()
+		return nil
+	}
 	return fmt.Errorf("unknown Metadata nullable field %s", name)
 }
 
@@ -5918,6 +6770,9 @@ func (m *MetadataMutation) ResetField(name string) error {
 	switch name {
 	case metadata.FieldProtoMessage:
 		m.ResetProtoMessage()
+		return nil
+	case metadata.FieldSourceDataID:
+		m.ResetSourceDataID()
 		return nil
 	case metadata.FieldNativeID:
 		m.ResetNativeID()
@@ -5941,9 +6796,6 @@ func (m *MetadataMutation) ResetField(name string) error {
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *MetadataMutation) AddedEdges() []string {
 	edges := make([]string, 0, 5)
-	if m.document != nil {
-		edges = append(edges, metadata.EdgeDocument)
-	}
 	if m.tools != nil {
 		edges = append(edges, metadata.EdgeTools)
 	}
@@ -5956,6 +6808,9 @@ func (m *MetadataMutation) AddedEdges() []string {
 	if m.source_data != nil {
 		edges = append(edges, metadata.EdgeSourceData)
 	}
+	if m.documents != nil {
+		edges = append(edges, metadata.EdgeDocuments)
+	}
 	return edges
 }
 
@@ -5963,10 +6818,6 @@ func (m *MetadataMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *MetadataMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case metadata.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
-		}
 	case metadata.EdgeTools:
 		ids := make([]ent.Value, 0, len(m.tools))
 		for id := range m.tools {
@@ -5986,8 +6837,12 @@ func (m *MetadataMutation) AddedIDs(name string) []ent.Value {
 		}
 		return ids
 	case metadata.EdgeSourceData:
-		ids := make([]ent.Value, 0, len(m.source_data))
-		for id := range m.source_data {
+		if id := m.source_data; id != nil {
+			return []ent.Value{*id}
+		}
+	case metadata.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.documents))
+		for id := range m.documents {
 			ids = append(ids, id)
 		}
 		return ids
@@ -6007,8 +6862,8 @@ func (m *MetadataMutation) RemovedEdges() []string {
 	if m.removeddocument_types != nil {
 		edges = append(edges, metadata.EdgeDocumentTypes)
 	}
-	if m.removedsource_data != nil {
-		edges = append(edges, metadata.EdgeSourceData)
+	if m.removeddocuments != nil {
+		edges = append(edges, metadata.EdgeDocuments)
 	}
 	return edges
 }
@@ -6035,9 +6890,9 @@ func (m *MetadataMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
-	case metadata.EdgeSourceData:
-		ids := make([]ent.Value, 0, len(m.removedsource_data))
-		for id := range m.removedsource_data {
+	case metadata.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.removeddocuments))
+		for id := range m.removeddocuments {
 			ids = append(ids, id)
 		}
 		return ids
@@ -6048,9 +6903,6 @@ func (m *MetadataMutation) RemovedIDs(name string) []ent.Value {
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *MetadataMutation) ClearedEdges() []string {
 	edges := make([]string, 0, 5)
-	if m.cleareddocument {
-		edges = append(edges, metadata.EdgeDocument)
-	}
 	if m.clearedtools {
 		edges = append(edges, metadata.EdgeTools)
 	}
@@ -6063,6 +6915,9 @@ func (m *MetadataMutation) ClearedEdges() []string {
 	if m.clearedsource_data {
 		edges = append(edges, metadata.EdgeSourceData)
 	}
+	if m.cleareddocuments {
+		edges = append(edges, metadata.EdgeDocuments)
+	}
 	return edges
 }
 
@@ -6070,8 +6925,6 @@ func (m *MetadataMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *MetadataMutation) EdgeCleared(name string) bool {
 	switch name {
-	case metadata.EdgeDocument:
-		return m.cleareddocument
 	case metadata.EdgeTools:
 		return m.clearedtools
 	case metadata.EdgeAuthors:
@@ -6080,6 +6933,8 @@ func (m *MetadataMutation) EdgeCleared(name string) bool {
 		return m.cleareddocument_types
 	case metadata.EdgeSourceData:
 		return m.clearedsource_data
+	case metadata.EdgeDocuments:
+		return m.cleareddocuments
 	}
 	return false
 }
@@ -6088,8 +6943,8 @@ func (m *MetadataMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *MetadataMutation) ClearEdge(name string) error {
 	switch name {
-	case metadata.EdgeDocument:
-		m.ClearDocument()
+	case metadata.EdgeSourceData:
+		m.ClearSourceData()
 		return nil
 	}
 	return fmt.Errorf("unknown Metadata unique edge %s", name)
@@ -6099,9 +6954,6 @@ func (m *MetadataMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *MetadataMutation) ResetEdge(name string) error {
 	switch name {
-	case metadata.EdgeDocument:
-		m.ResetDocument()
-		return nil
 	case metadata.EdgeTools:
 		m.ResetTools()
 		return nil
@@ -6113,6 +6965,9 @@ func (m *MetadataMutation) ResetEdge(name string) error {
 		return nil
 	case metadata.EdgeSourceData:
 		m.ResetSourceData()
+		return nil
+	case metadata.EdgeDocuments:
+		m.ResetDocuments()
 		return nil
 	}
 	return fmt.Errorf("unknown Metadata edge %s", name)
@@ -6126,7 +6981,6 @@ type NodeMutation struct {
 	id                         *uuid.UUID
 	proto_message              **sbom.Node
 	native_id                  *string
-	node_list_id               *uuid.UUID
 	_type                      *node.Type
 	name                       *string
 	version                    *string
@@ -6150,8 +7004,6 @@ type NodeMutation struct {
 	file_types                 *[]string
 	appendfile_types           []string
 	clearedFields              map[string]struct{}
-	document                   *uuid.UUID
-	cleareddocument            bool
 	annotations                map[int]struct{}
 	removedannotations         map[int]struct{}
 	clearedannotations         bool
@@ -6182,6 +7034,9 @@ type NodeMutation struct {
 	properties                 map[uuid.UUID]struct{}
 	removedproperties          map[uuid.UUID]struct{}
 	clearedproperties          bool
+	documents                  map[uuid.UUID]struct{}
+	removeddocuments           map[uuid.UUID]struct{}
+	cleareddocuments           bool
 	node_lists                 map[uuid.UUID]struct{}
 	removednode_lists          map[uuid.UUID]struct{}
 	clearednode_lists          bool
@@ -6297,55 +7152,6 @@ func (m *NodeMutation) IDs(ctx context.Context) ([]uuid.UUID, error) {
 	}
 }
 
-// SetDocumentID sets the "document_id" field.
-func (m *NodeMutation) SetDocumentID(u uuid.UUID) {
-	m.document = &u
-}
-
-// DocumentID returns the value of the "document_id" field in the mutation.
-func (m *NodeMutation) DocumentID() (r uuid.UUID, exists bool) {
-	v := m.document
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDocumentID returns the old "document_id" field's value of the Node entity.
-// If the Node object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *NodeMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDocumentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
-	}
-	return oldValue.DocumentID, nil
-}
-
-// ClearDocumentID clears the value of the "document_id" field.
-func (m *NodeMutation) ClearDocumentID() {
-	m.document = nil
-	m.clearedFields[node.FieldDocumentID] = struct{}{}
-}
-
-// DocumentIDCleared returns if the "document_id" field was cleared in this mutation.
-func (m *NodeMutation) DocumentIDCleared() bool {
-	_, ok := m.clearedFields[node.FieldDocumentID]
-	return ok
-}
-
-// ResetDocumentID resets all changes to the "document_id" field.
-func (m *NodeMutation) ResetDocumentID() {
-	m.document = nil
-	delete(m.clearedFields, node.FieldDocumentID)
-}
-
 // SetProtoMessage sets the "proto_message" field.
 func (m *NodeMutation) SetProtoMessage(s *sbom.Node) {
 	m.proto_message = &s
@@ -6416,55 +7222,6 @@ func (m *NodeMutation) OldNativeID(ctx context.Context) (v string, err error) {
 // ResetNativeID resets all changes to the "native_id" field.
 func (m *NodeMutation) ResetNativeID() {
 	m.native_id = nil
-}
-
-// SetNodeListID sets the "node_list_id" field.
-func (m *NodeMutation) SetNodeListID(u uuid.UUID) {
-	m.node_list_id = &u
-}
-
-// NodeListID returns the value of the "node_list_id" field in the mutation.
-func (m *NodeMutation) NodeListID() (r uuid.UUID, exists bool) {
-	v := m.node_list_id
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldNodeListID returns the old "node_list_id" field's value of the Node entity.
-// If the Node object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *NodeMutation) OldNodeListID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldNodeListID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldNodeListID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldNodeListID: %w", err)
-	}
-	return oldValue.NodeListID, nil
-}
-
-// ClearNodeListID clears the value of the "node_list_id" field.
-func (m *NodeMutation) ClearNodeListID() {
-	m.node_list_id = nil
-	m.clearedFields[node.FieldNodeListID] = struct{}{}
-}
-
-// NodeListIDCleared returns if the "node_list_id" field was cleared in this mutation.
-func (m *NodeMutation) NodeListIDCleared() bool {
-	_, ok := m.clearedFields[node.FieldNodeListID]
-	return ok
-}
-
-// ResetNodeListID resets all changes to the "node_list_id" field.
-func (m *NodeMutation) ResetNodeListID() {
-	m.node_list_id = nil
-	delete(m.clearedFields, node.FieldNodeListID)
 }
 
 // SetType sets the "type" field.
@@ -7196,33 +7953,6 @@ func (m *NodeMutation) ResetFileTypes() {
 	m.appendfile_types = nil
 }
 
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *NodeMutation) ClearDocument() {
-	m.cleareddocument = true
-	m.clearedFields[node.FieldDocumentID] = struct{}{}
-}
-
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *NodeMutation) DocumentCleared() bool {
-	return m.DocumentIDCleared() || m.cleareddocument
-}
-
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *NodeMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
-	}
-	return
-}
-
-// ResetDocument resets all changes to the "document" edge.
-func (m *NodeMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
-}
-
 // AddAnnotationIDs adds the "annotations" edge to the Annotation entity by ids.
 func (m *NodeMutation) AddAnnotationIDs(ids ...int) {
 	if m.annotations == nil {
@@ -7763,6 +8493,60 @@ func (m *NodeMutation) ResetProperties() {
 	m.removedproperties = nil
 }
 
+// AddDocumentIDs adds the "documents" edge to the Document entity by ids.
+func (m *NodeMutation) AddDocumentIDs(ids ...uuid.UUID) {
+	if m.documents == nil {
+		m.documents = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.documents[ids[i]] = struct{}{}
+	}
+}
+
+// ClearDocuments clears the "documents" edge to the Document entity.
+func (m *NodeMutation) ClearDocuments() {
+	m.cleareddocuments = true
+}
+
+// DocumentsCleared reports if the "documents" edge to the Document entity was cleared.
+func (m *NodeMutation) DocumentsCleared() bool {
+	return m.cleareddocuments
+}
+
+// RemoveDocumentIDs removes the "documents" edge to the Document entity by IDs.
+func (m *NodeMutation) RemoveDocumentIDs(ids ...uuid.UUID) {
+	if m.removeddocuments == nil {
+		m.removeddocuments = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.documents, ids[i])
+		m.removeddocuments[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocuments returns the removed IDs of the "documents" edge to the Document entity.
+func (m *NodeMutation) RemovedDocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocuments {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// DocumentsIDs returns the "documents" edge IDs in the mutation.
+func (m *NodeMutation) DocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.documents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetDocuments resets all changes to the "documents" edge.
+func (m *NodeMutation) ResetDocuments() {
+	m.documents = nil
+	m.cleareddocuments = false
+	m.removeddocuments = nil
+}
+
 // AddNodeListIDs adds the "node_lists" edge to the NodeList entity by ids.
 func (m *NodeMutation) AddNodeListIDs(ids ...uuid.UUID) {
 	if m.node_lists == nil {
@@ -7905,18 +8689,12 @@ func (m *NodeMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *NodeMutation) Fields() []string {
-	fields := make([]string, 0, 23)
-	if m.document != nil {
-		fields = append(fields, node.FieldDocumentID)
-	}
+	fields := make([]string, 0, 21)
 	if m.proto_message != nil {
 		fields = append(fields, node.FieldProtoMessage)
 	}
 	if m.native_id != nil {
 		fields = append(fields, node.FieldNativeID)
-	}
-	if m.node_list_id != nil {
-		fields = append(fields, node.FieldNodeListID)
 	}
 	if m._type != nil {
 		fields = append(fields, node.FieldType)
@@ -7983,14 +8761,10 @@ func (m *NodeMutation) Fields() []string {
 // schema.
 func (m *NodeMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case node.FieldDocumentID:
-		return m.DocumentID()
 	case node.FieldProtoMessage:
 		return m.ProtoMessage()
 	case node.FieldNativeID:
 		return m.NativeID()
-	case node.FieldNodeListID:
-		return m.NodeListID()
 	case node.FieldType:
 		return m.GetType()
 	case node.FieldName:
@@ -8038,14 +8812,10 @@ func (m *NodeMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *NodeMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case node.FieldDocumentID:
-		return m.OldDocumentID(ctx)
 	case node.FieldProtoMessage:
 		return m.OldProtoMessage(ctx)
 	case node.FieldNativeID:
 		return m.OldNativeID(ctx)
-	case node.FieldNodeListID:
-		return m.OldNodeListID(ctx)
 	case node.FieldType:
 		return m.OldType(ctx)
 	case node.FieldName:
@@ -8093,13 +8863,6 @@ func (m *NodeMutation) OldField(ctx context.Context, name string) (ent.Value, er
 // type.
 func (m *NodeMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case node.FieldDocumentID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDocumentID(v)
-		return nil
 	case node.FieldProtoMessage:
 		v, ok := value.(*sbom.Node)
 		if !ok {
@@ -8113,13 +8876,6 @@ func (m *NodeMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetNativeID(v)
-		return nil
-	case node.FieldNodeListID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetNodeListID(v)
 		return nil
 	case node.FieldType:
 		v, ok := value.(node.Type)
@@ -8283,14 +9039,7 @@ func (m *NodeMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *NodeMutation) ClearedFields() []string {
-	var fields []string
-	if m.FieldCleared(node.FieldDocumentID) {
-		fields = append(fields, node.FieldDocumentID)
-	}
-	if m.FieldCleared(node.FieldNodeListID) {
-		fields = append(fields, node.FieldNodeListID)
-	}
-	return fields
+	return nil
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -8303,14 +9052,6 @@ func (m *NodeMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *NodeMutation) ClearField(name string) error {
-	switch name {
-	case node.FieldDocumentID:
-		m.ClearDocumentID()
-		return nil
-	case node.FieldNodeListID:
-		m.ClearNodeListID()
-		return nil
-	}
 	return fmt.Errorf("unknown Node nullable field %s", name)
 }
 
@@ -8318,17 +9059,11 @@ func (m *NodeMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *NodeMutation) ResetField(name string) error {
 	switch name {
-	case node.FieldDocumentID:
-		m.ResetDocumentID()
-		return nil
 	case node.FieldProtoMessage:
 		m.ResetProtoMessage()
 		return nil
 	case node.FieldNativeID:
 		m.ResetNativeID()
-		return nil
-	case node.FieldNodeListID:
-		m.ResetNodeListID()
 		return nil
 	case node.FieldType:
 		m.ResetType()
@@ -8394,9 +9129,6 @@ func (m *NodeMutation) ResetField(name string) error {
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *NodeMutation) AddedEdges() []string {
 	edges := make([]string, 0, 13)
-	if m.document != nil {
-		edges = append(edges, node.EdgeDocument)
-	}
 	if m.annotations != nil {
 		edges = append(edges, node.EdgeAnnotations)
 	}
@@ -8427,6 +9159,9 @@ func (m *NodeMutation) AddedEdges() []string {
 	if m.properties != nil {
 		edges = append(edges, node.EdgeProperties)
 	}
+	if m.documents != nil {
+		edges = append(edges, node.EdgeDocuments)
+	}
 	if m.node_lists != nil {
 		edges = append(edges, node.EdgeNodeLists)
 	}
@@ -8440,10 +9175,6 @@ func (m *NodeMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *NodeMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case node.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
-		}
 	case node.EdgeAnnotations:
 		ids := make([]ent.Value, 0, len(m.annotations))
 		for id := range m.annotations {
@@ -8504,6 +9235,12 @@ func (m *NodeMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case node.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.documents))
+		for id := range m.documents {
+			ids = append(ids, id)
+		}
+		return ids
 	case node.EdgeNodeLists:
 		ids := make([]ent.Value, 0, len(m.node_lists))
 		for id := range m.node_lists {
@@ -8552,6 +9289,9 @@ func (m *NodeMutation) RemovedEdges() []string {
 	}
 	if m.removedproperties != nil {
 		edges = append(edges, node.EdgeProperties)
+	}
+	if m.removeddocuments != nil {
+		edges = append(edges, node.EdgeDocuments)
 	}
 	if m.removednode_lists != nil {
 		edges = append(edges, node.EdgeNodeLists)
@@ -8626,6 +9366,12 @@ func (m *NodeMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case node.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.removeddocuments))
+		for id := range m.removeddocuments {
+			ids = append(ids, id)
+		}
+		return ids
 	case node.EdgeNodeLists:
 		ids := make([]ent.Value, 0, len(m.removednode_lists))
 		for id := range m.removednode_lists {
@@ -8645,9 +9391,6 @@ func (m *NodeMutation) RemovedIDs(name string) []ent.Value {
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *NodeMutation) ClearedEdges() []string {
 	edges := make([]string, 0, 13)
-	if m.cleareddocument {
-		edges = append(edges, node.EdgeDocument)
-	}
 	if m.clearedannotations {
 		edges = append(edges, node.EdgeAnnotations)
 	}
@@ -8678,6 +9421,9 @@ func (m *NodeMutation) ClearedEdges() []string {
 	if m.clearedproperties {
 		edges = append(edges, node.EdgeProperties)
 	}
+	if m.cleareddocuments {
+		edges = append(edges, node.EdgeDocuments)
+	}
 	if m.clearednode_lists {
 		edges = append(edges, node.EdgeNodeLists)
 	}
@@ -8691,8 +9437,6 @@ func (m *NodeMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *NodeMutation) EdgeCleared(name string) bool {
 	switch name {
-	case node.EdgeDocument:
-		return m.cleareddocument
 	case node.EdgeAnnotations:
 		return m.clearedannotations
 	case node.EdgeSuppliers:
@@ -8713,6 +9457,8 @@ func (m *NodeMutation) EdgeCleared(name string) bool {
 		return m.clearedidentifiers
 	case node.EdgeProperties:
 		return m.clearedproperties
+	case node.EdgeDocuments:
+		return m.cleareddocuments
 	case node.EdgeNodeLists:
 		return m.clearednode_lists
 	case node.EdgeEdgeTypes:
@@ -8725,9 +9471,6 @@ func (m *NodeMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *NodeMutation) ClearEdge(name string) error {
 	switch name {
-	case node.EdgeDocument:
-		m.ClearDocument()
-		return nil
 	}
 	return fmt.Errorf("unknown Node unique edge %s", name)
 }
@@ -8736,9 +9479,6 @@ func (m *NodeMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *NodeMutation) ResetEdge(name string) error {
 	switch name {
-	case node.EdgeDocument:
-		m.ResetDocument()
-		return nil
 	case node.EdgeAnnotations:
 		m.ResetAnnotations()
 		return nil
@@ -8769,6 +9509,9 @@ func (m *NodeMutation) ResetEdge(name string) error {
 	case node.EdgeProperties:
 		m.ResetProperties()
 		return nil
+	case node.EdgeDocuments:
+		m.ResetDocuments()
+		return nil
 	case node.EdgeNodeLists:
 		m.ResetNodeLists()
 		return nil
@@ -8789,14 +9532,15 @@ type NodeListMutation struct {
 	root_elements       *[]string
 	appendroot_elements []string
 	clearedFields       map[string]struct{}
-	document            *uuid.UUID
-	cleareddocument     bool
 	edge_types          map[uuid.UUID]struct{}
 	removededge_types   map[uuid.UUID]struct{}
 	clearededge_types   bool
 	nodes               map[uuid.UUID]struct{}
 	removednodes        map[uuid.UUID]struct{}
 	clearednodes        bool
+	documents           map[uuid.UUID]struct{}
+	removeddocuments    map[uuid.UUID]struct{}
+	cleareddocuments    bool
 	done                bool
 	oldValue            func(context.Context) (*NodeList, error)
 	predicates          []predicate.NodeList
@@ -8993,45 +9737,6 @@ func (m *NodeListMutation) ResetRootElements() {
 	m.appendroot_elements = nil
 }
 
-// SetDocumentID sets the "document" edge to the Document entity by id.
-func (m *NodeListMutation) SetDocumentID(id uuid.UUID) {
-	m.document = &id
-}
-
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *NodeListMutation) ClearDocument() {
-	m.cleareddocument = true
-}
-
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *NodeListMutation) DocumentCleared() bool {
-	return m.cleareddocument
-}
-
-// DocumentID returns the "document" edge ID in the mutation.
-func (m *NodeListMutation) DocumentID() (id uuid.UUID, exists bool) {
-	if m.document != nil {
-		return *m.document, true
-	}
-	return
-}
-
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *NodeListMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
-	}
-	return
-}
-
-// ResetDocument resets all changes to the "document" edge.
-func (m *NodeListMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
-}
-
 // AddEdgeTypeIDs adds the "edge_types" edge to the EdgeType entity by ids.
 func (m *NodeListMutation) AddEdgeTypeIDs(ids ...uuid.UUID) {
 	if m.edge_types == nil {
@@ -9138,6 +9843,60 @@ func (m *NodeListMutation) ResetNodes() {
 	m.nodes = nil
 	m.clearednodes = false
 	m.removednodes = nil
+}
+
+// AddDocumentIDs adds the "documents" edge to the Document entity by ids.
+func (m *NodeListMutation) AddDocumentIDs(ids ...uuid.UUID) {
+	if m.documents == nil {
+		m.documents = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.documents[ids[i]] = struct{}{}
+	}
+}
+
+// ClearDocuments clears the "documents" edge to the Document entity.
+func (m *NodeListMutation) ClearDocuments() {
+	m.cleareddocuments = true
+}
+
+// DocumentsCleared reports if the "documents" edge to the Document entity was cleared.
+func (m *NodeListMutation) DocumentsCleared() bool {
+	return m.cleareddocuments
+}
+
+// RemoveDocumentIDs removes the "documents" edge to the Document entity by IDs.
+func (m *NodeListMutation) RemoveDocumentIDs(ids ...uuid.UUID) {
+	if m.removeddocuments == nil {
+		m.removeddocuments = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.documents, ids[i])
+		m.removeddocuments[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocuments returns the removed IDs of the "documents" edge to the Document entity.
+func (m *NodeListMutation) RemovedDocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocuments {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// DocumentsIDs returns the "documents" edge IDs in the mutation.
+func (m *NodeListMutation) DocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.documents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetDocuments resets all changes to the "documents" edge.
+func (m *NodeListMutation) ResetDocuments() {
+	m.documents = nil
+	m.cleareddocuments = false
+	m.removeddocuments = nil
 }
 
 // Where appends a list predicates to the NodeListMutation builder.
@@ -9291,14 +10050,14 @@ func (m *NodeListMutation) ResetField(name string) error {
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *NodeListMutation) AddedEdges() []string {
 	edges := make([]string, 0, 3)
-	if m.document != nil {
-		edges = append(edges, nodelist.EdgeDocument)
-	}
 	if m.edge_types != nil {
 		edges = append(edges, nodelist.EdgeEdgeTypes)
 	}
 	if m.nodes != nil {
 		edges = append(edges, nodelist.EdgeNodes)
+	}
+	if m.documents != nil {
+		edges = append(edges, nodelist.EdgeDocuments)
 	}
 	return edges
 }
@@ -9307,10 +10066,6 @@ func (m *NodeListMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *NodeListMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case nodelist.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
-		}
 	case nodelist.EdgeEdgeTypes:
 		ids := make([]ent.Value, 0, len(m.edge_types))
 		for id := range m.edge_types {
@@ -9320,6 +10075,12 @@ func (m *NodeListMutation) AddedIDs(name string) []ent.Value {
 	case nodelist.EdgeNodes:
 		ids := make([]ent.Value, 0, len(m.nodes))
 		for id := range m.nodes {
+			ids = append(ids, id)
+		}
+		return ids
+	case nodelist.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.documents))
+		for id := range m.documents {
 			ids = append(ids, id)
 		}
 		return ids
@@ -9335,6 +10096,9 @@ func (m *NodeListMutation) RemovedEdges() []string {
 	}
 	if m.removednodes != nil {
 		edges = append(edges, nodelist.EdgeNodes)
+	}
+	if m.removeddocuments != nil {
+		edges = append(edges, nodelist.EdgeDocuments)
 	}
 	return edges
 }
@@ -9355,6 +10119,12 @@ func (m *NodeListMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case nodelist.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.removeddocuments))
+		for id := range m.removeddocuments {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
@@ -9362,14 +10132,14 @@ func (m *NodeListMutation) RemovedIDs(name string) []ent.Value {
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *NodeListMutation) ClearedEdges() []string {
 	edges := make([]string, 0, 3)
-	if m.cleareddocument {
-		edges = append(edges, nodelist.EdgeDocument)
-	}
 	if m.clearededge_types {
 		edges = append(edges, nodelist.EdgeEdgeTypes)
 	}
 	if m.clearednodes {
 		edges = append(edges, nodelist.EdgeNodes)
+	}
+	if m.cleareddocuments {
+		edges = append(edges, nodelist.EdgeDocuments)
 	}
 	return edges
 }
@@ -9378,12 +10148,12 @@ func (m *NodeListMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *NodeListMutation) EdgeCleared(name string) bool {
 	switch name {
-	case nodelist.EdgeDocument:
-		return m.cleareddocument
 	case nodelist.EdgeEdgeTypes:
 		return m.clearededge_types
 	case nodelist.EdgeNodes:
 		return m.clearednodes
+	case nodelist.EdgeDocuments:
+		return m.cleareddocuments
 	}
 	return false
 }
@@ -9392,9 +10162,6 @@ func (m *NodeListMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *NodeListMutation) ClearEdge(name string) error {
 	switch name {
-	case nodelist.EdgeDocument:
-		m.ClearDocument()
-		return nil
 	}
 	return fmt.Errorf("unknown NodeList unique edge %s", name)
 }
@@ -9403,14 +10170,14 @@ func (m *NodeListMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *NodeListMutation) ResetEdge(name string) error {
 	switch name {
-	case nodelist.EdgeDocument:
-		m.ResetDocument()
-		return nil
 	case nodelist.EdgeEdgeTypes:
 		m.ResetEdgeTypes()
 		return nil
 	case nodelist.EdgeNodes:
 		m.ResetNodes()
+		return nil
+	case nodelist.EdgeDocuments:
+		m.ResetDocuments()
 		return nil
 	}
 	return fmt.Errorf("unknown NodeList edge %s", name)
@@ -9419,30 +10186,37 @@ func (m *NodeListMutation) ResetEdge(name string) error {
 // PersonMutation represents an operation that mutates the Person nodes in the graph.
 type PersonMutation struct {
 	config
-	op                   Op
-	typ                  string
-	id                   *uuid.UUID
-	proto_message        **sbom.Person
-	name                 *string
-	is_org               *bool
-	email                *string
-	url                  *string
-	phone                *string
-	clearedFields        map[string]struct{}
-	document             *uuid.UUID
-	cleareddocument      bool
-	contact_owner        *uuid.UUID
-	clearedcontact_owner bool
-	contacts             map[uuid.UUID]struct{}
-	removedcontacts      map[uuid.UUID]struct{}
-	clearedcontacts      bool
-	metadata             *uuid.UUID
-	clearedmetadata      bool
-	node                 *uuid.UUID
-	clearednode          bool
-	done                 bool
-	oldValue             func(context.Context) (*Person, error)
-	predicates           []predicate.Person
+	op                      Op
+	typ                     string
+	id                      *uuid.UUID
+	proto_message           **sbom.Person
+	name                    *string
+	is_org                  *bool
+	email                   *string
+	url                     *string
+	phone                   *string
+	clearedFields           map[string]struct{}
+	contact_owner           map[uuid.UUID]struct{}
+	removedcontact_owner    map[uuid.UUID]struct{}
+	clearedcontact_owner    bool
+	contacts                map[uuid.UUID]struct{}
+	removedcontacts         map[uuid.UUID]struct{}
+	clearedcontacts         bool
+	documents               map[uuid.UUID]struct{}
+	removeddocuments        map[uuid.UUID]struct{}
+	cleareddocuments        bool
+	metadata                map[uuid.UUID]struct{}
+	removedmetadata         map[uuid.UUID]struct{}
+	clearedmetadata         bool
+	originator_nodes        map[uuid.UUID]struct{}
+	removedoriginator_nodes map[uuid.UUID]struct{}
+	clearedoriginator_nodes bool
+	supplier_nodes          map[uuid.UUID]struct{}
+	removedsupplier_nodes   map[uuid.UUID]struct{}
+	clearedsupplier_nodes   bool
+	done                    bool
+	oldValue                func(context.Context) (*Person, error)
+	predicates              []predicate.Person
 }
 
 var _ ent.Mutation = (*PersonMutation)(nil)
@@ -9549,55 +10323,6 @@ func (m *PersonMutation) IDs(ctx context.Context) ([]uuid.UUID, error) {
 	}
 }
 
-// SetDocumentID sets the "document_id" field.
-func (m *PersonMutation) SetDocumentID(u uuid.UUID) {
-	m.document = &u
-}
-
-// DocumentID returns the value of the "document_id" field in the mutation.
-func (m *PersonMutation) DocumentID() (r uuid.UUID, exists bool) {
-	v := m.document
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDocumentID returns the old "document_id" field's value of the Person entity.
-// If the Person object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *PersonMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDocumentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
-	}
-	return oldValue.DocumentID, nil
-}
-
-// ClearDocumentID clears the value of the "document_id" field.
-func (m *PersonMutation) ClearDocumentID() {
-	m.document = nil
-	m.clearedFields[person.FieldDocumentID] = struct{}{}
-}
-
-// DocumentIDCleared returns if the "document_id" field was cleared in this mutation.
-func (m *PersonMutation) DocumentIDCleared() bool {
-	_, ok := m.clearedFields[person.FieldDocumentID]
-	return ok
-}
-
-// ResetDocumentID resets all changes to the "document_id" field.
-func (m *PersonMutation) ResetDocumentID() {
-	m.document = nil
-	delete(m.clearedFields, person.FieldDocumentID)
-}
-
 // SetProtoMessage sets the "proto_message" field.
 func (m *PersonMutation) SetProtoMessage(s *sbom.Person) {
 	m.proto_message = &s
@@ -9632,104 +10357,6 @@ func (m *PersonMutation) OldProtoMessage(ctx context.Context) (v *sbom.Person, e
 // ResetProtoMessage resets all changes to the "proto_message" field.
 func (m *PersonMutation) ResetProtoMessage() {
 	m.proto_message = nil
-}
-
-// SetMetadataID sets the "metadata_id" field.
-func (m *PersonMutation) SetMetadataID(u uuid.UUID) {
-	m.metadata = &u
-}
-
-// MetadataID returns the value of the "metadata_id" field in the mutation.
-func (m *PersonMutation) MetadataID() (r uuid.UUID, exists bool) {
-	v := m.metadata
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldMetadataID returns the old "metadata_id" field's value of the Person entity.
-// If the Person object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *PersonMutation) OldMetadataID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldMetadataID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldMetadataID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldMetadataID: %w", err)
-	}
-	return oldValue.MetadataID, nil
-}
-
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (m *PersonMutation) ClearMetadataID() {
-	m.metadata = nil
-	m.clearedFields[person.FieldMetadataID] = struct{}{}
-}
-
-// MetadataIDCleared returns if the "metadata_id" field was cleared in this mutation.
-func (m *PersonMutation) MetadataIDCleared() bool {
-	_, ok := m.clearedFields[person.FieldMetadataID]
-	return ok
-}
-
-// ResetMetadataID resets all changes to the "metadata_id" field.
-func (m *PersonMutation) ResetMetadataID() {
-	m.metadata = nil
-	delete(m.clearedFields, person.FieldMetadataID)
-}
-
-// SetNodeID sets the "node_id" field.
-func (m *PersonMutation) SetNodeID(u uuid.UUID) {
-	m.node = &u
-}
-
-// NodeID returns the value of the "node_id" field in the mutation.
-func (m *PersonMutation) NodeID() (r uuid.UUID, exists bool) {
-	v := m.node
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldNodeID returns the old "node_id" field's value of the Person entity.
-// If the Person object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *PersonMutation) OldNodeID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldNodeID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldNodeID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldNodeID: %w", err)
-	}
-	return oldValue.NodeID, nil
-}
-
-// ClearNodeID clears the value of the "node_id" field.
-func (m *PersonMutation) ClearNodeID() {
-	m.node = nil
-	m.clearedFields[person.FieldNodeID] = struct{}{}
-}
-
-// NodeIDCleared returns if the "node_id" field was cleared in this mutation.
-func (m *PersonMutation) NodeIDCleared() bool {
-	_, ok := m.clearedFields[person.FieldNodeID]
-	return ok
-}
-
-// ResetNodeID resets all changes to the "node_id" field.
-func (m *PersonMutation) ResetNodeID() {
-	m.node = nil
-	delete(m.clearedFields, person.FieldNodeID)
 }
 
 // SetName sets the "name" field.
@@ -9912,36 +10539,14 @@ func (m *PersonMutation) ResetPhone() {
 	m.phone = nil
 }
 
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *PersonMutation) ClearDocument() {
-	m.cleareddocument = true
-	m.clearedFields[person.FieldDocumentID] = struct{}{}
-}
-
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *PersonMutation) DocumentCleared() bool {
-	return m.DocumentIDCleared() || m.cleareddocument
-}
-
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *PersonMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
+// AddContactOwnerIDs adds the "contact_owner" edge to the Person entity by ids.
+func (m *PersonMutation) AddContactOwnerIDs(ids ...uuid.UUID) {
+	if m.contact_owner == nil {
+		m.contact_owner = make(map[uuid.UUID]struct{})
 	}
-	return
-}
-
-// ResetDocument resets all changes to the "document" edge.
-func (m *PersonMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
-}
-
-// SetContactOwnerID sets the "contact_owner" edge to the Person entity by id.
-func (m *PersonMutation) SetContactOwnerID(id uuid.UUID) {
-	m.contact_owner = &id
+	for i := range ids {
+		m.contact_owner[ids[i]] = struct{}{}
+	}
 }
 
 // ClearContactOwner clears the "contact_owner" edge to the Person entity.
@@ -9954,20 +10559,29 @@ func (m *PersonMutation) ContactOwnerCleared() bool {
 	return m.clearedcontact_owner
 }
 
-// ContactOwnerID returns the "contact_owner" edge ID in the mutation.
-func (m *PersonMutation) ContactOwnerID() (id uuid.UUID, exists bool) {
-	if m.contact_owner != nil {
-		return *m.contact_owner, true
+// RemoveContactOwnerIDs removes the "contact_owner" edge to the Person entity by IDs.
+func (m *PersonMutation) RemoveContactOwnerIDs(ids ...uuid.UUID) {
+	if m.removedcontact_owner == nil {
+		m.removedcontact_owner = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.contact_owner, ids[i])
+		m.removedcontact_owner[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedContactOwner returns the removed IDs of the "contact_owner" edge to the Person entity.
+func (m *PersonMutation) RemovedContactOwnerIDs() (ids []uuid.UUID) {
+	for id := range m.removedcontact_owner {
+		ids = append(ids, id)
 	}
 	return
 }
 
 // ContactOwnerIDs returns the "contact_owner" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// ContactOwnerID instead. It exists only for internal usage by the builders.
 func (m *PersonMutation) ContactOwnerIDs() (ids []uuid.UUID) {
-	if id := m.contact_owner; id != nil {
-		ids = append(ids, *id)
+	for id := range m.contact_owner {
+		ids = append(ids, id)
 	}
 	return
 }
@@ -9976,6 +10590,7 @@ func (m *PersonMutation) ContactOwnerIDs() (ids []uuid.UUID) {
 func (m *PersonMutation) ResetContactOwner() {
 	m.contact_owner = nil
 	m.clearedcontact_owner = false
+	m.removedcontact_owner = nil
 }
 
 // AddContactIDs adds the "contacts" edge to the Person entity by ids.
@@ -10032,23 +10647,103 @@ func (m *PersonMutation) ResetContacts() {
 	m.removedcontacts = nil
 }
 
+// AddDocumentIDs adds the "documents" edge to the Document entity by ids.
+func (m *PersonMutation) AddDocumentIDs(ids ...uuid.UUID) {
+	if m.documents == nil {
+		m.documents = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.documents[ids[i]] = struct{}{}
+	}
+}
+
+// ClearDocuments clears the "documents" edge to the Document entity.
+func (m *PersonMutation) ClearDocuments() {
+	m.cleareddocuments = true
+}
+
+// DocumentsCleared reports if the "documents" edge to the Document entity was cleared.
+func (m *PersonMutation) DocumentsCleared() bool {
+	return m.cleareddocuments
+}
+
+// RemoveDocumentIDs removes the "documents" edge to the Document entity by IDs.
+func (m *PersonMutation) RemoveDocumentIDs(ids ...uuid.UUID) {
+	if m.removeddocuments == nil {
+		m.removeddocuments = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.documents, ids[i])
+		m.removeddocuments[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocuments returns the removed IDs of the "documents" edge to the Document entity.
+func (m *PersonMutation) RemovedDocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocuments {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// DocumentsIDs returns the "documents" edge IDs in the mutation.
+func (m *PersonMutation) DocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.documents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetDocuments resets all changes to the "documents" edge.
+func (m *PersonMutation) ResetDocuments() {
+	m.documents = nil
+	m.cleareddocuments = false
+	m.removeddocuments = nil
+}
+
+// AddMetadatumIDs adds the "metadata" edge to the Metadata entity by ids.
+func (m *PersonMutation) AddMetadatumIDs(ids ...uuid.UUID) {
+	if m.metadata == nil {
+		m.metadata = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.metadata[ids[i]] = struct{}{}
+	}
+}
+
 // ClearMetadata clears the "metadata" edge to the Metadata entity.
 func (m *PersonMutation) ClearMetadata() {
 	m.clearedmetadata = true
-	m.clearedFields[person.FieldMetadataID] = struct{}{}
 }
 
 // MetadataCleared reports if the "metadata" edge to the Metadata entity was cleared.
 func (m *PersonMutation) MetadataCleared() bool {
-	return m.MetadataIDCleared() || m.clearedmetadata
+	return m.clearedmetadata
+}
+
+// RemoveMetadatumIDs removes the "metadata" edge to the Metadata entity by IDs.
+func (m *PersonMutation) RemoveMetadatumIDs(ids ...uuid.UUID) {
+	if m.removedmetadata == nil {
+		m.removedmetadata = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.metadata, ids[i])
+		m.removedmetadata[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedMetadata returns the removed IDs of the "metadata" edge to the Metadata entity.
+func (m *PersonMutation) RemovedMetadataIDs() (ids []uuid.UUID) {
+	for id := range m.removedmetadata {
+		ids = append(ids, id)
+	}
+	return
 }
 
 // MetadataIDs returns the "metadata" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// MetadataID instead. It exists only for internal usage by the builders.
 func (m *PersonMutation) MetadataIDs() (ids []uuid.UUID) {
-	if id := m.metadata; id != nil {
-		ids = append(ids, *id)
+	for id := range m.metadata {
+		ids = append(ids, id)
 	}
 	return
 }
@@ -10057,33 +10752,115 @@ func (m *PersonMutation) MetadataIDs() (ids []uuid.UUID) {
 func (m *PersonMutation) ResetMetadata() {
 	m.metadata = nil
 	m.clearedmetadata = false
+	m.removedmetadata = nil
 }
 
-// ClearNode clears the "node" edge to the Node entity.
-func (m *PersonMutation) ClearNode() {
-	m.clearednode = true
-	m.clearedFields[person.FieldNodeID] = struct{}{}
+// AddOriginatorNodeIDs adds the "originator_nodes" edge to the Node entity by ids.
+func (m *PersonMutation) AddOriginatorNodeIDs(ids ...uuid.UUID) {
+	if m.originator_nodes == nil {
+		m.originator_nodes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.originator_nodes[ids[i]] = struct{}{}
+	}
 }
 
-// NodeCleared reports if the "node" edge to the Node entity was cleared.
-func (m *PersonMutation) NodeCleared() bool {
-	return m.NodeIDCleared() || m.clearednode
+// ClearOriginatorNodes clears the "originator_nodes" edge to the Node entity.
+func (m *PersonMutation) ClearOriginatorNodes() {
+	m.clearedoriginator_nodes = true
 }
 
-// NodeIDs returns the "node" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// NodeID instead. It exists only for internal usage by the builders.
-func (m *PersonMutation) NodeIDs() (ids []uuid.UUID) {
-	if id := m.node; id != nil {
-		ids = append(ids, *id)
+// OriginatorNodesCleared reports if the "originator_nodes" edge to the Node entity was cleared.
+func (m *PersonMutation) OriginatorNodesCleared() bool {
+	return m.clearedoriginator_nodes
+}
+
+// RemoveOriginatorNodeIDs removes the "originator_nodes" edge to the Node entity by IDs.
+func (m *PersonMutation) RemoveOriginatorNodeIDs(ids ...uuid.UUID) {
+	if m.removedoriginator_nodes == nil {
+		m.removedoriginator_nodes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.originator_nodes, ids[i])
+		m.removedoriginator_nodes[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedOriginatorNodes returns the removed IDs of the "originator_nodes" edge to the Node entity.
+func (m *PersonMutation) RemovedOriginatorNodesIDs() (ids []uuid.UUID) {
+	for id := range m.removedoriginator_nodes {
+		ids = append(ids, id)
 	}
 	return
 }
 
-// ResetNode resets all changes to the "node" edge.
-func (m *PersonMutation) ResetNode() {
-	m.node = nil
-	m.clearednode = false
+// OriginatorNodesIDs returns the "originator_nodes" edge IDs in the mutation.
+func (m *PersonMutation) OriginatorNodesIDs() (ids []uuid.UUID) {
+	for id := range m.originator_nodes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetOriginatorNodes resets all changes to the "originator_nodes" edge.
+func (m *PersonMutation) ResetOriginatorNodes() {
+	m.originator_nodes = nil
+	m.clearedoriginator_nodes = false
+	m.removedoriginator_nodes = nil
+}
+
+// AddSupplierNodeIDs adds the "supplier_nodes" edge to the Node entity by ids.
+func (m *PersonMutation) AddSupplierNodeIDs(ids ...uuid.UUID) {
+	if m.supplier_nodes == nil {
+		m.supplier_nodes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.supplier_nodes[ids[i]] = struct{}{}
+	}
+}
+
+// ClearSupplierNodes clears the "supplier_nodes" edge to the Node entity.
+func (m *PersonMutation) ClearSupplierNodes() {
+	m.clearedsupplier_nodes = true
+}
+
+// SupplierNodesCleared reports if the "supplier_nodes" edge to the Node entity was cleared.
+func (m *PersonMutation) SupplierNodesCleared() bool {
+	return m.clearedsupplier_nodes
+}
+
+// RemoveSupplierNodeIDs removes the "supplier_nodes" edge to the Node entity by IDs.
+func (m *PersonMutation) RemoveSupplierNodeIDs(ids ...uuid.UUID) {
+	if m.removedsupplier_nodes == nil {
+		m.removedsupplier_nodes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.supplier_nodes, ids[i])
+		m.removedsupplier_nodes[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedSupplierNodes returns the removed IDs of the "supplier_nodes" edge to the Node entity.
+func (m *PersonMutation) RemovedSupplierNodesIDs() (ids []uuid.UUID) {
+	for id := range m.removedsupplier_nodes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// SupplierNodesIDs returns the "supplier_nodes" edge IDs in the mutation.
+func (m *PersonMutation) SupplierNodesIDs() (ids []uuid.UUID) {
+	for id := range m.supplier_nodes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetSupplierNodes resets all changes to the "supplier_nodes" edge.
+func (m *PersonMutation) ResetSupplierNodes() {
+	m.supplier_nodes = nil
+	m.clearedsupplier_nodes = false
+	m.removedsupplier_nodes = nil
 }
 
 // Where appends a list predicates to the PersonMutation builder.
@@ -10120,18 +10897,9 @@ func (m *PersonMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PersonMutation) Fields() []string {
-	fields := make([]string, 0, 9)
-	if m.document != nil {
-		fields = append(fields, person.FieldDocumentID)
-	}
+	fields := make([]string, 0, 6)
 	if m.proto_message != nil {
 		fields = append(fields, person.FieldProtoMessage)
-	}
-	if m.metadata != nil {
-		fields = append(fields, person.FieldMetadataID)
-	}
-	if m.node != nil {
-		fields = append(fields, person.FieldNodeID)
 	}
 	if m.name != nil {
 		fields = append(fields, person.FieldName)
@@ -10156,14 +10924,8 @@ func (m *PersonMutation) Fields() []string {
 // schema.
 func (m *PersonMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case person.FieldDocumentID:
-		return m.DocumentID()
 	case person.FieldProtoMessage:
 		return m.ProtoMessage()
-	case person.FieldMetadataID:
-		return m.MetadataID()
-	case person.FieldNodeID:
-		return m.NodeID()
 	case person.FieldName:
 		return m.Name()
 	case person.FieldIsOrg:
@@ -10183,14 +10945,8 @@ func (m *PersonMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *PersonMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case person.FieldDocumentID:
-		return m.OldDocumentID(ctx)
 	case person.FieldProtoMessage:
 		return m.OldProtoMessage(ctx)
-	case person.FieldMetadataID:
-		return m.OldMetadataID(ctx)
-	case person.FieldNodeID:
-		return m.OldNodeID(ctx)
 	case person.FieldName:
 		return m.OldName(ctx)
 	case person.FieldIsOrg:
@@ -10210,33 +10966,12 @@ func (m *PersonMutation) OldField(ctx context.Context, name string) (ent.Value, 
 // type.
 func (m *PersonMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case person.FieldDocumentID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDocumentID(v)
-		return nil
 	case person.FieldProtoMessage:
 		v, ok := value.(*sbom.Person)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetProtoMessage(v)
-		return nil
-	case person.FieldMetadataID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetMetadataID(v)
-		return nil
-	case person.FieldNodeID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetNodeID(v)
 		return nil
 	case person.FieldName:
 		v, ok := value.(string)
@@ -10302,17 +11037,7 @@ func (m *PersonMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *PersonMutation) ClearedFields() []string {
-	var fields []string
-	if m.FieldCleared(person.FieldDocumentID) {
-		fields = append(fields, person.FieldDocumentID)
-	}
-	if m.FieldCleared(person.FieldMetadataID) {
-		fields = append(fields, person.FieldMetadataID)
-	}
-	if m.FieldCleared(person.FieldNodeID) {
-		fields = append(fields, person.FieldNodeID)
-	}
-	return fields
+	return nil
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -10325,17 +11050,6 @@ func (m *PersonMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *PersonMutation) ClearField(name string) error {
-	switch name {
-	case person.FieldDocumentID:
-		m.ClearDocumentID()
-		return nil
-	case person.FieldMetadataID:
-		m.ClearMetadataID()
-		return nil
-	case person.FieldNodeID:
-		m.ClearNodeID()
-		return nil
-	}
 	return fmt.Errorf("unknown Person nullable field %s", name)
 }
 
@@ -10343,17 +11057,8 @@ func (m *PersonMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *PersonMutation) ResetField(name string) error {
 	switch name {
-	case person.FieldDocumentID:
-		m.ResetDocumentID()
-		return nil
 	case person.FieldProtoMessage:
 		m.ResetProtoMessage()
-		return nil
-	case person.FieldMetadataID:
-		m.ResetMetadataID()
-		return nil
-	case person.FieldNodeID:
-		m.ResetNodeID()
 		return nil
 	case person.FieldName:
 		m.ResetName()
@@ -10376,21 +11081,24 @@ func (m *PersonMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *PersonMutation) AddedEdges() []string {
-	edges := make([]string, 0, 5)
-	if m.document != nil {
-		edges = append(edges, person.EdgeDocument)
-	}
+	edges := make([]string, 0, 6)
 	if m.contact_owner != nil {
 		edges = append(edges, person.EdgeContactOwner)
 	}
 	if m.contacts != nil {
 		edges = append(edges, person.EdgeContacts)
 	}
+	if m.documents != nil {
+		edges = append(edges, person.EdgeDocuments)
+	}
 	if m.metadata != nil {
 		edges = append(edges, person.EdgeMetadata)
 	}
-	if m.node != nil {
-		edges = append(edges, person.EdgeNode)
+	if m.originator_nodes != nil {
+		edges = append(edges, person.EdgeOriginatorNodes)
+	}
+	if m.supplier_nodes != nil {
+		edges = append(edges, person.EdgeSupplierNodes)
 	}
 	return edges
 }
@@ -10399,37 +11107,66 @@ func (m *PersonMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *PersonMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case person.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
-		}
 	case person.EdgeContactOwner:
-		if id := m.contact_owner; id != nil {
-			return []ent.Value{*id}
+		ids := make([]ent.Value, 0, len(m.contact_owner))
+		for id := range m.contact_owner {
+			ids = append(ids, id)
 		}
+		return ids
 	case person.EdgeContacts:
 		ids := make([]ent.Value, 0, len(m.contacts))
 		for id := range m.contacts {
 			ids = append(ids, id)
 		}
 		return ids
+	case person.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.documents))
+		for id := range m.documents {
+			ids = append(ids, id)
+		}
+		return ids
 	case person.EdgeMetadata:
-		if id := m.metadata; id != nil {
-			return []ent.Value{*id}
+		ids := make([]ent.Value, 0, len(m.metadata))
+		for id := range m.metadata {
+			ids = append(ids, id)
 		}
-	case person.EdgeNode:
-		if id := m.node; id != nil {
-			return []ent.Value{*id}
+		return ids
+	case person.EdgeOriginatorNodes:
+		ids := make([]ent.Value, 0, len(m.originator_nodes))
+		for id := range m.originator_nodes {
+			ids = append(ids, id)
 		}
+		return ids
+	case person.EdgeSupplierNodes:
+		ids := make([]ent.Value, 0, len(m.supplier_nodes))
+		for id := range m.supplier_nodes {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *PersonMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 5)
+	edges := make([]string, 0, 6)
+	if m.removedcontact_owner != nil {
+		edges = append(edges, person.EdgeContactOwner)
+	}
 	if m.removedcontacts != nil {
 		edges = append(edges, person.EdgeContacts)
+	}
+	if m.removeddocuments != nil {
+		edges = append(edges, person.EdgeDocuments)
+	}
+	if m.removedmetadata != nil {
+		edges = append(edges, person.EdgeMetadata)
+	}
+	if m.removedoriginator_nodes != nil {
+		edges = append(edges, person.EdgeOriginatorNodes)
+	}
+	if m.removedsupplier_nodes != nil {
+		edges = append(edges, person.EdgeSupplierNodes)
 	}
 	return edges
 }
@@ -10438,9 +11175,39 @@ func (m *PersonMutation) RemovedEdges() []string {
 // the given name in this mutation.
 func (m *PersonMutation) RemovedIDs(name string) []ent.Value {
 	switch name {
+	case person.EdgeContactOwner:
+		ids := make([]ent.Value, 0, len(m.removedcontact_owner))
+		for id := range m.removedcontact_owner {
+			ids = append(ids, id)
+		}
+		return ids
 	case person.EdgeContacts:
 		ids := make([]ent.Value, 0, len(m.removedcontacts))
 		for id := range m.removedcontacts {
+			ids = append(ids, id)
+		}
+		return ids
+	case person.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.removeddocuments))
+		for id := range m.removeddocuments {
+			ids = append(ids, id)
+		}
+		return ids
+	case person.EdgeMetadata:
+		ids := make([]ent.Value, 0, len(m.removedmetadata))
+		for id := range m.removedmetadata {
+			ids = append(ids, id)
+		}
+		return ids
+	case person.EdgeOriginatorNodes:
+		ids := make([]ent.Value, 0, len(m.removedoriginator_nodes))
+		for id := range m.removedoriginator_nodes {
+			ids = append(ids, id)
+		}
+		return ids
+	case person.EdgeSupplierNodes:
+		ids := make([]ent.Value, 0, len(m.removedsupplier_nodes))
+		for id := range m.removedsupplier_nodes {
 			ids = append(ids, id)
 		}
 		return ids
@@ -10450,21 +11217,24 @@ func (m *PersonMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *PersonMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 5)
-	if m.cleareddocument {
-		edges = append(edges, person.EdgeDocument)
-	}
+	edges := make([]string, 0, 6)
 	if m.clearedcontact_owner {
 		edges = append(edges, person.EdgeContactOwner)
 	}
 	if m.clearedcontacts {
 		edges = append(edges, person.EdgeContacts)
 	}
+	if m.cleareddocuments {
+		edges = append(edges, person.EdgeDocuments)
+	}
 	if m.clearedmetadata {
 		edges = append(edges, person.EdgeMetadata)
 	}
-	if m.clearednode {
-		edges = append(edges, person.EdgeNode)
+	if m.clearedoriginator_nodes {
+		edges = append(edges, person.EdgeOriginatorNodes)
+	}
+	if m.clearedsupplier_nodes {
+		edges = append(edges, person.EdgeSupplierNodes)
 	}
 	return edges
 }
@@ -10473,16 +11243,18 @@ func (m *PersonMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *PersonMutation) EdgeCleared(name string) bool {
 	switch name {
-	case person.EdgeDocument:
-		return m.cleareddocument
 	case person.EdgeContactOwner:
 		return m.clearedcontact_owner
 	case person.EdgeContacts:
 		return m.clearedcontacts
+	case person.EdgeDocuments:
+		return m.cleareddocuments
 	case person.EdgeMetadata:
 		return m.clearedmetadata
-	case person.EdgeNode:
-		return m.clearednode
+	case person.EdgeOriginatorNodes:
+		return m.clearedoriginator_nodes
+	case person.EdgeSupplierNodes:
+		return m.clearedsupplier_nodes
 	}
 	return false
 }
@@ -10491,18 +11263,6 @@ func (m *PersonMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *PersonMutation) ClearEdge(name string) error {
 	switch name {
-	case person.EdgeDocument:
-		m.ClearDocument()
-		return nil
-	case person.EdgeContactOwner:
-		m.ClearContactOwner()
-		return nil
-	case person.EdgeMetadata:
-		m.ClearMetadata()
-		return nil
-	case person.EdgeNode:
-		m.ClearNode()
-		return nil
 	}
 	return fmt.Errorf("unknown Person unique edge %s", name)
 }
@@ -10511,20 +11271,23 @@ func (m *PersonMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *PersonMutation) ResetEdge(name string) error {
 	switch name {
-	case person.EdgeDocument:
-		m.ResetDocument()
-		return nil
 	case person.EdgeContactOwner:
 		m.ResetContactOwner()
 		return nil
 	case person.EdgeContacts:
 		m.ResetContacts()
 		return nil
+	case person.EdgeDocuments:
+		m.ResetDocuments()
+		return nil
 	case person.EdgeMetadata:
 		m.ResetMetadata()
 		return nil
-	case person.EdgeNode:
-		m.ResetNode()
+	case person.EdgeOriginatorNodes:
+		m.ResetOriginatorNodes()
+		return nil
+	case person.EdgeSupplierNodes:
+		m.ResetSupplierNodes()
 		return nil
 	}
 	return fmt.Errorf("unknown Person edge %s", name)
@@ -10533,20 +11296,22 @@ func (m *PersonMutation) ResetEdge(name string) error {
 // PropertyMutation represents an operation that mutates the Property nodes in the graph.
 type PropertyMutation struct {
 	config
-	op              Op
-	typ             string
-	id              *uuid.UUID
-	proto_message   **sbom.Property
-	name            *string
-	data            *string
-	clearedFields   map[string]struct{}
-	document        *uuid.UUID
-	cleareddocument bool
-	node            *uuid.UUID
-	clearednode     bool
-	done            bool
-	oldValue        func(context.Context) (*Property, error)
-	predicates      []predicate.Property
+	op               Op
+	typ              string
+	id               *uuid.UUID
+	proto_message    **sbom.Property
+	name             *string
+	data             *string
+	clearedFields    map[string]struct{}
+	documents        map[uuid.UUID]struct{}
+	removeddocuments map[uuid.UUID]struct{}
+	cleareddocuments bool
+	nodes            map[uuid.UUID]struct{}
+	removednodes     map[uuid.UUID]struct{}
+	clearednodes     bool
+	done             bool
+	oldValue         func(context.Context) (*Property, error)
+	predicates       []predicate.Property
 }
 
 var _ ent.Mutation = (*PropertyMutation)(nil)
@@ -10653,55 +11418,6 @@ func (m *PropertyMutation) IDs(ctx context.Context) ([]uuid.UUID, error) {
 	}
 }
 
-// SetDocumentID sets the "document_id" field.
-func (m *PropertyMutation) SetDocumentID(u uuid.UUID) {
-	m.document = &u
-}
-
-// DocumentID returns the value of the "document_id" field in the mutation.
-func (m *PropertyMutation) DocumentID() (r uuid.UUID, exists bool) {
-	v := m.document
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDocumentID returns the old "document_id" field's value of the Property entity.
-// If the Property object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *PropertyMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDocumentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
-	}
-	return oldValue.DocumentID, nil
-}
-
-// ClearDocumentID clears the value of the "document_id" field.
-func (m *PropertyMutation) ClearDocumentID() {
-	m.document = nil
-	m.clearedFields[property.FieldDocumentID] = struct{}{}
-}
-
-// DocumentIDCleared returns if the "document_id" field was cleared in this mutation.
-func (m *PropertyMutation) DocumentIDCleared() bool {
-	_, ok := m.clearedFields[property.FieldDocumentID]
-	return ok
-}
-
-// ResetDocumentID resets all changes to the "document_id" field.
-func (m *PropertyMutation) ResetDocumentID() {
-	m.document = nil
-	delete(m.clearedFields, property.FieldDocumentID)
-}
-
 // SetProtoMessage sets the "proto_message" field.
 func (m *PropertyMutation) SetProtoMessage(s *sbom.Property) {
 	m.proto_message = &s
@@ -10736,42 +11452,6 @@ func (m *PropertyMutation) OldProtoMessage(ctx context.Context) (v *sbom.Propert
 // ResetProtoMessage resets all changes to the "proto_message" field.
 func (m *PropertyMutation) ResetProtoMessage() {
 	m.proto_message = nil
-}
-
-// SetNodeID sets the "node_id" field.
-func (m *PropertyMutation) SetNodeID(u uuid.UUID) {
-	m.node = &u
-}
-
-// NodeID returns the value of the "node_id" field in the mutation.
-func (m *PropertyMutation) NodeID() (r uuid.UUID, exists bool) {
-	v := m.node
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldNodeID returns the old "node_id" field's value of the Property entity.
-// If the Property object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *PropertyMutation) OldNodeID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldNodeID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldNodeID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldNodeID: %w", err)
-	}
-	return oldValue.NodeID, nil
-}
-
-// ResetNodeID resets all changes to the "node_id" field.
-func (m *PropertyMutation) ResetNodeID() {
-	m.node = nil
 }
 
 // SetName sets the "name" field.
@@ -10846,58 +11526,112 @@ func (m *PropertyMutation) ResetData() {
 	m.data = nil
 }
 
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *PropertyMutation) ClearDocument() {
-	m.cleareddocument = true
-	m.clearedFields[property.FieldDocumentID] = struct{}{}
+// AddDocumentIDs adds the "documents" edge to the Document entity by ids.
+func (m *PropertyMutation) AddDocumentIDs(ids ...uuid.UUID) {
+	if m.documents == nil {
+		m.documents = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.documents[ids[i]] = struct{}{}
+	}
 }
 
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *PropertyMutation) DocumentCleared() bool {
-	return m.DocumentIDCleared() || m.cleareddocument
+// ClearDocuments clears the "documents" edge to the Document entity.
+func (m *PropertyMutation) ClearDocuments() {
+	m.cleareddocuments = true
 }
 
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *PropertyMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
+// DocumentsCleared reports if the "documents" edge to the Document entity was cleared.
+func (m *PropertyMutation) DocumentsCleared() bool {
+	return m.cleareddocuments
+}
+
+// RemoveDocumentIDs removes the "documents" edge to the Document entity by IDs.
+func (m *PropertyMutation) RemoveDocumentIDs(ids ...uuid.UUID) {
+	if m.removeddocuments == nil {
+		m.removeddocuments = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.documents, ids[i])
+		m.removeddocuments[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocuments returns the removed IDs of the "documents" edge to the Document entity.
+func (m *PropertyMutation) RemovedDocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocuments {
+		ids = append(ids, id)
 	}
 	return
 }
 
-// ResetDocument resets all changes to the "document" edge.
-func (m *PropertyMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
-}
-
-// ClearNode clears the "node" edge to the Node entity.
-func (m *PropertyMutation) ClearNode() {
-	m.clearednode = true
-	m.clearedFields[property.FieldNodeID] = struct{}{}
-}
-
-// NodeCleared reports if the "node" edge to the Node entity was cleared.
-func (m *PropertyMutation) NodeCleared() bool {
-	return m.clearednode
-}
-
-// NodeIDs returns the "node" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// NodeID instead. It exists only for internal usage by the builders.
-func (m *PropertyMutation) NodeIDs() (ids []uuid.UUID) {
-	if id := m.node; id != nil {
-		ids = append(ids, *id)
+// DocumentsIDs returns the "documents" edge IDs in the mutation.
+func (m *PropertyMutation) DocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.documents {
+		ids = append(ids, id)
 	}
 	return
 }
 
-// ResetNode resets all changes to the "node" edge.
-func (m *PropertyMutation) ResetNode() {
-	m.node = nil
-	m.clearednode = false
+// ResetDocuments resets all changes to the "documents" edge.
+func (m *PropertyMutation) ResetDocuments() {
+	m.documents = nil
+	m.cleareddocuments = false
+	m.removeddocuments = nil
+}
+
+// AddNodeIDs adds the "nodes" edge to the Node entity by ids.
+func (m *PropertyMutation) AddNodeIDs(ids ...uuid.UUID) {
+	if m.nodes == nil {
+		m.nodes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.nodes[ids[i]] = struct{}{}
+	}
+}
+
+// ClearNodes clears the "nodes" edge to the Node entity.
+func (m *PropertyMutation) ClearNodes() {
+	m.clearednodes = true
+}
+
+// NodesCleared reports if the "nodes" edge to the Node entity was cleared.
+func (m *PropertyMutation) NodesCleared() bool {
+	return m.clearednodes
+}
+
+// RemoveNodeIDs removes the "nodes" edge to the Node entity by IDs.
+func (m *PropertyMutation) RemoveNodeIDs(ids ...uuid.UUID) {
+	if m.removednodes == nil {
+		m.removednodes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.nodes, ids[i])
+		m.removednodes[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedNodes returns the removed IDs of the "nodes" edge to the Node entity.
+func (m *PropertyMutation) RemovedNodesIDs() (ids []uuid.UUID) {
+	for id := range m.removednodes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// NodesIDs returns the "nodes" edge IDs in the mutation.
+func (m *PropertyMutation) NodesIDs() (ids []uuid.UUID) {
+	for id := range m.nodes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetNodes resets all changes to the "nodes" edge.
+func (m *PropertyMutation) ResetNodes() {
+	m.nodes = nil
+	m.clearednodes = false
+	m.removednodes = nil
 }
 
 // Where appends a list predicates to the PropertyMutation builder.
@@ -10934,15 +11668,9 @@ func (m *PropertyMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PropertyMutation) Fields() []string {
-	fields := make([]string, 0, 5)
-	if m.document != nil {
-		fields = append(fields, property.FieldDocumentID)
-	}
+	fields := make([]string, 0, 3)
 	if m.proto_message != nil {
 		fields = append(fields, property.FieldProtoMessage)
-	}
-	if m.node != nil {
-		fields = append(fields, property.FieldNodeID)
 	}
 	if m.name != nil {
 		fields = append(fields, property.FieldName)
@@ -10958,12 +11686,8 @@ func (m *PropertyMutation) Fields() []string {
 // schema.
 func (m *PropertyMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case property.FieldDocumentID:
-		return m.DocumentID()
 	case property.FieldProtoMessage:
 		return m.ProtoMessage()
-	case property.FieldNodeID:
-		return m.NodeID()
 	case property.FieldName:
 		return m.Name()
 	case property.FieldData:
@@ -10977,12 +11701,8 @@ func (m *PropertyMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *PropertyMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case property.FieldDocumentID:
-		return m.OldDocumentID(ctx)
 	case property.FieldProtoMessage:
 		return m.OldProtoMessage(ctx)
-	case property.FieldNodeID:
-		return m.OldNodeID(ctx)
 	case property.FieldName:
 		return m.OldName(ctx)
 	case property.FieldData:
@@ -10996,26 +11716,12 @@ func (m *PropertyMutation) OldField(ctx context.Context, name string) (ent.Value
 // type.
 func (m *PropertyMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case property.FieldDocumentID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDocumentID(v)
-		return nil
 	case property.FieldProtoMessage:
 		v, ok := value.(*sbom.Property)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetProtoMessage(v)
-		return nil
-	case property.FieldNodeID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetNodeID(v)
 		return nil
 	case property.FieldName:
 		v, ok := value.(string)
@@ -11060,11 +11766,7 @@ func (m *PropertyMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *PropertyMutation) ClearedFields() []string {
-	var fields []string
-	if m.FieldCleared(property.FieldDocumentID) {
-		fields = append(fields, property.FieldDocumentID)
-	}
-	return fields
+	return nil
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -11077,11 +11779,6 @@ func (m *PropertyMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *PropertyMutation) ClearField(name string) error {
-	switch name {
-	case property.FieldDocumentID:
-		m.ClearDocumentID()
-		return nil
-	}
 	return fmt.Errorf("unknown Property nullable field %s", name)
 }
 
@@ -11089,14 +11786,8 @@ func (m *PropertyMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *PropertyMutation) ResetField(name string) error {
 	switch name {
-	case property.FieldDocumentID:
-		m.ResetDocumentID()
-		return nil
 	case property.FieldProtoMessage:
 		m.ResetProtoMessage()
-		return nil
-	case property.FieldNodeID:
-		m.ResetNodeID()
 		return nil
 	case property.FieldName:
 		m.ResetName()
@@ -11111,11 +11802,11 @@ func (m *PropertyMutation) ResetField(name string) error {
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *PropertyMutation) AddedEdges() []string {
 	edges := make([]string, 0, 2)
-	if m.document != nil {
-		edges = append(edges, property.EdgeDocument)
+	if m.documents != nil {
+		edges = append(edges, property.EdgeDocuments)
 	}
-	if m.node != nil {
-		edges = append(edges, property.EdgeNode)
+	if m.nodes != nil {
+		edges = append(edges, property.EdgeNodes)
 	}
 	return edges
 }
@@ -11124,14 +11815,18 @@ func (m *PropertyMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *PropertyMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case property.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
+	case property.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.documents))
+		for id := range m.documents {
+			ids = append(ids, id)
 		}
-	case property.EdgeNode:
-		if id := m.node; id != nil {
-			return []ent.Value{*id}
+		return ids
+	case property.EdgeNodes:
+		ids := make([]ent.Value, 0, len(m.nodes))
+		for id := range m.nodes {
+			ids = append(ids, id)
 		}
+		return ids
 	}
 	return nil
 }
@@ -11139,23 +11834,43 @@ func (m *PropertyMutation) AddedIDs(name string) []ent.Value {
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *PropertyMutation) RemovedEdges() []string {
 	edges := make([]string, 0, 2)
+	if m.removeddocuments != nil {
+		edges = append(edges, property.EdgeDocuments)
+	}
+	if m.removednodes != nil {
+		edges = append(edges, property.EdgeNodes)
+	}
 	return edges
 }
 
 // RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
 // the given name in this mutation.
 func (m *PropertyMutation) RemovedIDs(name string) []ent.Value {
+	switch name {
+	case property.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.removeddocuments))
+		for id := range m.removeddocuments {
+			ids = append(ids, id)
+		}
+		return ids
+	case property.EdgeNodes:
+		ids := make([]ent.Value, 0, len(m.removednodes))
+		for id := range m.removednodes {
+			ids = append(ids, id)
+		}
+		return ids
+	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *PropertyMutation) ClearedEdges() []string {
 	edges := make([]string, 0, 2)
-	if m.cleareddocument {
-		edges = append(edges, property.EdgeDocument)
+	if m.cleareddocuments {
+		edges = append(edges, property.EdgeDocuments)
 	}
-	if m.clearednode {
-		edges = append(edges, property.EdgeNode)
+	if m.clearednodes {
+		edges = append(edges, property.EdgeNodes)
 	}
 	return edges
 }
@@ -11164,10 +11879,10 @@ func (m *PropertyMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *PropertyMutation) EdgeCleared(name string) bool {
 	switch name {
-	case property.EdgeDocument:
-		return m.cleareddocument
-	case property.EdgeNode:
-		return m.clearednode
+	case property.EdgeDocuments:
+		return m.cleareddocuments
+	case property.EdgeNodes:
+		return m.clearednodes
 	}
 	return false
 }
@@ -11176,12 +11891,6 @@ func (m *PropertyMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *PropertyMutation) ClearEdge(name string) error {
 	switch name {
-	case property.EdgeDocument:
-		m.ClearDocument()
-		return nil
-	case property.EdgeNode:
-		m.ClearNode()
-		return nil
 	}
 	return fmt.Errorf("unknown Property unique edge %s", name)
 }
@@ -11190,11 +11899,11 @@ func (m *PropertyMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *PropertyMutation) ResetEdge(name string) error {
 	switch name {
-	case property.EdgeDocument:
-		m.ResetDocument()
+	case property.EdgeDocuments:
+		m.ResetDocuments()
 		return nil
-	case property.EdgeNode:
-		m.ResetNode()
+	case property.EdgeNodes:
+		m.ResetNodes()
 		return nil
 	}
 	return fmt.Errorf("unknown Property edge %s", name)
@@ -11203,18 +11912,20 @@ func (m *PropertyMutation) ResetEdge(name string) error {
 // PurposeMutation represents an operation that mutates the Purpose nodes in the graph.
 type PurposeMutation struct {
 	config
-	op              Op
-	typ             string
-	id              *int
-	primary_purpose *purpose.PrimaryPurpose
-	clearedFields   map[string]struct{}
-	document        *uuid.UUID
-	cleareddocument bool
-	node            *uuid.UUID
-	clearednode     bool
-	done            bool
-	oldValue        func(context.Context) (*Purpose, error)
-	predicates      []predicate.Purpose
+	op               Op
+	typ              string
+	id               *int
+	primary_purpose  *purpose.PrimaryPurpose
+	clearedFields    map[string]struct{}
+	documents        map[uuid.UUID]struct{}
+	removeddocuments map[uuid.UUID]struct{}
+	cleareddocuments bool
+	nodes            map[uuid.UUID]struct{}
+	removednodes     map[uuid.UUID]struct{}
+	clearednodes     bool
+	done             bool
+	oldValue         func(context.Context) (*Purpose, error)
+	predicates       []predicate.Purpose
 }
 
 var _ ent.Mutation = (*PurposeMutation)(nil)
@@ -11315,91 +12026,6 @@ func (m *PurposeMutation) IDs(ctx context.Context) ([]int, error) {
 	}
 }
 
-// SetDocumentID sets the "document_id" field.
-func (m *PurposeMutation) SetDocumentID(u uuid.UUID) {
-	m.document = &u
-}
-
-// DocumentID returns the value of the "document_id" field in the mutation.
-func (m *PurposeMutation) DocumentID() (r uuid.UUID, exists bool) {
-	v := m.document
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDocumentID returns the old "document_id" field's value of the Purpose entity.
-// If the Purpose object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *PurposeMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDocumentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
-	}
-	return oldValue.DocumentID, nil
-}
-
-// ClearDocumentID clears the value of the "document_id" field.
-func (m *PurposeMutation) ClearDocumentID() {
-	m.document = nil
-	m.clearedFields[purpose.FieldDocumentID] = struct{}{}
-}
-
-// DocumentIDCleared returns if the "document_id" field was cleared in this mutation.
-func (m *PurposeMutation) DocumentIDCleared() bool {
-	_, ok := m.clearedFields[purpose.FieldDocumentID]
-	return ok
-}
-
-// ResetDocumentID resets all changes to the "document_id" field.
-func (m *PurposeMutation) ResetDocumentID() {
-	m.document = nil
-	delete(m.clearedFields, purpose.FieldDocumentID)
-}
-
-// SetNodeID sets the "node_id" field.
-func (m *PurposeMutation) SetNodeID(u uuid.UUID) {
-	m.node = &u
-}
-
-// NodeID returns the value of the "node_id" field in the mutation.
-func (m *PurposeMutation) NodeID() (r uuid.UUID, exists bool) {
-	v := m.node
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldNodeID returns the old "node_id" field's value of the Purpose entity.
-// If the Purpose object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *PurposeMutation) OldNodeID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldNodeID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldNodeID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldNodeID: %w", err)
-	}
-	return oldValue.NodeID, nil
-}
-
-// ResetNodeID resets all changes to the "node_id" field.
-func (m *PurposeMutation) ResetNodeID() {
-	m.node = nil
-}
-
 // SetPrimaryPurpose sets the "primary_purpose" field.
 func (m *PurposeMutation) SetPrimaryPurpose(pp purpose.PrimaryPurpose) {
 	m.primary_purpose = &pp
@@ -11436,58 +12062,112 @@ func (m *PurposeMutation) ResetPrimaryPurpose() {
 	m.primary_purpose = nil
 }
 
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *PurposeMutation) ClearDocument() {
-	m.cleareddocument = true
-	m.clearedFields[purpose.FieldDocumentID] = struct{}{}
+// AddDocumentIDs adds the "documents" edge to the Document entity by ids.
+func (m *PurposeMutation) AddDocumentIDs(ids ...uuid.UUID) {
+	if m.documents == nil {
+		m.documents = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.documents[ids[i]] = struct{}{}
+	}
 }
 
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *PurposeMutation) DocumentCleared() bool {
-	return m.DocumentIDCleared() || m.cleareddocument
+// ClearDocuments clears the "documents" edge to the Document entity.
+func (m *PurposeMutation) ClearDocuments() {
+	m.cleareddocuments = true
 }
 
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *PurposeMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
+// DocumentsCleared reports if the "documents" edge to the Document entity was cleared.
+func (m *PurposeMutation) DocumentsCleared() bool {
+	return m.cleareddocuments
+}
+
+// RemoveDocumentIDs removes the "documents" edge to the Document entity by IDs.
+func (m *PurposeMutation) RemoveDocumentIDs(ids ...uuid.UUID) {
+	if m.removeddocuments == nil {
+		m.removeddocuments = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.documents, ids[i])
+		m.removeddocuments[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocuments returns the removed IDs of the "documents" edge to the Document entity.
+func (m *PurposeMutation) RemovedDocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocuments {
+		ids = append(ids, id)
 	}
 	return
 }
 
-// ResetDocument resets all changes to the "document" edge.
-func (m *PurposeMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
-}
-
-// ClearNode clears the "node" edge to the Node entity.
-func (m *PurposeMutation) ClearNode() {
-	m.clearednode = true
-	m.clearedFields[purpose.FieldNodeID] = struct{}{}
-}
-
-// NodeCleared reports if the "node" edge to the Node entity was cleared.
-func (m *PurposeMutation) NodeCleared() bool {
-	return m.clearednode
-}
-
-// NodeIDs returns the "node" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// NodeID instead. It exists only for internal usage by the builders.
-func (m *PurposeMutation) NodeIDs() (ids []uuid.UUID) {
-	if id := m.node; id != nil {
-		ids = append(ids, *id)
+// DocumentsIDs returns the "documents" edge IDs in the mutation.
+func (m *PurposeMutation) DocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.documents {
+		ids = append(ids, id)
 	}
 	return
 }
 
-// ResetNode resets all changes to the "node" edge.
-func (m *PurposeMutation) ResetNode() {
-	m.node = nil
-	m.clearednode = false
+// ResetDocuments resets all changes to the "documents" edge.
+func (m *PurposeMutation) ResetDocuments() {
+	m.documents = nil
+	m.cleareddocuments = false
+	m.removeddocuments = nil
+}
+
+// AddNodeIDs adds the "nodes" edge to the Node entity by ids.
+func (m *PurposeMutation) AddNodeIDs(ids ...uuid.UUID) {
+	if m.nodes == nil {
+		m.nodes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.nodes[ids[i]] = struct{}{}
+	}
+}
+
+// ClearNodes clears the "nodes" edge to the Node entity.
+func (m *PurposeMutation) ClearNodes() {
+	m.clearednodes = true
+}
+
+// NodesCleared reports if the "nodes" edge to the Node entity was cleared.
+func (m *PurposeMutation) NodesCleared() bool {
+	return m.clearednodes
+}
+
+// RemoveNodeIDs removes the "nodes" edge to the Node entity by IDs.
+func (m *PurposeMutation) RemoveNodeIDs(ids ...uuid.UUID) {
+	if m.removednodes == nil {
+		m.removednodes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.nodes, ids[i])
+		m.removednodes[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedNodes returns the removed IDs of the "nodes" edge to the Node entity.
+func (m *PurposeMutation) RemovedNodesIDs() (ids []uuid.UUID) {
+	for id := range m.removednodes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// NodesIDs returns the "nodes" edge IDs in the mutation.
+func (m *PurposeMutation) NodesIDs() (ids []uuid.UUID) {
+	for id := range m.nodes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetNodes resets all changes to the "nodes" edge.
+func (m *PurposeMutation) ResetNodes() {
+	m.nodes = nil
+	m.clearednodes = false
+	m.removednodes = nil
 }
 
 // Where appends a list predicates to the PurposeMutation builder.
@@ -11524,13 +12204,7 @@ func (m *PurposeMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PurposeMutation) Fields() []string {
-	fields := make([]string, 0, 3)
-	if m.document != nil {
-		fields = append(fields, purpose.FieldDocumentID)
-	}
-	if m.node != nil {
-		fields = append(fields, purpose.FieldNodeID)
-	}
+	fields := make([]string, 0, 1)
 	if m.primary_purpose != nil {
 		fields = append(fields, purpose.FieldPrimaryPurpose)
 	}
@@ -11542,10 +12216,6 @@ func (m *PurposeMutation) Fields() []string {
 // schema.
 func (m *PurposeMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case purpose.FieldDocumentID:
-		return m.DocumentID()
-	case purpose.FieldNodeID:
-		return m.NodeID()
 	case purpose.FieldPrimaryPurpose:
 		return m.PrimaryPurpose()
 	}
@@ -11557,10 +12227,6 @@ func (m *PurposeMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *PurposeMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case purpose.FieldDocumentID:
-		return m.OldDocumentID(ctx)
-	case purpose.FieldNodeID:
-		return m.OldNodeID(ctx)
 	case purpose.FieldPrimaryPurpose:
 		return m.OldPrimaryPurpose(ctx)
 	}
@@ -11572,20 +12238,6 @@ func (m *PurposeMutation) OldField(ctx context.Context, name string) (ent.Value,
 // type.
 func (m *PurposeMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case purpose.FieldDocumentID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDocumentID(v)
-		return nil
-	case purpose.FieldNodeID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetNodeID(v)
-		return nil
 	case purpose.FieldPrimaryPurpose:
 		v, ok := value.(purpose.PrimaryPurpose)
 		if !ok {
@@ -11622,11 +12274,7 @@ func (m *PurposeMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *PurposeMutation) ClearedFields() []string {
-	var fields []string
-	if m.FieldCleared(purpose.FieldDocumentID) {
-		fields = append(fields, purpose.FieldDocumentID)
-	}
-	return fields
+	return nil
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -11639,11 +12287,6 @@ func (m *PurposeMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *PurposeMutation) ClearField(name string) error {
-	switch name {
-	case purpose.FieldDocumentID:
-		m.ClearDocumentID()
-		return nil
-	}
 	return fmt.Errorf("unknown Purpose nullable field %s", name)
 }
 
@@ -11651,12 +12294,6 @@ func (m *PurposeMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *PurposeMutation) ResetField(name string) error {
 	switch name {
-	case purpose.FieldDocumentID:
-		m.ResetDocumentID()
-		return nil
-	case purpose.FieldNodeID:
-		m.ResetNodeID()
-		return nil
 	case purpose.FieldPrimaryPurpose:
 		m.ResetPrimaryPurpose()
 		return nil
@@ -11667,11 +12304,11 @@ func (m *PurposeMutation) ResetField(name string) error {
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *PurposeMutation) AddedEdges() []string {
 	edges := make([]string, 0, 2)
-	if m.document != nil {
-		edges = append(edges, purpose.EdgeDocument)
+	if m.documents != nil {
+		edges = append(edges, purpose.EdgeDocuments)
 	}
-	if m.node != nil {
-		edges = append(edges, purpose.EdgeNode)
+	if m.nodes != nil {
+		edges = append(edges, purpose.EdgeNodes)
 	}
 	return edges
 }
@@ -11680,14 +12317,18 @@ func (m *PurposeMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *PurposeMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case purpose.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
+	case purpose.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.documents))
+		for id := range m.documents {
+			ids = append(ids, id)
 		}
-	case purpose.EdgeNode:
-		if id := m.node; id != nil {
-			return []ent.Value{*id}
+		return ids
+	case purpose.EdgeNodes:
+		ids := make([]ent.Value, 0, len(m.nodes))
+		for id := range m.nodes {
+			ids = append(ids, id)
 		}
+		return ids
 	}
 	return nil
 }
@@ -11695,23 +12336,43 @@ func (m *PurposeMutation) AddedIDs(name string) []ent.Value {
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *PurposeMutation) RemovedEdges() []string {
 	edges := make([]string, 0, 2)
+	if m.removeddocuments != nil {
+		edges = append(edges, purpose.EdgeDocuments)
+	}
+	if m.removednodes != nil {
+		edges = append(edges, purpose.EdgeNodes)
+	}
 	return edges
 }
 
 // RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
 // the given name in this mutation.
 func (m *PurposeMutation) RemovedIDs(name string) []ent.Value {
+	switch name {
+	case purpose.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.removeddocuments))
+		for id := range m.removeddocuments {
+			ids = append(ids, id)
+		}
+		return ids
+	case purpose.EdgeNodes:
+		ids := make([]ent.Value, 0, len(m.removednodes))
+		for id := range m.removednodes {
+			ids = append(ids, id)
+		}
+		return ids
+	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *PurposeMutation) ClearedEdges() []string {
 	edges := make([]string, 0, 2)
-	if m.cleareddocument {
-		edges = append(edges, purpose.EdgeDocument)
+	if m.cleareddocuments {
+		edges = append(edges, purpose.EdgeDocuments)
 	}
-	if m.clearednode {
-		edges = append(edges, purpose.EdgeNode)
+	if m.clearednodes {
+		edges = append(edges, purpose.EdgeNodes)
 	}
 	return edges
 }
@@ -11720,10 +12381,10 @@ func (m *PurposeMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *PurposeMutation) EdgeCleared(name string) bool {
 	switch name {
-	case purpose.EdgeDocument:
-		return m.cleareddocument
-	case purpose.EdgeNode:
-		return m.clearednode
+	case purpose.EdgeDocuments:
+		return m.cleareddocuments
+	case purpose.EdgeNodes:
+		return m.clearednodes
 	}
 	return false
 }
@@ -11732,12 +12393,6 @@ func (m *PurposeMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *PurposeMutation) ClearEdge(name string) error {
 	switch name {
-	case purpose.EdgeDocument:
-		m.ClearDocument()
-		return nil
-	case purpose.EdgeNode:
-		m.ClearNode()
-		return nil
 	}
 	return fmt.Errorf("unknown Purpose unique edge %s", name)
 }
@@ -11746,11 +12401,11 @@ func (m *PurposeMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *PurposeMutation) ResetEdge(name string) error {
 	switch name {
-	case purpose.EdgeDocument:
-		m.ResetDocument()
+	case purpose.EdgeDocuments:
+		m.ResetDocuments()
 		return nil
-	case purpose.EdgeNode:
-		m.ResetNode()
+	case purpose.EdgeNodes:
+		m.ResetNodes()
 		return nil
 	}
 	return fmt.Errorf("unknown Purpose edge %s", name)
@@ -11759,23 +12414,27 @@ func (m *PurposeMutation) ResetEdge(name string) error {
 // SourceDataMutation represents an operation that mutates the SourceData nodes in the graph.
 type SourceDataMutation struct {
 	config
-	op              Op
-	typ             string
-	id              *uuid.UUID
-	proto_message   **sbom.SourceData
-	format          *string
-	size            *int64
-	addsize         *int64
-	uri             *string
-	hashes          *map[int32]string
-	clearedFields   map[string]struct{}
-	document        *uuid.UUID
-	cleareddocument bool
-	metadata        *uuid.UUID
-	clearedmetadata bool
-	done            bool
-	oldValue        func(context.Context) (*SourceData, error)
-	predicates      []predicate.SourceData
+	op               Op
+	typ              string
+	id               *uuid.UUID
+	proto_message    **sbom.SourceData
+	format           *string
+	size             *int64
+	addsize          *int64
+	uri              *string
+	clearedFields    map[string]struct{}
+	hashes           map[uuid.UUID]struct{}
+	removedhashes    map[uuid.UUID]struct{}
+	clearedhashes    bool
+	documents        map[uuid.UUID]struct{}
+	removeddocuments map[uuid.UUID]struct{}
+	cleareddocuments bool
+	metadata         map[uuid.UUID]struct{}
+	removedmetadata  map[uuid.UUID]struct{}
+	clearedmetadata  bool
+	done             bool
+	oldValue         func(context.Context) (*SourceData, error)
+	predicates       []predicate.SourceData
 }
 
 var _ ent.Mutation = (*SourceDataMutation)(nil)
@@ -11882,55 +12541,6 @@ func (m *SourceDataMutation) IDs(ctx context.Context) ([]uuid.UUID, error) {
 	}
 }
 
-// SetDocumentID sets the "document_id" field.
-func (m *SourceDataMutation) SetDocumentID(u uuid.UUID) {
-	m.document = &u
-}
-
-// DocumentID returns the value of the "document_id" field in the mutation.
-func (m *SourceDataMutation) DocumentID() (r uuid.UUID, exists bool) {
-	v := m.document
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDocumentID returns the old "document_id" field's value of the SourceData entity.
-// If the SourceData object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *SourceDataMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDocumentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
-	}
-	return oldValue.DocumentID, nil
-}
-
-// ClearDocumentID clears the value of the "document_id" field.
-func (m *SourceDataMutation) ClearDocumentID() {
-	m.document = nil
-	m.clearedFields[sourcedata.FieldDocumentID] = struct{}{}
-}
-
-// DocumentIDCleared returns if the "document_id" field was cleared in this mutation.
-func (m *SourceDataMutation) DocumentIDCleared() bool {
-	_, ok := m.clearedFields[sourcedata.FieldDocumentID]
-	return ok
-}
-
-// ResetDocumentID resets all changes to the "document_id" field.
-func (m *SourceDataMutation) ResetDocumentID() {
-	m.document = nil
-	delete(m.clearedFields, sourcedata.FieldDocumentID)
-}
-
 // SetProtoMessage sets the "proto_message" field.
 func (m *SourceDataMutation) SetProtoMessage(sd *sbom.SourceData) {
 	m.proto_message = &sd
@@ -11965,42 +12575,6 @@ func (m *SourceDataMutation) OldProtoMessage(ctx context.Context) (v *sbom.Sourc
 // ResetProtoMessage resets all changes to the "proto_message" field.
 func (m *SourceDataMutation) ResetProtoMessage() {
 	m.proto_message = nil
-}
-
-// SetMetadataID sets the "metadata_id" field.
-func (m *SourceDataMutation) SetMetadataID(u uuid.UUID) {
-	m.metadata = &u
-}
-
-// MetadataID returns the value of the "metadata_id" field in the mutation.
-func (m *SourceDataMutation) MetadataID() (r uuid.UUID, exists bool) {
-	v := m.metadata
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldMetadataID returns the old "metadata_id" field's value of the SourceData entity.
-// If the SourceData object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *SourceDataMutation) OldMetadataID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldMetadataID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldMetadataID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldMetadataID: %w", err)
-	}
-	return oldValue.MetadataID, nil
-}
-
-// ResetMetadataID resets all changes to the "metadata_id" field.
-func (m *SourceDataMutation) ResetMetadataID() {
-	m.metadata = nil
 }
 
 // SetFormat sets the "format" field.
@@ -12144,86 +12718,127 @@ func (m *SourceDataMutation) ResetURI() {
 	delete(m.clearedFields, sourcedata.FieldURI)
 }
 
-// SetHashes sets the "hashes" field.
-func (m *SourceDataMutation) SetHashes(value map[int32]string) {
-	m.hashes = &value
+// AddHashIDs adds the "hashes" edge to the HashesEntry entity by ids.
+func (m *SourceDataMutation) AddHashIDs(ids ...uuid.UUID) {
+	if m.hashes == nil {
+		m.hashes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.hashes[ids[i]] = struct{}{}
+	}
 }
 
-// Hashes returns the value of the "hashes" field in the mutation.
-func (m *SourceDataMutation) Hashes() (r map[int32]string, exists bool) {
-	v := m.hashes
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldHashes returns the old "hashes" field's value of the SourceData entity.
-// If the SourceData object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *SourceDataMutation) OldHashes(ctx context.Context) (v map[int32]string, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldHashes is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldHashes requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldHashes: %w", err)
-	}
-	return oldValue.Hashes, nil
-}
-
-// ClearHashes clears the value of the "hashes" field.
+// ClearHashes clears the "hashes" edge to the HashesEntry entity.
 func (m *SourceDataMutation) ClearHashes() {
-	m.hashes = nil
-	m.clearedFields[sourcedata.FieldHashes] = struct{}{}
+	m.clearedhashes = true
 }
 
-// HashesCleared returns if the "hashes" field was cleared in this mutation.
+// HashesCleared reports if the "hashes" edge to the HashesEntry entity was cleared.
 func (m *SourceDataMutation) HashesCleared() bool {
-	_, ok := m.clearedFields[sourcedata.FieldHashes]
-	return ok
+	return m.clearedhashes
 }
 
-// ResetHashes resets all changes to the "hashes" field.
-func (m *SourceDataMutation) ResetHashes() {
-	m.hashes = nil
-	delete(m.clearedFields, sourcedata.FieldHashes)
+// RemoveHashIDs removes the "hashes" edge to the HashesEntry entity by IDs.
+func (m *SourceDataMutation) RemoveHashIDs(ids ...uuid.UUID) {
+	if m.removedhashes == nil {
+		m.removedhashes = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.hashes, ids[i])
+		m.removedhashes[ids[i]] = struct{}{}
+	}
 }
 
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *SourceDataMutation) ClearDocument() {
-	m.cleareddocument = true
-	m.clearedFields[sourcedata.FieldDocumentID] = struct{}{}
-}
-
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *SourceDataMutation) DocumentCleared() bool {
-	return m.DocumentIDCleared() || m.cleareddocument
-}
-
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *SourceDataMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
+// RemovedHashes returns the removed IDs of the "hashes" edge to the HashesEntry entity.
+func (m *SourceDataMutation) RemovedHashesIDs() (ids []uuid.UUID) {
+	for id := range m.removedhashes {
+		ids = append(ids, id)
 	}
 	return
 }
 
-// ResetDocument resets all changes to the "document" edge.
-func (m *SourceDataMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
+// HashesIDs returns the "hashes" edge IDs in the mutation.
+func (m *SourceDataMutation) HashesIDs() (ids []uuid.UUID) {
+	for id := range m.hashes {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetHashes resets all changes to the "hashes" edge.
+func (m *SourceDataMutation) ResetHashes() {
+	m.hashes = nil
+	m.clearedhashes = false
+	m.removedhashes = nil
+}
+
+// AddDocumentIDs adds the "documents" edge to the Document entity by ids.
+func (m *SourceDataMutation) AddDocumentIDs(ids ...uuid.UUID) {
+	if m.documents == nil {
+		m.documents = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.documents[ids[i]] = struct{}{}
+	}
+}
+
+// ClearDocuments clears the "documents" edge to the Document entity.
+func (m *SourceDataMutation) ClearDocuments() {
+	m.cleareddocuments = true
+}
+
+// DocumentsCleared reports if the "documents" edge to the Document entity was cleared.
+func (m *SourceDataMutation) DocumentsCleared() bool {
+	return m.cleareddocuments
+}
+
+// RemoveDocumentIDs removes the "documents" edge to the Document entity by IDs.
+func (m *SourceDataMutation) RemoveDocumentIDs(ids ...uuid.UUID) {
+	if m.removeddocuments == nil {
+		m.removeddocuments = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.documents, ids[i])
+		m.removeddocuments[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocuments returns the removed IDs of the "documents" edge to the Document entity.
+func (m *SourceDataMutation) RemovedDocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocuments {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// DocumentsIDs returns the "documents" edge IDs in the mutation.
+func (m *SourceDataMutation) DocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.documents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetDocuments resets all changes to the "documents" edge.
+func (m *SourceDataMutation) ResetDocuments() {
+	m.documents = nil
+	m.cleareddocuments = false
+	m.removeddocuments = nil
+}
+
+// AddMetadatumIDs adds the "metadata" edge to the Metadata entity by ids.
+func (m *SourceDataMutation) AddMetadatumIDs(ids ...uuid.UUID) {
+	if m.metadata == nil {
+		m.metadata = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.metadata[ids[i]] = struct{}{}
+	}
 }
 
 // ClearMetadata clears the "metadata" edge to the Metadata entity.
 func (m *SourceDataMutation) ClearMetadata() {
 	m.clearedmetadata = true
-	m.clearedFields[sourcedata.FieldMetadataID] = struct{}{}
 }
 
 // MetadataCleared reports if the "metadata" edge to the Metadata entity was cleared.
@@ -12231,12 +12846,29 @@ func (m *SourceDataMutation) MetadataCleared() bool {
 	return m.clearedmetadata
 }
 
+// RemoveMetadatumIDs removes the "metadata" edge to the Metadata entity by IDs.
+func (m *SourceDataMutation) RemoveMetadatumIDs(ids ...uuid.UUID) {
+	if m.removedmetadata == nil {
+		m.removedmetadata = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.metadata, ids[i])
+		m.removedmetadata[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedMetadata returns the removed IDs of the "metadata" edge to the Metadata entity.
+func (m *SourceDataMutation) RemovedMetadataIDs() (ids []uuid.UUID) {
+	for id := range m.removedmetadata {
+		ids = append(ids, id)
+	}
+	return
+}
+
 // MetadataIDs returns the "metadata" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// MetadataID instead. It exists only for internal usage by the builders.
 func (m *SourceDataMutation) MetadataIDs() (ids []uuid.UUID) {
-	if id := m.metadata; id != nil {
-		ids = append(ids, *id)
+	for id := range m.metadata {
+		ids = append(ids, id)
 	}
 	return
 }
@@ -12245,6 +12877,7 @@ func (m *SourceDataMutation) MetadataIDs() (ids []uuid.UUID) {
 func (m *SourceDataMutation) ResetMetadata() {
 	m.metadata = nil
 	m.clearedmetadata = false
+	m.removedmetadata = nil
 }
 
 // Where appends a list predicates to the SourceDataMutation builder.
@@ -12281,15 +12914,9 @@ func (m *SourceDataMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SourceDataMutation) Fields() []string {
-	fields := make([]string, 0, 7)
-	if m.document != nil {
-		fields = append(fields, sourcedata.FieldDocumentID)
-	}
+	fields := make([]string, 0, 4)
 	if m.proto_message != nil {
 		fields = append(fields, sourcedata.FieldProtoMessage)
-	}
-	if m.metadata != nil {
-		fields = append(fields, sourcedata.FieldMetadataID)
 	}
 	if m.format != nil {
 		fields = append(fields, sourcedata.FieldFormat)
@@ -12300,9 +12927,6 @@ func (m *SourceDataMutation) Fields() []string {
 	if m.uri != nil {
 		fields = append(fields, sourcedata.FieldURI)
 	}
-	if m.hashes != nil {
-		fields = append(fields, sourcedata.FieldHashes)
-	}
 	return fields
 }
 
@@ -12311,20 +12935,14 @@ func (m *SourceDataMutation) Fields() []string {
 // schema.
 func (m *SourceDataMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case sourcedata.FieldDocumentID:
-		return m.DocumentID()
 	case sourcedata.FieldProtoMessage:
 		return m.ProtoMessage()
-	case sourcedata.FieldMetadataID:
-		return m.MetadataID()
 	case sourcedata.FieldFormat:
 		return m.Format()
 	case sourcedata.FieldSize:
 		return m.Size()
 	case sourcedata.FieldURI:
 		return m.URI()
-	case sourcedata.FieldHashes:
-		return m.Hashes()
 	}
 	return nil, false
 }
@@ -12334,20 +12952,14 @@ func (m *SourceDataMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *SourceDataMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case sourcedata.FieldDocumentID:
-		return m.OldDocumentID(ctx)
 	case sourcedata.FieldProtoMessage:
 		return m.OldProtoMessage(ctx)
-	case sourcedata.FieldMetadataID:
-		return m.OldMetadataID(ctx)
 	case sourcedata.FieldFormat:
 		return m.OldFormat(ctx)
 	case sourcedata.FieldSize:
 		return m.OldSize(ctx)
 	case sourcedata.FieldURI:
 		return m.OldURI(ctx)
-	case sourcedata.FieldHashes:
-		return m.OldHashes(ctx)
 	}
 	return nil, fmt.Errorf("unknown SourceData field %s", name)
 }
@@ -12357,26 +12969,12 @@ func (m *SourceDataMutation) OldField(ctx context.Context, name string) (ent.Val
 // type.
 func (m *SourceDataMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case sourcedata.FieldDocumentID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDocumentID(v)
-		return nil
 	case sourcedata.FieldProtoMessage:
 		v, ok := value.(*sbom.SourceData)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetProtoMessage(v)
-		return nil
-	case sourcedata.FieldMetadataID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetMetadataID(v)
 		return nil
 	case sourcedata.FieldFormat:
 		v, ok := value.(string)
@@ -12398,13 +12996,6 @@ func (m *SourceDataMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetURI(v)
-		return nil
-	case sourcedata.FieldHashes:
-		v, ok := value.(map[int32]string)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetHashes(v)
 		return nil
 	}
 	return fmt.Errorf("unknown SourceData field %s", name)
@@ -12451,14 +13042,8 @@ func (m *SourceDataMutation) AddField(name string, value ent.Value) error {
 // mutation.
 func (m *SourceDataMutation) ClearedFields() []string {
 	var fields []string
-	if m.FieldCleared(sourcedata.FieldDocumentID) {
-		fields = append(fields, sourcedata.FieldDocumentID)
-	}
 	if m.FieldCleared(sourcedata.FieldURI) {
 		fields = append(fields, sourcedata.FieldURI)
-	}
-	if m.FieldCleared(sourcedata.FieldHashes) {
-		fields = append(fields, sourcedata.FieldHashes)
 	}
 	return fields
 }
@@ -12474,14 +13059,8 @@ func (m *SourceDataMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *SourceDataMutation) ClearField(name string) error {
 	switch name {
-	case sourcedata.FieldDocumentID:
-		m.ClearDocumentID()
-		return nil
 	case sourcedata.FieldURI:
 		m.ClearURI()
-		return nil
-	case sourcedata.FieldHashes:
-		m.ClearHashes()
 		return nil
 	}
 	return fmt.Errorf("unknown SourceData nullable field %s", name)
@@ -12491,14 +13070,8 @@ func (m *SourceDataMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *SourceDataMutation) ResetField(name string) error {
 	switch name {
-	case sourcedata.FieldDocumentID:
-		m.ResetDocumentID()
-		return nil
 	case sourcedata.FieldProtoMessage:
 		m.ResetProtoMessage()
-		return nil
-	case sourcedata.FieldMetadataID:
-		m.ResetMetadataID()
 		return nil
 	case sourcedata.FieldFormat:
 		m.ResetFormat()
@@ -12509,18 +13082,18 @@ func (m *SourceDataMutation) ResetField(name string) error {
 	case sourcedata.FieldURI:
 		m.ResetURI()
 		return nil
-	case sourcedata.FieldHashes:
-		m.ResetHashes()
-		return nil
 	}
 	return fmt.Errorf("unknown SourceData field %s", name)
 }
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *SourceDataMutation) AddedEdges() []string {
-	edges := make([]string, 0, 2)
-	if m.document != nil {
-		edges = append(edges, sourcedata.EdgeDocument)
+	edges := make([]string, 0, 3)
+	if m.hashes != nil {
+		edges = append(edges, sourcedata.EdgeHashes)
+	}
+	if m.documents != nil {
+		edges = append(edges, sourcedata.EdgeDocuments)
 	}
 	if m.metadata != nil {
 		edges = append(edges, sourcedata.EdgeMetadata)
@@ -12532,35 +13105,77 @@ func (m *SourceDataMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *SourceDataMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case sourcedata.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
+	case sourcedata.EdgeHashes:
+		ids := make([]ent.Value, 0, len(m.hashes))
+		for id := range m.hashes {
+			ids = append(ids, id)
 		}
+		return ids
+	case sourcedata.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.documents))
+		for id := range m.documents {
+			ids = append(ids, id)
+		}
+		return ids
 	case sourcedata.EdgeMetadata:
-		if id := m.metadata; id != nil {
-			return []ent.Value{*id}
+		ids := make([]ent.Value, 0, len(m.metadata))
+		for id := range m.metadata {
+			ids = append(ids, id)
 		}
+		return ids
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *SourceDataMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
+	if m.removedhashes != nil {
+		edges = append(edges, sourcedata.EdgeHashes)
+	}
+	if m.removeddocuments != nil {
+		edges = append(edges, sourcedata.EdgeDocuments)
+	}
+	if m.removedmetadata != nil {
+		edges = append(edges, sourcedata.EdgeMetadata)
+	}
 	return edges
 }
 
 // RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
 // the given name in this mutation.
 func (m *SourceDataMutation) RemovedIDs(name string) []ent.Value {
+	switch name {
+	case sourcedata.EdgeHashes:
+		ids := make([]ent.Value, 0, len(m.removedhashes))
+		for id := range m.removedhashes {
+			ids = append(ids, id)
+		}
+		return ids
+	case sourcedata.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.removeddocuments))
+		for id := range m.removeddocuments {
+			ids = append(ids, id)
+		}
+		return ids
+	case sourcedata.EdgeMetadata:
+		ids := make([]ent.Value, 0, len(m.removedmetadata))
+		for id := range m.removedmetadata {
+			ids = append(ids, id)
+		}
+		return ids
+	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *SourceDataMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 2)
-	if m.cleareddocument {
-		edges = append(edges, sourcedata.EdgeDocument)
+	edges := make([]string, 0, 3)
+	if m.clearedhashes {
+		edges = append(edges, sourcedata.EdgeHashes)
+	}
+	if m.cleareddocuments {
+		edges = append(edges, sourcedata.EdgeDocuments)
 	}
 	if m.clearedmetadata {
 		edges = append(edges, sourcedata.EdgeMetadata)
@@ -12572,8 +13187,10 @@ func (m *SourceDataMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *SourceDataMutation) EdgeCleared(name string) bool {
 	switch name {
-	case sourcedata.EdgeDocument:
-		return m.cleareddocument
+	case sourcedata.EdgeHashes:
+		return m.clearedhashes
+	case sourcedata.EdgeDocuments:
+		return m.cleareddocuments
 	case sourcedata.EdgeMetadata:
 		return m.clearedmetadata
 	}
@@ -12584,12 +13201,6 @@ func (m *SourceDataMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *SourceDataMutation) ClearEdge(name string) error {
 	switch name {
-	case sourcedata.EdgeDocument:
-		m.ClearDocument()
-		return nil
-	case sourcedata.EdgeMetadata:
-		m.ClearMetadata()
-		return nil
 	}
 	return fmt.Errorf("unknown SourceData unique edge %s", name)
 }
@@ -12598,8 +13209,11 @@ func (m *SourceDataMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *SourceDataMutation) ResetEdge(name string) error {
 	switch name {
-	case sourcedata.EdgeDocument:
-		m.ResetDocument()
+	case sourcedata.EdgeHashes:
+		m.ResetHashes()
+		return nil
+	case sourcedata.EdgeDocuments:
+		m.ResetDocuments()
 		return nil
 	case sourcedata.EdgeMetadata:
 		m.ResetMetadata()
@@ -12611,21 +13225,23 @@ func (m *SourceDataMutation) ResetEdge(name string) error {
 // ToolMutation represents an operation that mutates the Tool nodes in the graph.
 type ToolMutation struct {
 	config
-	op              Op
-	typ             string
-	id              *uuid.UUID
-	proto_message   **sbom.Tool
-	name            *string
-	version         *string
-	vendor          *string
-	clearedFields   map[string]struct{}
-	document        *uuid.UUID
-	cleareddocument bool
-	metadata        *uuid.UUID
-	clearedmetadata bool
-	done            bool
-	oldValue        func(context.Context) (*Tool, error)
-	predicates      []predicate.Tool
+	op               Op
+	typ              string
+	id               *uuid.UUID
+	proto_message    **sbom.Tool
+	name             *string
+	version          *string
+	vendor           *string
+	clearedFields    map[string]struct{}
+	documents        map[uuid.UUID]struct{}
+	removeddocuments map[uuid.UUID]struct{}
+	cleareddocuments bool
+	metadata         map[uuid.UUID]struct{}
+	removedmetadata  map[uuid.UUID]struct{}
+	clearedmetadata  bool
+	done             bool
+	oldValue         func(context.Context) (*Tool, error)
+	predicates       []predicate.Tool
 }
 
 var _ ent.Mutation = (*ToolMutation)(nil)
@@ -12732,55 +13348,6 @@ func (m *ToolMutation) IDs(ctx context.Context) ([]uuid.UUID, error) {
 	}
 }
 
-// SetDocumentID sets the "document_id" field.
-func (m *ToolMutation) SetDocumentID(u uuid.UUID) {
-	m.document = &u
-}
-
-// DocumentID returns the value of the "document_id" field in the mutation.
-func (m *ToolMutation) DocumentID() (r uuid.UUID, exists bool) {
-	v := m.document
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDocumentID returns the old "document_id" field's value of the Tool entity.
-// If the Tool object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ToolMutation) OldDocumentID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDocumentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDocumentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDocumentID: %w", err)
-	}
-	return oldValue.DocumentID, nil
-}
-
-// ClearDocumentID clears the value of the "document_id" field.
-func (m *ToolMutation) ClearDocumentID() {
-	m.document = nil
-	m.clearedFields[tool.FieldDocumentID] = struct{}{}
-}
-
-// DocumentIDCleared returns if the "document_id" field was cleared in this mutation.
-func (m *ToolMutation) DocumentIDCleared() bool {
-	_, ok := m.clearedFields[tool.FieldDocumentID]
-	return ok
-}
-
-// ResetDocumentID resets all changes to the "document_id" field.
-func (m *ToolMutation) ResetDocumentID() {
-	m.document = nil
-	delete(m.clearedFields, tool.FieldDocumentID)
-}
-
 // SetProtoMessage sets the "proto_message" field.
 func (m *ToolMutation) SetProtoMessage(s *sbom.Tool) {
 	m.proto_message = &s
@@ -12815,42 +13382,6 @@ func (m *ToolMutation) OldProtoMessage(ctx context.Context) (v *sbom.Tool, err e
 // ResetProtoMessage resets all changes to the "proto_message" field.
 func (m *ToolMutation) ResetProtoMessage() {
 	m.proto_message = nil
-}
-
-// SetMetadataID sets the "metadata_id" field.
-func (m *ToolMutation) SetMetadataID(u uuid.UUID) {
-	m.metadata = &u
-}
-
-// MetadataID returns the value of the "metadata_id" field in the mutation.
-func (m *ToolMutation) MetadataID() (r uuid.UUID, exists bool) {
-	v := m.metadata
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldMetadataID returns the old "metadata_id" field's value of the Tool entity.
-// If the Tool object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ToolMutation) OldMetadataID(ctx context.Context) (v uuid.UUID, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldMetadataID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldMetadataID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldMetadataID: %w", err)
-	}
-	return oldValue.MetadataID, nil
-}
-
-// ResetMetadataID resets all changes to the "metadata_id" field.
-func (m *ToolMutation) ResetMetadataID() {
-	m.metadata = nil
 }
 
 // SetName sets the "name" field.
@@ -12961,37 +13492,73 @@ func (m *ToolMutation) ResetVendor() {
 	m.vendor = nil
 }
 
-// ClearDocument clears the "document" edge to the Document entity.
-func (m *ToolMutation) ClearDocument() {
-	m.cleareddocument = true
-	m.clearedFields[tool.FieldDocumentID] = struct{}{}
+// AddDocumentIDs adds the "documents" edge to the Document entity by ids.
+func (m *ToolMutation) AddDocumentIDs(ids ...uuid.UUID) {
+	if m.documents == nil {
+		m.documents = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.documents[ids[i]] = struct{}{}
+	}
 }
 
-// DocumentCleared reports if the "document" edge to the Document entity was cleared.
-func (m *ToolMutation) DocumentCleared() bool {
-	return m.DocumentIDCleared() || m.cleareddocument
+// ClearDocuments clears the "documents" edge to the Document entity.
+func (m *ToolMutation) ClearDocuments() {
+	m.cleareddocuments = true
 }
 
-// DocumentIDs returns the "document" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DocumentID instead. It exists only for internal usage by the builders.
-func (m *ToolMutation) DocumentIDs() (ids []uuid.UUID) {
-	if id := m.document; id != nil {
-		ids = append(ids, *id)
+// DocumentsCleared reports if the "documents" edge to the Document entity was cleared.
+func (m *ToolMutation) DocumentsCleared() bool {
+	return m.cleareddocuments
+}
+
+// RemoveDocumentIDs removes the "documents" edge to the Document entity by IDs.
+func (m *ToolMutation) RemoveDocumentIDs(ids ...uuid.UUID) {
+	if m.removeddocuments == nil {
+		m.removeddocuments = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.documents, ids[i])
+		m.removeddocuments[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDocuments returns the removed IDs of the "documents" edge to the Document entity.
+func (m *ToolMutation) RemovedDocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.removeddocuments {
+		ids = append(ids, id)
 	}
 	return
 }
 
-// ResetDocument resets all changes to the "document" edge.
-func (m *ToolMutation) ResetDocument() {
-	m.document = nil
-	m.cleareddocument = false
+// DocumentsIDs returns the "documents" edge IDs in the mutation.
+func (m *ToolMutation) DocumentsIDs() (ids []uuid.UUID) {
+	for id := range m.documents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetDocuments resets all changes to the "documents" edge.
+func (m *ToolMutation) ResetDocuments() {
+	m.documents = nil
+	m.cleareddocuments = false
+	m.removeddocuments = nil
+}
+
+// AddMetadatumIDs adds the "metadata" edge to the Metadata entity by ids.
+func (m *ToolMutation) AddMetadatumIDs(ids ...uuid.UUID) {
+	if m.metadata == nil {
+		m.metadata = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		m.metadata[ids[i]] = struct{}{}
+	}
 }
 
 // ClearMetadata clears the "metadata" edge to the Metadata entity.
 func (m *ToolMutation) ClearMetadata() {
 	m.clearedmetadata = true
-	m.clearedFields[tool.FieldMetadataID] = struct{}{}
 }
 
 // MetadataCleared reports if the "metadata" edge to the Metadata entity was cleared.
@@ -12999,12 +13566,29 @@ func (m *ToolMutation) MetadataCleared() bool {
 	return m.clearedmetadata
 }
 
+// RemoveMetadatumIDs removes the "metadata" edge to the Metadata entity by IDs.
+func (m *ToolMutation) RemoveMetadatumIDs(ids ...uuid.UUID) {
+	if m.removedmetadata == nil {
+		m.removedmetadata = make(map[uuid.UUID]struct{})
+	}
+	for i := range ids {
+		delete(m.metadata, ids[i])
+		m.removedmetadata[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedMetadata returns the removed IDs of the "metadata" edge to the Metadata entity.
+func (m *ToolMutation) RemovedMetadataIDs() (ids []uuid.UUID) {
+	for id := range m.removedmetadata {
+		ids = append(ids, id)
+	}
+	return
+}
+
 // MetadataIDs returns the "metadata" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// MetadataID instead. It exists only for internal usage by the builders.
 func (m *ToolMutation) MetadataIDs() (ids []uuid.UUID) {
-	if id := m.metadata; id != nil {
-		ids = append(ids, *id)
+	for id := range m.metadata {
+		ids = append(ids, id)
 	}
 	return
 }
@@ -13013,6 +13597,7 @@ func (m *ToolMutation) MetadataIDs() (ids []uuid.UUID) {
 func (m *ToolMutation) ResetMetadata() {
 	m.metadata = nil
 	m.clearedmetadata = false
+	m.removedmetadata = nil
 }
 
 // Where appends a list predicates to the ToolMutation builder.
@@ -13049,15 +13634,9 @@ func (m *ToolMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ToolMutation) Fields() []string {
-	fields := make([]string, 0, 6)
-	if m.document != nil {
-		fields = append(fields, tool.FieldDocumentID)
-	}
+	fields := make([]string, 0, 4)
 	if m.proto_message != nil {
 		fields = append(fields, tool.FieldProtoMessage)
-	}
-	if m.metadata != nil {
-		fields = append(fields, tool.FieldMetadataID)
 	}
 	if m.name != nil {
 		fields = append(fields, tool.FieldName)
@@ -13076,12 +13655,8 @@ func (m *ToolMutation) Fields() []string {
 // schema.
 func (m *ToolMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case tool.FieldDocumentID:
-		return m.DocumentID()
 	case tool.FieldProtoMessage:
 		return m.ProtoMessage()
-	case tool.FieldMetadataID:
-		return m.MetadataID()
 	case tool.FieldName:
 		return m.Name()
 	case tool.FieldVersion:
@@ -13097,12 +13672,8 @@ func (m *ToolMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *ToolMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case tool.FieldDocumentID:
-		return m.OldDocumentID(ctx)
 	case tool.FieldProtoMessage:
 		return m.OldProtoMessage(ctx)
-	case tool.FieldMetadataID:
-		return m.OldMetadataID(ctx)
 	case tool.FieldName:
 		return m.OldName(ctx)
 	case tool.FieldVersion:
@@ -13118,26 +13689,12 @@ func (m *ToolMutation) OldField(ctx context.Context, name string) (ent.Value, er
 // type.
 func (m *ToolMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case tool.FieldDocumentID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDocumentID(v)
-		return nil
 	case tool.FieldProtoMessage:
 		v, ok := value.(*sbom.Tool)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetProtoMessage(v)
-		return nil
-	case tool.FieldMetadataID:
-		v, ok := value.(uuid.UUID)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetMetadataID(v)
 		return nil
 	case tool.FieldName:
 		v, ok := value.(string)
@@ -13189,11 +13746,7 @@ func (m *ToolMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *ToolMutation) ClearedFields() []string {
-	var fields []string
-	if m.FieldCleared(tool.FieldDocumentID) {
-		fields = append(fields, tool.FieldDocumentID)
-	}
-	return fields
+	return nil
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -13206,11 +13759,6 @@ func (m *ToolMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *ToolMutation) ClearField(name string) error {
-	switch name {
-	case tool.FieldDocumentID:
-		m.ClearDocumentID()
-		return nil
-	}
 	return fmt.Errorf("unknown Tool nullable field %s", name)
 }
 
@@ -13218,14 +13766,8 @@ func (m *ToolMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *ToolMutation) ResetField(name string) error {
 	switch name {
-	case tool.FieldDocumentID:
-		m.ResetDocumentID()
-		return nil
 	case tool.FieldProtoMessage:
 		m.ResetProtoMessage()
-		return nil
-	case tool.FieldMetadataID:
-		m.ResetMetadataID()
 		return nil
 	case tool.FieldName:
 		m.ResetName()
@@ -13243,8 +13785,8 @@ func (m *ToolMutation) ResetField(name string) error {
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *ToolMutation) AddedEdges() []string {
 	edges := make([]string, 0, 2)
-	if m.document != nil {
-		edges = append(edges, tool.EdgeDocument)
+	if m.documents != nil {
+		edges = append(edges, tool.EdgeDocuments)
 	}
 	if m.metadata != nil {
 		edges = append(edges, tool.EdgeMetadata)
@@ -13256,14 +13798,18 @@ func (m *ToolMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *ToolMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case tool.EdgeDocument:
-		if id := m.document; id != nil {
-			return []ent.Value{*id}
+	case tool.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.documents))
+		for id := range m.documents {
+			ids = append(ids, id)
 		}
+		return ids
 	case tool.EdgeMetadata:
-		if id := m.metadata; id != nil {
-			return []ent.Value{*id}
+		ids := make([]ent.Value, 0, len(m.metadata))
+		for id := range m.metadata {
+			ids = append(ids, id)
 		}
+		return ids
 	}
 	return nil
 }
@@ -13271,20 +13817,40 @@ func (m *ToolMutation) AddedIDs(name string) []ent.Value {
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *ToolMutation) RemovedEdges() []string {
 	edges := make([]string, 0, 2)
+	if m.removeddocuments != nil {
+		edges = append(edges, tool.EdgeDocuments)
+	}
+	if m.removedmetadata != nil {
+		edges = append(edges, tool.EdgeMetadata)
+	}
 	return edges
 }
 
 // RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
 // the given name in this mutation.
 func (m *ToolMutation) RemovedIDs(name string) []ent.Value {
+	switch name {
+	case tool.EdgeDocuments:
+		ids := make([]ent.Value, 0, len(m.removeddocuments))
+		for id := range m.removeddocuments {
+			ids = append(ids, id)
+		}
+		return ids
+	case tool.EdgeMetadata:
+		ids := make([]ent.Value, 0, len(m.removedmetadata))
+		for id := range m.removedmetadata {
+			ids = append(ids, id)
+		}
+		return ids
+	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *ToolMutation) ClearedEdges() []string {
 	edges := make([]string, 0, 2)
-	if m.cleareddocument {
-		edges = append(edges, tool.EdgeDocument)
+	if m.cleareddocuments {
+		edges = append(edges, tool.EdgeDocuments)
 	}
 	if m.clearedmetadata {
 		edges = append(edges, tool.EdgeMetadata)
@@ -13296,8 +13862,8 @@ func (m *ToolMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *ToolMutation) EdgeCleared(name string) bool {
 	switch name {
-	case tool.EdgeDocument:
-		return m.cleareddocument
+	case tool.EdgeDocuments:
+		return m.cleareddocuments
 	case tool.EdgeMetadata:
 		return m.clearedmetadata
 	}
@@ -13308,12 +13874,6 @@ func (m *ToolMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *ToolMutation) ClearEdge(name string) error {
 	switch name {
-	case tool.EdgeDocument:
-		m.ClearDocument()
-		return nil
-	case tool.EdgeMetadata:
-		m.ClearMetadata()
-		return nil
 	}
 	return fmt.Errorf("unknown Tool unique edge %s", name)
 }
@@ -13322,8 +13882,8 @@ func (m *ToolMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *ToolMutation) ResetEdge(name string) error {
 	switch name {
-	case tool.EdgeDocument:
-		m.ResetDocument()
+	case tool.EdgeDocuments:
+		m.ResetDocuments()
 		return nil
 	case tool.EdgeMetadata:
 		m.ResetMetadata()

--- a/internal/backends/ent/node.go
+++ b/internal/backends/ent/node.go
@@ -17,7 +17,6 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/google/uuid"
 	"github.com/protobom/protobom/pkg/sbom"
-	"github.com/protobom/storage/internal/backends/ent/document"
 	"github.com/protobom/storage/internal/backends/ent/node"
 )
 
@@ -26,14 +25,10 @@ type Node struct {
 	config `json:"-"`
 	// ID of the ent.
 	ID uuid.UUID `json:"-"`
-	// DocumentID holds the value of the "document_id" field.
-	DocumentID uuid.UUID `json:"-"`
 	// ProtoMessage holds the value of the "proto_message" field.
 	ProtoMessage *sbom.Node `json:"-"`
 	// NativeID holds the value of the "native_id" field.
 	NativeID string `json:"id"`
-	// NodeListID holds the value of the "node_list_id" field.
-	NodeListID uuid.UUID `json:"node_list_id,omitempty"`
 	// Type holds the value of the "type" field.
 	Type node.Type `json:"type,omitempty"`
 	// Name holds the value of the "name" field.
@@ -80,8 +75,6 @@ type Node struct {
 
 // NodeEdges holds the relations/edges for other nodes in the graph.
 type NodeEdges struct {
-	// Document holds the value of the document edge.
-	Document *Document `json:"document,omitempty"`
 	// Annotations holds the value of the annotations edge.
 	Annotations []*Annotation `json:"-"`
 	// Suppliers holds the value of the suppliers edge.
@@ -102,6 +95,8 @@ type NodeEdges struct {
 	Identifiers []*IdentifiersEntry `json:"identifiers,omitempty"`
 	// Properties holds the value of the properties edge.
 	Properties []*Property `json:"properties,omitempty"`
+	// Documents holds the value of the documents edge.
+	Documents []*Document `json:"-"`
 	// NodeLists holds the value of the node_lists edge.
 	NodeLists []*NodeList `json:"-"`
 	// EdgeTypes holds the value of the edge_types edge.
@@ -111,21 +106,10 @@ type NodeEdges struct {
 	loadedTypes [13]bool
 }
 
-// DocumentOrErr returns the Document value or an error if the edge
-// was not loaded in eager-loading, or loaded but was not found.
-func (e NodeEdges) DocumentOrErr() (*Document, error) {
-	if e.Document != nil {
-		return e.Document, nil
-	} else if e.loadedTypes[0] {
-		return nil, &NotFoundError{label: document.Label}
-	}
-	return nil, &NotLoadedError{edge: "document"}
-}
-
 // AnnotationsOrErr returns the Annotations value or an error if the edge
 // was not loaded in eager-loading.
 func (e NodeEdges) AnnotationsOrErr() ([]*Annotation, error) {
-	if e.loadedTypes[1] {
+	if e.loadedTypes[0] {
 		return e.Annotations, nil
 	}
 	return nil, &NotLoadedError{edge: "annotations"}
@@ -134,7 +118,7 @@ func (e NodeEdges) AnnotationsOrErr() ([]*Annotation, error) {
 // SuppliersOrErr returns the Suppliers value or an error if the edge
 // was not loaded in eager-loading.
 func (e NodeEdges) SuppliersOrErr() ([]*Person, error) {
-	if e.loadedTypes[2] {
+	if e.loadedTypes[1] {
 		return e.Suppliers, nil
 	}
 	return nil, &NotLoadedError{edge: "suppliers"}
@@ -143,7 +127,7 @@ func (e NodeEdges) SuppliersOrErr() ([]*Person, error) {
 // OriginatorsOrErr returns the Originators value or an error if the edge
 // was not loaded in eager-loading.
 func (e NodeEdges) OriginatorsOrErr() ([]*Person, error) {
-	if e.loadedTypes[3] {
+	if e.loadedTypes[2] {
 		return e.Originators, nil
 	}
 	return nil, &NotLoadedError{edge: "originators"}
@@ -152,7 +136,7 @@ func (e NodeEdges) OriginatorsOrErr() ([]*Person, error) {
 // ExternalReferencesOrErr returns the ExternalReferences value or an error if the edge
 // was not loaded in eager-loading.
 func (e NodeEdges) ExternalReferencesOrErr() ([]*ExternalReference, error) {
-	if e.loadedTypes[4] {
+	if e.loadedTypes[3] {
 		return e.ExternalReferences, nil
 	}
 	return nil, &NotLoadedError{edge: "external_references"}
@@ -161,7 +145,7 @@ func (e NodeEdges) ExternalReferencesOrErr() ([]*ExternalReference, error) {
 // PrimaryPurposeOrErr returns the PrimaryPurpose value or an error if the edge
 // was not loaded in eager-loading.
 func (e NodeEdges) PrimaryPurposeOrErr() ([]*Purpose, error) {
-	if e.loadedTypes[5] {
+	if e.loadedTypes[4] {
 		return e.PrimaryPurpose, nil
 	}
 	return nil, &NotLoadedError{edge: "primary_purpose"}
@@ -170,7 +154,7 @@ func (e NodeEdges) PrimaryPurposeOrErr() ([]*Purpose, error) {
 // ToNodesOrErr returns the ToNodes value or an error if the edge
 // was not loaded in eager-loading.
 func (e NodeEdges) ToNodesOrErr() ([]*Node, error) {
-	if e.loadedTypes[6] {
+	if e.loadedTypes[5] {
 		return e.ToNodes, nil
 	}
 	return nil, &NotLoadedError{edge: "to_nodes"}
@@ -179,7 +163,7 @@ func (e NodeEdges) ToNodesOrErr() ([]*Node, error) {
 // NodesOrErr returns the Nodes value or an error if the edge
 // was not loaded in eager-loading.
 func (e NodeEdges) NodesOrErr() ([]*Node, error) {
-	if e.loadedTypes[7] {
+	if e.loadedTypes[6] {
 		return e.Nodes, nil
 	}
 	return nil, &NotLoadedError{edge: "nodes"}
@@ -188,7 +172,7 @@ func (e NodeEdges) NodesOrErr() ([]*Node, error) {
 // HashesOrErr returns the Hashes value or an error if the edge
 // was not loaded in eager-loading.
 func (e NodeEdges) HashesOrErr() ([]*HashesEntry, error) {
-	if e.loadedTypes[8] {
+	if e.loadedTypes[7] {
 		return e.Hashes, nil
 	}
 	return nil, &NotLoadedError{edge: "hashes"}
@@ -197,7 +181,7 @@ func (e NodeEdges) HashesOrErr() ([]*HashesEntry, error) {
 // IdentifiersOrErr returns the Identifiers value or an error if the edge
 // was not loaded in eager-loading.
 func (e NodeEdges) IdentifiersOrErr() ([]*IdentifiersEntry, error) {
-	if e.loadedTypes[9] {
+	if e.loadedTypes[8] {
 		return e.Identifiers, nil
 	}
 	return nil, &NotLoadedError{edge: "identifiers"}
@@ -206,10 +190,19 @@ func (e NodeEdges) IdentifiersOrErr() ([]*IdentifiersEntry, error) {
 // PropertiesOrErr returns the Properties value or an error if the edge
 // was not loaded in eager-loading.
 func (e NodeEdges) PropertiesOrErr() ([]*Property, error) {
-	if e.loadedTypes[10] {
+	if e.loadedTypes[9] {
 		return e.Properties, nil
 	}
 	return nil, &NotLoadedError{edge: "properties"}
+}
+
+// DocumentsOrErr returns the Documents value or an error if the edge
+// was not loaded in eager-loading.
+func (e NodeEdges) DocumentsOrErr() ([]*Document, error) {
+	if e.loadedTypes[10] {
+		return e.Documents, nil
+	}
+	return nil, &NotLoadedError{edge: "documents"}
 }
 
 // NodeListsOrErr returns the NodeLists value or an error if the edge
@@ -243,7 +236,7 @@ func (*Node) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullString)
 		case node.FieldReleaseDate, node.FieldBuildDate, node.FieldValidUntilDate:
 			values[i] = new(sql.NullTime)
-		case node.FieldID, node.FieldDocumentID, node.FieldNodeListID:
+		case node.FieldID:
 			values[i] = new(uuid.UUID)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -266,12 +259,6 @@ func (n *Node) assignValues(columns []string, values []any) error {
 			} else if value != nil {
 				n.ID = *value
 			}
-		case node.FieldDocumentID:
-			if value, ok := values[i].(*uuid.UUID); !ok {
-				return fmt.Errorf("unexpected type %T for field document_id", values[i])
-			} else if value != nil {
-				n.DocumentID = *value
-			}
 		case node.FieldProtoMessage:
 			if value, ok := values[i].(*sql.NullScanner); !ok {
 				return fmt.Errorf("unexpected type %T for field proto_message", values[i])
@@ -283,12 +270,6 @@ func (n *Node) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field native_id", values[i])
 			} else if value.Valid {
 				n.NativeID = value.String
-			}
-		case node.FieldNodeListID:
-			if value, ok := values[i].(*uuid.UUID); !ok {
-				return fmt.Errorf("unexpected type %T for field node_list_id", values[i])
-			} else if value != nil {
-				n.NodeListID = *value
 			}
 		case node.FieldType:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -423,11 +404,6 @@ func (n *Node) Value(name string) (ent.Value, error) {
 	return n.selectValues.Get(name)
 }
 
-// QueryDocument queries the "document" edge of the Node entity.
-func (n *Node) QueryDocument() *DocumentQuery {
-	return NewNodeClient(n.config).QueryDocument(n)
-}
-
 // QueryAnnotations queries the "annotations" edge of the Node entity.
 func (n *Node) QueryAnnotations() *AnnotationQuery {
 	return NewNodeClient(n.config).QueryAnnotations(n)
@@ -478,6 +454,11 @@ func (n *Node) QueryProperties() *PropertyQuery {
 	return NewNodeClient(n.config).QueryProperties(n)
 }
 
+// QueryDocuments queries the "documents" edge of the Node entity.
+func (n *Node) QueryDocuments() *DocumentQuery {
+	return NewNodeClient(n.config).QueryDocuments(n)
+}
+
 // QueryNodeLists queries the "node_lists" edge of the Node entity.
 func (n *Node) QueryNodeLists() *NodeListQuery {
 	return NewNodeClient(n.config).QueryNodeLists(n)
@@ -511,9 +492,6 @@ func (n *Node) String() string {
 	var builder strings.Builder
 	builder.WriteString("Node(")
 	builder.WriteString(fmt.Sprintf("id=%v, ", n.ID))
-	builder.WriteString("document_id=")
-	builder.WriteString(fmt.Sprintf("%v", n.DocumentID))
-	builder.WriteString(", ")
 	if v := n.ProtoMessage; v != nil {
 		builder.WriteString("proto_message=")
 		builder.WriteString(fmt.Sprintf("%v", *v))
@@ -521,9 +499,6 @@ func (n *Node) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("native_id=")
 	builder.WriteString(n.NativeID)
-	builder.WriteString(", ")
-	builder.WriteString("node_list_id=")
-	builder.WriteString(fmt.Sprintf("%v", n.NodeListID))
 	builder.WriteString(", ")
 	builder.WriteString("type=")
 	builder.WriteString(fmt.Sprintf("%v", n.Type))

--- a/internal/backends/ent/node/node.go
+++ b/internal/backends/ent/node/node.go
@@ -21,14 +21,10 @@ const (
 	Label = "node"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
-	// FieldDocumentID holds the string denoting the document_id field in the database.
-	FieldDocumentID = "document_id"
 	// FieldProtoMessage holds the string denoting the proto_message field in the database.
 	FieldProtoMessage = "proto_message"
 	// FieldNativeID holds the string denoting the native_id field in the database.
 	FieldNativeID = "native_id"
-	// FieldNodeListID holds the string denoting the node_list_id field in the database.
-	FieldNodeListID = "node_list_id"
 	// FieldType holds the string denoting the type field in the database.
 	FieldType = "type"
 	// FieldName holds the string denoting the name field in the database.
@@ -67,8 +63,6 @@ const (
 	FieldAttribution = "attribution"
 	// FieldFileTypes holds the string denoting the file_types field in the database.
 	FieldFileTypes = "file_types"
-	// EdgeDocument holds the string denoting the document edge name in mutations.
-	EdgeDocument = "document"
 	// EdgeAnnotations holds the string denoting the annotations edge name in mutations.
 	EdgeAnnotations = "annotations"
 	// EdgeSuppliers holds the string denoting the suppliers edge name in mutations.
@@ -89,19 +83,14 @@ const (
 	EdgeIdentifiers = "identifiers"
 	// EdgeProperties holds the string denoting the properties edge name in mutations.
 	EdgeProperties = "properties"
+	// EdgeDocuments holds the string denoting the documents edge name in mutations.
+	EdgeDocuments = "documents"
 	// EdgeNodeLists holds the string denoting the node_lists edge name in mutations.
 	EdgeNodeLists = "node_lists"
 	// EdgeEdgeTypes holds the string denoting the edge_types edge name in mutations.
 	EdgeEdgeTypes = "edge_types"
 	// Table holds the table name of the node in the database.
 	Table = "nodes"
-	// DocumentTable is the table that holds the document relation/edge.
-	DocumentTable = "nodes"
-	// DocumentInverseTable is the table name for the Document entity.
-	// It exists in this package in order to avoid circular dependency with the "document" package.
-	DocumentInverseTable = "documents"
-	// DocumentColumn is the table column denoting the document relation/edge.
-	DocumentColumn = "document_id"
 	// AnnotationsTable is the table that holds the annotations relation/edge.
 	AnnotationsTable = "annotations"
 	// AnnotationsInverseTable is the table name for the Annotation entity.
@@ -109,32 +98,26 @@ const (
 	AnnotationsInverseTable = "annotations"
 	// AnnotationsColumn is the table column denoting the annotations relation/edge.
 	AnnotationsColumn = "node_id"
-	// SuppliersTable is the table that holds the suppliers relation/edge.
-	SuppliersTable = "persons"
+	// SuppliersTable is the table that holds the suppliers relation/edge. The primary key declared below.
+	SuppliersTable = "node_suppliers"
 	// SuppliersInverseTable is the table name for the Person entity.
 	// It exists in this package in order to avoid circular dependency with the "person" package.
 	SuppliersInverseTable = "persons"
-	// SuppliersColumn is the table column denoting the suppliers relation/edge.
-	SuppliersColumn = "node_suppliers"
-	// OriginatorsTable is the table that holds the originators relation/edge.
-	OriginatorsTable = "persons"
+	// OriginatorsTable is the table that holds the originators relation/edge. The primary key declared below.
+	OriginatorsTable = "node_originators"
 	// OriginatorsInverseTable is the table name for the Person entity.
 	// It exists in this package in order to avoid circular dependency with the "person" package.
 	OriginatorsInverseTable = "persons"
-	// OriginatorsColumn is the table column denoting the originators relation/edge.
-	OriginatorsColumn = "node_id"
 	// ExternalReferencesTable is the table that holds the external_references relation/edge. The primary key declared below.
 	ExternalReferencesTable = "node_external_references"
 	// ExternalReferencesInverseTable is the table name for the ExternalReference entity.
 	// It exists in this package in order to avoid circular dependency with the "externalreference" package.
 	ExternalReferencesInverseTable = "external_references"
-	// PrimaryPurposeTable is the table that holds the primary_purpose relation/edge.
-	PrimaryPurposeTable = "purposes"
+	// PrimaryPurposeTable is the table that holds the primary_purpose relation/edge. The primary key declared below.
+	PrimaryPurposeTable = "node_primary_purposes"
 	// PrimaryPurposeInverseTable is the table name for the Purpose entity.
 	// It exists in this package in order to avoid circular dependency with the "purpose" package.
 	PrimaryPurposeInverseTable = "purposes"
-	// PrimaryPurposeColumn is the table column denoting the primary_purpose relation/edge.
-	PrimaryPurposeColumn = "node_id"
 	// ToNodesTable is the table that holds the to_nodes relation/edge. The primary key declared below.
 	ToNodesTable = "edge_types"
 	// NodesTable is the table that holds the nodes relation/edge. The primary key declared below.
@@ -149,13 +132,16 @@ const (
 	// IdentifiersInverseTable is the table name for the IdentifiersEntry entity.
 	// It exists in this package in order to avoid circular dependency with the "identifiersentry" package.
 	IdentifiersInverseTable = "identifiers_entries"
-	// PropertiesTable is the table that holds the properties relation/edge.
-	PropertiesTable = "properties"
+	// PropertiesTable is the table that holds the properties relation/edge. The primary key declared below.
+	PropertiesTable = "node_properties"
 	// PropertiesInverseTable is the table name for the Property entity.
 	// It exists in this package in order to avoid circular dependency with the "property" package.
 	PropertiesInverseTable = "properties"
-	// PropertiesColumn is the table column denoting the properties relation/edge.
-	PropertiesColumn = "node_id"
+	// DocumentsTable is the table that holds the documents relation/edge. The primary key declared below.
+	DocumentsTable = "document_nodes"
+	// DocumentsInverseTable is the table name for the Document entity.
+	// It exists in this package in order to avoid circular dependency with the "document" package.
+	DocumentsInverseTable = "documents"
 	// NodeListsTable is the table that holds the node_lists relation/edge. The primary key declared below.
 	NodeListsTable = "node_list_nodes"
 	// NodeListsInverseTable is the table name for the NodeList entity.
@@ -173,10 +159,8 @@ const (
 // Columns holds all SQL columns for node fields.
 var Columns = []string{
 	FieldID,
-	FieldDocumentID,
 	FieldProtoMessage,
 	FieldNativeID,
-	FieldNodeListID,
 	FieldType,
 	FieldName,
 	FieldVersion,
@@ -199,9 +183,18 @@ var Columns = []string{
 }
 
 var (
+	// SuppliersPrimaryKey and SuppliersColumn2 are the table columns denoting the
+	// primary key for the suppliers relation (M2M).
+	SuppliersPrimaryKey = []string{"node_id", "person_id"}
+	// OriginatorsPrimaryKey and OriginatorsColumn2 are the table columns denoting the
+	// primary key for the originators relation (M2M).
+	OriginatorsPrimaryKey = []string{"node_id", "person_id"}
 	// ExternalReferencesPrimaryKey and ExternalReferencesColumn2 are the table columns denoting the
 	// primary key for the external_references relation (M2M).
 	ExternalReferencesPrimaryKey = []string{"node_id", "external_reference_id"}
+	// PrimaryPurposePrimaryKey and PrimaryPurposeColumn2 are the table columns denoting the
+	// primary key for the primary_purpose relation (M2M).
+	PrimaryPurposePrimaryKey = []string{"node_id", "purpose_id"}
 	// ToNodesPrimaryKey and ToNodesColumn2 are the table columns denoting the
 	// primary key for the to_nodes relation (M2M).
 	ToNodesPrimaryKey = []string{"node_id", "to_node_id"}
@@ -214,6 +207,12 @@ var (
 	// IdentifiersPrimaryKey and IdentifiersColumn2 are the table columns denoting the
 	// primary key for the identifiers relation (M2M).
 	IdentifiersPrimaryKey = []string{"node_id", "identifier_entry_id"}
+	// PropertiesPrimaryKey and PropertiesColumn2 are the table columns denoting the
+	// primary key for the properties relation (M2M).
+	PropertiesPrimaryKey = []string{"node_id", "property_id"}
+	// DocumentsPrimaryKey and DocumentsColumn2 are the table columns denoting the
+	// primary key for the documents relation (M2M).
+	DocumentsPrimaryKey = []string{"document_id", "node_id"}
 	// NodeListsPrimaryKey and NodeListsColumn2 are the table columns denoting the
 	// primary key for the node_lists relation (M2M).
 	NodeListsPrimaryKey = []string{"node_list_id", "node_id"}
@@ -236,8 +235,6 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/protobom/storage/internal/backends/ent/runtime"
 var (
 	Hooks [1]ent.Hook
-	// DefaultDocumentID holds the default value on creation for the "document_id" field.
-	DefaultDocumentID func() uuid.UUID
 	// NativeIDValidator is a validator for the "native_id" field. It is called by the builders before save.
 	NativeIDValidator func(string) error
 	// DefaultID holds the default value on creation for the "id" field.
@@ -275,19 +272,9 @@ func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
-// ByDocumentID orders the results by the document_id field.
-func ByDocumentID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldDocumentID, opts...).ToFunc()
-}
-
 // ByNativeID orders the results by the native_id field.
 func ByNativeID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNativeID, opts...).ToFunc()
-}
-
-// ByNodeListID orders the results by the node_list_id field.
-func ByNodeListID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldNodeListID, opts...).ToFunc()
 }
 
 // ByType orders the results by the type field.
@@ -368,13 +355,6 @@ func ByBuildDate(opts ...sql.OrderTermOption) OrderOption {
 // ByValidUntilDate orders the results by the valid_until_date field.
 func ByValidUntilDate(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldValidUntilDate, opts...).ToFunc()
-}
-
-// ByDocumentField orders the results by document field.
-func ByDocumentField(field string, opts ...sql.OrderTermOption) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newDocumentStep(), sql.OrderByField(field, opts...))
-	}
 }
 
 // ByAnnotationsCount orders the results by annotations count.
@@ -517,6 +497,20 @@ func ByProperties(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	}
 }
 
+// ByDocumentsCount orders the results by documents count.
+func ByDocumentsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newDocumentsStep(), opts...)
+	}
+}
+
+// ByDocuments orders the results by documents terms.
+func ByDocuments(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newDocumentsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
 // ByNodeListsCount orders the results by node_lists count.
 func ByNodeListsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -544,13 +538,6 @@ func ByEdgeTypes(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 		sqlgraph.OrderByNeighborTerms(s, newEdgeTypesStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
-func newDocumentStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(DocumentInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
-	)
-}
 func newAnnotationsStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
@@ -562,14 +549,14 @@ func newSuppliersStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(SuppliersInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2M, false, SuppliersTable, SuppliersColumn),
+		sqlgraph.Edge(sqlgraph.M2M, false, SuppliersTable, SuppliersPrimaryKey...),
 	)
 }
 func newOriginatorsStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(OriginatorsInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2M, false, OriginatorsTable, OriginatorsColumn),
+		sqlgraph.Edge(sqlgraph.M2M, false, OriginatorsTable, OriginatorsPrimaryKey...),
 	)
 }
 func newExternalReferencesStep() *sqlgraph.Step {
@@ -583,7 +570,7 @@ func newPrimaryPurposeStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(PrimaryPurposeInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2M, false, PrimaryPurposeTable, PrimaryPurposeColumn),
+		sqlgraph.Edge(sqlgraph.M2M, false, PrimaryPurposeTable, PrimaryPurposePrimaryKey...),
 	)
 }
 func newToNodesStep() *sqlgraph.Step {
@@ -618,7 +605,14 @@ func newPropertiesStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(PropertiesInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2M, false, PropertiesTable, PropertiesColumn),
+		sqlgraph.Edge(sqlgraph.M2M, false, PropertiesTable, PropertiesPrimaryKey...),
+	)
+}
+func newDocumentsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(DocumentsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
 	)
 }
 func newNodeListsStep() *sqlgraph.Step {

--- a/internal/backends/ent/node/where.go
+++ b/internal/backends/ent/node/where.go
@@ -62,11 +62,6 @@ func IDLTE(id uuid.UUID) predicate.Node {
 	return predicate.Node(sql.FieldLTE(FieldID, id))
 }
 
-// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
-func DocumentID(v uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldEQ(FieldDocumentID, v))
-}
-
 // ProtoMessage applies equality check predicate on the "proto_message" field. It's identical to ProtoMessageEQ.
 func ProtoMessage(v *sbom.Node) predicate.Node {
 	return predicate.Node(sql.FieldEQ(FieldProtoMessage, v))
@@ -75,11 +70,6 @@ func ProtoMessage(v *sbom.Node) predicate.Node {
 // NativeID applies equality check predicate on the "native_id" field. It's identical to NativeIDEQ.
 func NativeID(v string) predicate.Node {
 	return predicate.Node(sql.FieldEQ(FieldNativeID, v))
-}
-
-// NodeListID applies equality check predicate on the "node_list_id" field. It's identical to NodeListIDEQ.
-func NodeListID(v uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldEQ(FieldNodeListID, v))
 }
 
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
@@ -155,36 +145,6 @@ func BuildDate(v time.Time) predicate.Node {
 // ValidUntilDate applies equality check predicate on the "valid_until_date" field. It's identical to ValidUntilDateEQ.
 func ValidUntilDate(v time.Time) predicate.Node {
 	return predicate.Node(sql.FieldEQ(FieldValidUntilDate, v))
-}
-
-// DocumentIDEQ applies the EQ predicate on the "document_id" field.
-func DocumentIDEQ(v uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldEQ(FieldDocumentID, v))
-}
-
-// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
-func DocumentIDNEQ(v uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldNEQ(FieldDocumentID, v))
-}
-
-// DocumentIDIn applies the In predicate on the "document_id" field.
-func DocumentIDIn(vs ...uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
-func DocumentIDNotIn(vs ...uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldNotIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDIsNil applies the IsNil predicate on the "document_id" field.
-func DocumentIDIsNil() predicate.Node {
-	return predicate.Node(sql.FieldIsNull(FieldDocumentID))
-}
-
-// DocumentIDNotNil applies the NotNil predicate on the "document_id" field.
-func DocumentIDNotNil() predicate.Node {
-	return predicate.Node(sql.FieldNotNull(FieldDocumentID))
 }
 
 // ProtoMessageEQ applies the EQ predicate on the "proto_message" field.
@@ -290,56 +250,6 @@ func NativeIDEqualFold(v string) predicate.Node {
 // NativeIDContainsFold applies the ContainsFold predicate on the "native_id" field.
 func NativeIDContainsFold(v string) predicate.Node {
 	return predicate.Node(sql.FieldContainsFold(FieldNativeID, v))
-}
-
-// NodeListIDEQ applies the EQ predicate on the "node_list_id" field.
-func NodeListIDEQ(v uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldEQ(FieldNodeListID, v))
-}
-
-// NodeListIDNEQ applies the NEQ predicate on the "node_list_id" field.
-func NodeListIDNEQ(v uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldNEQ(FieldNodeListID, v))
-}
-
-// NodeListIDIn applies the In predicate on the "node_list_id" field.
-func NodeListIDIn(vs ...uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldIn(FieldNodeListID, vs...))
-}
-
-// NodeListIDNotIn applies the NotIn predicate on the "node_list_id" field.
-func NodeListIDNotIn(vs ...uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldNotIn(FieldNodeListID, vs...))
-}
-
-// NodeListIDGT applies the GT predicate on the "node_list_id" field.
-func NodeListIDGT(v uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldGT(FieldNodeListID, v))
-}
-
-// NodeListIDGTE applies the GTE predicate on the "node_list_id" field.
-func NodeListIDGTE(v uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldGTE(FieldNodeListID, v))
-}
-
-// NodeListIDLT applies the LT predicate on the "node_list_id" field.
-func NodeListIDLT(v uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldLT(FieldNodeListID, v))
-}
-
-// NodeListIDLTE applies the LTE predicate on the "node_list_id" field.
-func NodeListIDLTE(v uuid.UUID) predicate.Node {
-	return predicate.Node(sql.FieldLTE(FieldNodeListID, v))
-}
-
-// NodeListIDIsNil applies the IsNil predicate on the "node_list_id" field.
-func NodeListIDIsNil() predicate.Node {
-	return predicate.Node(sql.FieldIsNull(FieldNodeListID))
-}
-
-// NodeListIDNotNil applies the NotNil predicate on the "node_list_id" field.
-func NodeListIDNotNil() predicate.Node {
-	return predicate.Node(sql.FieldNotNull(FieldNodeListID))
 }
 
 // TypeEQ applies the EQ predicate on the "type" field.
@@ -1262,29 +1172,6 @@ func ValidUntilDateLTE(v time.Time) predicate.Node {
 	return predicate.Node(sql.FieldLTE(FieldValidUntilDate, v))
 }
 
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		step := newDocumentStep()
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
 // HasAnnotations applies the HasEdge predicate on the "annotations" edge.
 func HasAnnotations() predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
@@ -1313,7 +1200,7 @@ func HasSuppliers() predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, SuppliersTable, SuppliersColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, SuppliersTable, SuppliersPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -1336,7 +1223,7 @@ func HasOriginators() predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, OriginatorsTable, OriginatorsColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, OriginatorsTable, OriginatorsPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -1382,7 +1269,7 @@ func HasPrimaryPurpose() predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, PrimaryPurposeTable, PrimaryPurposeColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, PrimaryPurposeTable, PrimaryPurposePrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -1497,7 +1384,7 @@ func HasProperties() predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, PropertiesTable, PropertiesColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, PropertiesTable, PropertiesPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -1507,6 +1394,29 @@ func HasProperties() predicate.Node {
 func HasPropertiesWith(preds ...predicate.Property) predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
 		step := newPropertiesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasDocuments applies the HasEdge predicate on the "documents" edge.
+func HasDocuments() predicate.Node {
+	return predicate.Node(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasDocumentsWith applies the HasEdge predicate on the "documents" edge with a given conditions (other predicates).
+func HasDocumentsWith(preds ...predicate.Document) predicate.Node {
+	return predicate.Node(func(s *sql.Selector) {
+		step := newDocumentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/backends/ent/node_update.go
+++ b/internal/backends/ent/node_update.go
@@ -44,26 +44,6 @@ func (nu *NodeUpdate) Where(ps ...predicate.Node) *NodeUpdate {
 	return nu
 }
 
-// SetNodeListID sets the "node_list_id" field.
-func (nu *NodeUpdate) SetNodeListID(u uuid.UUID) *NodeUpdate {
-	nu.mutation.SetNodeListID(u)
-	return nu
-}
-
-// SetNillableNodeListID sets the "node_list_id" field if the given value is not nil.
-func (nu *NodeUpdate) SetNillableNodeListID(u *uuid.UUID) *NodeUpdate {
-	if u != nil {
-		nu.SetNodeListID(*u)
-	}
-	return nu
-}
-
-// ClearNodeListID clears the value of the "node_list_id" field.
-func (nu *NodeUpdate) ClearNodeListID() *NodeUpdate {
-	nu.mutation.ClearNodeListID()
-	return nu
-}
-
 // SetType sets the "type" field.
 func (nu *NodeUpdate) SetType(n node.Type) *NodeUpdate {
 	nu.mutation.SetType(n)
@@ -810,12 +790,6 @@ func (nu *NodeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			}
 		}
 	}
-	if value, ok := nu.mutation.NodeListID(); ok {
-		_spec.SetField(node.FieldNodeListID, field.TypeUUID, value)
-	}
-	if nu.mutation.NodeListIDCleared() {
-		_spec.ClearField(node.FieldNodeListID, field.TypeUUID)
-	}
 	if value, ok := nu.mutation.GetType(); ok {
 		_spec.SetField(node.FieldType, field.TypeEnum, value)
 	}
@@ -935,10 +909,10 @@ func (nu *NodeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nu.mutation.SuppliersCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.SuppliersTable,
-			Columns: []string{node.SuppliersColumn},
+			Columns: node.SuppliersPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -948,10 +922,10 @@ func (nu *NodeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := nu.mutation.RemovedSuppliersIDs(); len(nodes) > 0 && !nu.mutation.SuppliersCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.SuppliersTable,
-			Columns: []string{node.SuppliersColumn},
+			Columns: node.SuppliersPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -964,10 +938,10 @@ func (nu *NodeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := nu.mutation.SuppliersIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.SuppliersTable,
-			Columns: []string{node.SuppliersColumn},
+			Columns: node.SuppliersPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -980,10 +954,10 @@ func (nu *NodeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nu.mutation.OriginatorsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.OriginatorsTable,
-			Columns: []string{node.OriginatorsColumn},
+			Columns: node.OriginatorsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -993,10 +967,10 @@ func (nu *NodeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := nu.mutation.RemovedOriginatorsIDs(); len(nodes) > 0 && !nu.mutation.OriginatorsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.OriginatorsTable,
-			Columns: []string{node.OriginatorsColumn},
+			Columns: node.OriginatorsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -1009,10 +983,10 @@ func (nu *NodeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := nu.mutation.OriginatorsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.OriginatorsTable,
-			Columns: []string{node.OriginatorsColumn},
+			Columns: node.OriginatorsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -1070,10 +1044,10 @@ func (nu *NodeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nu.mutation.PrimaryPurposeCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.PrimaryPurposeTable,
-			Columns: []string{node.PrimaryPurposeColumn},
+			Columns: node.PrimaryPurposePrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(purpose.FieldID, field.TypeInt),
@@ -1083,10 +1057,10 @@ func (nu *NodeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := nu.mutation.RemovedPrimaryPurposeIDs(); len(nodes) > 0 && !nu.mutation.PrimaryPurposeCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.PrimaryPurposeTable,
-			Columns: []string{node.PrimaryPurposeColumn},
+			Columns: node.PrimaryPurposePrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(purpose.FieldID, field.TypeInt),
@@ -1099,10 +1073,10 @@ func (nu *NodeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := nu.mutation.PrimaryPurposeIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.PrimaryPurposeTable,
-			Columns: []string{node.PrimaryPurposeColumn},
+			Columns: node.PrimaryPurposePrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(purpose.FieldID, field.TypeInt),
@@ -1316,10 +1290,10 @@ func (nu *NodeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nu.mutation.PropertiesCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.PropertiesTable,
-			Columns: []string{node.PropertiesColumn},
+			Columns: node.PropertiesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID),
@@ -1329,10 +1303,10 @@ func (nu *NodeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := nu.mutation.RemovedPropertiesIDs(); len(nodes) > 0 && !nu.mutation.PropertiesCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.PropertiesTable,
-			Columns: []string{node.PropertiesColumn},
+			Columns: node.PropertiesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID),
@@ -1345,10 +1319,10 @@ func (nu *NodeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := nu.mutation.PropertiesIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.PropertiesTable,
-			Columns: []string{node.PropertiesColumn},
+			Columns: node.PropertiesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID),
@@ -1467,26 +1441,6 @@ type NodeUpdateOne struct {
 	fields   []string
 	hooks    []Hook
 	mutation *NodeMutation
-}
-
-// SetNodeListID sets the "node_list_id" field.
-func (nuo *NodeUpdateOne) SetNodeListID(u uuid.UUID) *NodeUpdateOne {
-	nuo.mutation.SetNodeListID(u)
-	return nuo
-}
-
-// SetNillableNodeListID sets the "node_list_id" field if the given value is not nil.
-func (nuo *NodeUpdateOne) SetNillableNodeListID(u *uuid.UUID) *NodeUpdateOne {
-	if u != nil {
-		nuo.SetNodeListID(*u)
-	}
-	return nuo
-}
-
-// ClearNodeListID clears the value of the "node_list_id" field.
-func (nuo *NodeUpdateOne) ClearNodeListID() *NodeUpdateOne {
-	nuo.mutation.ClearNodeListID()
-	return nuo
 }
 
 // SetType sets the "type" field.
@@ -2265,12 +2219,6 @@ func (nuo *NodeUpdateOne) sqlSave(ctx context.Context) (_node *Node, err error) 
 			}
 		}
 	}
-	if value, ok := nuo.mutation.NodeListID(); ok {
-		_spec.SetField(node.FieldNodeListID, field.TypeUUID, value)
-	}
-	if nuo.mutation.NodeListIDCleared() {
-		_spec.ClearField(node.FieldNodeListID, field.TypeUUID)
-	}
 	if value, ok := nuo.mutation.GetType(); ok {
 		_spec.SetField(node.FieldType, field.TypeEnum, value)
 	}
@@ -2390,10 +2338,10 @@ func (nuo *NodeUpdateOne) sqlSave(ctx context.Context) (_node *Node, err error) 
 	}
 	if nuo.mutation.SuppliersCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.SuppliersTable,
-			Columns: []string{node.SuppliersColumn},
+			Columns: node.SuppliersPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -2403,10 +2351,10 @@ func (nuo *NodeUpdateOne) sqlSave(ctx context.Context) (_node *Node, err error) 
 	}
 	if nodes := nuo.mutation.RemovedSuppliersIDs(); len(nodes) > 0 && !nuo.mutation.SuppliersCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.SuppliersTable,
-			Columns: []string{node.SuppliersColumn},
+			Columns: node.SuppliersPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -2419,10 +2367,10 @@ func (nuo *NodeUpdateOne) sqlSave(ctx context.Context) (_node *Node, err error) 
 	}
 	if nodes := nuo.mutation.SuppliersIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.SuppliersTable,
-			Columns: []string{node.SuppliersColumn},
+			Columns: node.SuppliersPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -2435,10 +2383,10 @@ func (nuo *NodeUpdateOne) sqlSave(ctx context.Context) (_node *Node, err error) 
 	}
 	if nuo.mutation.OriginatorsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.OriginatorsTable,
-			Columns: []string{node.OriginatorsColumn},
+			Columns: node.OriginatorsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -2448,10 +2396,10 @@ func (nuo *NodeUpdateOne) sqlSave(ctx context.Context) (_node *Node, err error) 
 	}
 	if nodes := nuo.mutation.RemovedOriginatorsIDs(); len(nodes) > 0 && !nuo.mutation.OriginatorsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.OriginatorsTable,
-			Columns: []string{node.OriginatorsColumn},
+			Columns: node.OriginatorsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -2464,10 +2412,10 @@ func (nuo *NodeUpdateOne) sqlSave(ctx context.Context) (_node *Node, err error) 
 	}
 	if nodes := nuo.mutation.OriginatorsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.OriginatorsTable,
-			Columns: []string{node.OriginatorsColumn},
+			Columns: node.OriginatorsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -2525,10 +2473,10 @@ func (nuo *NodeUpdateOne) sqlSave(ctx context.Context) (_node *Node, err error) 
 	}
 	if nuo.mutation.PrimaryPurposeCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.PrimaryPurposeTable,
-			Columns: []string{node.PrimaryPurposeColumn},
+			Columns: node.PrimaryPurposePrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(purpose.FieldID, field.TypeInt),
@@ -2538,10 +2486,10 @@ func (nuo *NodeUpdateOne) sqlSave(ctx context.Context) (_node *Node, err error) 
 	}
 	if nodes := nuo.mutation.RemovedPrimaryPurposeIDs(); len(nodes) > 0 && !nuo.mutation.PrimaryPurposeCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.PrimaryPurposeTable,
-			Columns: []string{node.PrimaryPurposeColumn},
+			Columns: node.PrimaryPurposePrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(purpose.FieldID, field.TypeInt),
@@ -2554,10 +2502,10 @@ func (nuo *NodeUpdateOne) sqlSave(ctx context.Context) (_node *Node, err error) 
 	}
 	if nodes := nuo.mutation.PrimaryPurposeIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.PrimaryPurposeTable,
-			Columns: []string{node.PrimaryPurposeColumn},
+			Columns: node.PrimaryPurposePrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(purpose.FieldID, field.TypeInt),
@@ -2771,10 +2719,10 @@ func (nuo *NodeUpdateOne) sqlSave(ctx context.Context) (_node *Node, err error) 
 	}
 	if nuo.mutation.PropertiesCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.PropertiesTable,
-			Columns: []string{node.PropertiesColumn},
+			Columns: node.PropertiesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID),
@@ -2784,10 +2732,10 @@ func (nuo *NodeUpdateOne) sqlSave(ctx context.Context) (_node *Node, err error) 
 	}
 	if nodes := nuo.mutation.RemovedPropertiesIDs(); len(nodes) > 0 && !nuo.mutation.PropertiesCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.PropertiesTable,
-			Columns: []string{node.PropertiesColumn},
+			Columns: node.PropertiesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID),
@@ -2800,10 +2748,10 @@ func (nuo *NodeUpdateOne) sqlSave(ctx context.Context) (_node *Node, err error) 
 	}
 	if nodes := nuo.mutation.PropertiesIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   node.PropertiesTable,
-			Columns: []string{node.PropertiesColumn},
+			Columns: node.PropertiesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(property.FieldID, field.TypeUUID),

--- a/internal/backends/ent/nodelist/where.go
+++ b/internal/backends/ent/nodelist/where.go
@@ -105,29 +105,6 @@ func ProtoMessageLTE(v *sbom.NodeList) predicate.NodeList {
 	return predicate.NodeList(sql.FieldLTE(FieldProtoMessage, v))
 }
 
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.NodeList {
-	return predicate.NodeList(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, DocumentTable, DocumentColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.NodeList {
-	return predicate.NodeList(func(s *sql.Selector) {
-		step := newDocumentStep()
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
 // HasEdgeTypes applies the HasEdge predicate on the "edge_types" edge.
 func HasEdgeTypes() predicate.NodeList {
 	return predicate.NodeList(func(s *sql.Selector) {
@@ -166,6 +143,29 @@ func HasNodes() predicate.NodeList {
 func HasNodesWith(preds ...predicate.Node) predicate.NodeList {
 	return predicate.NodeList(func(s *sql.Selector) {
 		step := newNodesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasDocuments applies the HasEdge predicate on the "documents" edge.
+func HasDocuments() predicate.NodeList {
+	return predicate.NodeList(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, true, DocumentsTable, DocumentsColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasDocumentsWith applies the HasEdge predicate on the "documents" edge with a given conditions (other predicates).
+func HasDocumentsWith(preds ...predicate.Document) predicate.NodeList {
+	return predicate.NodeList(func(s *sql.Selector) {
+		step := newDocumentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/backends/ent/nodelist_create.go
+++ b/internal/backends/ent/nodelist_create.go
@@ -58,17 +58,6 @@ func (nlc *NodeListCreate) SetNillableID(u *uuid.UUID) *NodeListCreate {
 	return nlc
 }
 
-// SetDocumentID sets the "document" edge to the Document entity by ID.
-func (nlc *NodeListCreate) SetDocumentID(id uuid.UUID) *NodeListCreate {
-	nlc.mutation.SetDocumentID(id)
-	return nlc
-}
-
-// SetDocument sets the "document" edge to the Document entity.
-func (nlc *NodeListCreate) SetDocument(d *Document) *NodeListCreate {
-	return nlc.SetDocumentID(d.ID)
-}
-
 // AddEdgeTypeIDs adds the "edge_types" edge to the EdgeType entity by IDs.
 func (nlc *NodeListCreate) AddEdgeTypeIDs(ids ...uuid.UUID) *NodeListCreate {
 	nlc.mutation.AddEdgeTypeIDs(ids...)
@@ -97,6 +86,21 @@ func (nlc *NodeListCreate) AddNodes(n ...*Node) *NodeListCreate {
 		ids[i] = n[i].ID
 	}
 	return nlc.AddNodeIDs(ids...)
+}
+
+// AddDocumentIDs adds the "documents" edge to the Document entity by IDs.
+func (nlc *NodeListCreate) AddDocumentIDs(ids ...uuid.UUID) *NodeListCreate {
+	nlc.mutation.AddDocumentIDs(ids...)
+	return nlc
+}
+
+// AddDocuments adds the "documents" edges to the Document entity.
+func (nlc *NodeListCreate) AddDocuments(d ...*Document) *NodeListCreate {
+	ids := make([]uuid.UUID, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return nlc.AddDocumentIDs(ids...)
 }
 
 // Mutation returns the NodeListMutation object of the builder.
@@ -154,8 +158,8 @@ func (nlc *NodeListCreate) check() error {
 	if _, ok := nlc.mutation.RootElements(); !ok {
 		return &ValidationError{Name: "root_elements", err: errors.New(`ent: missing required field "NodeList.root_elements"`)}
 	}
-	if len(nlc.mutation.DocumentIDs()) == 0 {
-		return &ValidationError{Name: "document", err: errors.New(`ent: missing required edge "NodeList.document"`)}
+	if len(nlc.mutation.DocumentsIDs()) == 0 {
+		return &ValidationError{Name: "documents", err: errors.New(`ent: missing required edge "NodeList.documents"`)}
 	}
 	return nil
 }
@@ -201,22 +205,6 @@ func (nlc *NodeListCreate) createSpec() (*NodeList, *sqlgraph.CreateSpec) {
 		_spec.SetField(nodelist.FieldRootElements, field.TypeJSON, value)
 		_node.RootElements = value
 	}
-	if nodes := nlc.mutation.DocumentIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2O,
-			Inverse: false,
-			Table:   nodelist.DocumentTable,
-			Columns: []string{nodelist.DocumentColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeUUID),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges = append(_spec.Edges, edge)
-	}
 	if nodes := nlc.mutation.EdgeTypesIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
@@ -242,6 +230,22 @@ func (nlc *NodeListCreate) createSpec() (*NodeList, *sqlgraph.CreateSpec) {
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := nlc.mutation.DocumentsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: true,
+			Table:   nodelist.DocumentsTable,
+			Columns: []string{nodelist.DocumentsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/internal/backends/ent/nodelist_query.go
+++ b/internal/backends/ent/nodelist_query.go
@@ -32,9 +32,9 @@ type NodeListQuery struct {
 	order         []nodelist.OrderOption
 	inters        []Interceptor
 	predicates    []predicate.NodeList
-	withDocument  *DocumentQuery
 	withEdgeTypes *EdgeTypeQuery
 	withNodes     *NodeQuery
+	withDocuments *DocumentQuery
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -69,28 +69,6 @@ func (nlq *NodeListQuery) Unique(unique bool) *NodeListQuery {
 func (nlq *NodeListQuery) Order(o ...nodelist.OrderOption) *NodeListQuery {
 	nlq.order = append(nlq.order, o...)
 	return nlq
-}
-
-// QueryDocument chains the current query on the "document" edge.
-func (nlq *NodeListQuery) QueryDocument() *DocumentQuery {
-	query := (&DocumentClient{config: nlq.config}).Query()
-	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
-		if err := nlq.prepareQuery(ctx); err != nil {
-			return nil, err
-		}
-		selector := nlq.sqlQuery(ctx)
-		if err := selector.Err(); err != nil {
-			return nil, err
-		}
-		step := sqlgraph.NewStep(
-			sqlgraph.From(nodelist.Table, nodelist.FieldID, selector),
-			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, nodelist.DocumentTable, nodelist.DocumentColumn),
-		)
-		fromU = sqlgraph.SetNeighbors(nlq.driver.Dialect(), step)
-		return fromU, nil
-	}
-	return query
 }
 
 // QueryEdgeTypes chains the current query on the "edge_types" edge.
@@ -130,6 +108,28 @@ func (nlq *NodeListQuery) QueryNodes() *NodeQuery {
 			sqlgraph.From(nodelist.Table, nodelist.FieldID, selector),
 			sqlgraph.To(node.Table, node.FieldID),
 			sqlgraph.Edge(sqlgraph.M2M, false, nodelist.NodesTable, nodelist.NodesPrimaryKey...),
+		)
+		fromU = sqlgraph.SetNeighbors(nlq.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryDocuments chains the current query on the "documents" edge.
+func (nlq *NodeListQuery) QueryDocuments() *DocumentQuery {
+	query := (&DocumentClient{config: nlq.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := nlq.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := nlq.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(nodelist.Table, nodelist.FieldID, selector),
+			sqlgraph.To(document.Table, document.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, true, nodelist.DocumentsTable, nodelist.DocumentsColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(nlq.driver.Dialect(), step)
 		return fromU, nil
@@ -329,24 +329,13 @@ func (nlq *NodeListQuery) Clone() *NodeListQuery {
 		order:         append([]nodelist.OrderOption{}, nlq.order...),
 		inters:        append([]Interceptor{}, nlq.inters...),
 		predicates:    append([]predicate.NodeList{}, nlq.predicates...),
-		withDocument:  nlq.withDocument.Clone(),
 		withEdgeTypes: nlq.withEdgeTypes.Clone(),
 		withNodes:     nlq.withNodes.Clone(),
+		withDocuments: nlq.withDocuments.Clone(),
 		// clone intermediate query.
 		sql:  nlq.sql.Clone(),
 		path: nlq.path,
 	}
-}
-
-// WithDocument tells the query-builder to eager-load the nodes that are connected to
-// the "document" edge. The optional arguments are used to configure the query builder of the edge.
-func (nlq *NodeListQuery) WithDocument(opts ...func(*DocumentQuery)) *NodeListQuery {
-	query := (&DocumentClient{config: nlq.config}).Query()
-	for _, opt := range opts {
-		opt(query)
-	}
-	nlq.withDocument = query
-	return nlq
 }
 
 // WithEdgeTypes tells the query-builder to eager-load the nodes that are connected to
@@ -368,6 +357,17 @@ func (nlq *NodeListQuery) WithNodes(opts ...func(*NodeQuery)) *NodeListQuery {
 		opt(query)
 	}
 	nlq.withNodes = query
+	return nlq
+}
+
+// WithDocuments tells the query-builder to eager-load the nodes that are connected to
+// the "documents" edge. The optional arguments are used to configure the query builder of the edge.
+func (nlq *NodeListQuery) WithDocuments(opts ...func(*DocumentQuery)) *NodeListQuery {
+	query := (&DocumentClient{config: nlq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	nlq.withDocuments = query
 	return nlq
 }
 
@@ -450,9 +450,9 @@ func (nlq *NodeListQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*No
 		nodes       = []*NodeList{}
 		_spec       = nlq.querySpec()
 		loadedTypes = [3]bool{
-			nlq.withDocument != nil,
 			nlq.withEdgeTypes != nil,
 			nlq.withNodes != nil,
+			nlq.withDocuments != nil,
 		}
 	)
 	_spec.ScanValues = func(columns []string) ([]any, error) {
@@ -473,12 +473,6 @@ func (nlq *NodeListQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*No
 	if len(nodes) == 0 {
 		return nodes, nil
 	}
-	if query := nlq.withDocument; query != nil {
-		if err := nlq.loadDocument(ctx, query, nodes, nil,
-			func(n *NodeList, e *Document) { n.Edges.Document = e }); err != nil {
-			return nil, err
-		}
-	}
 	if query := nlq.withEdgeTypes; query != nil {
 		if err := nlq.loadEdgeTypes(ctx, query, nodes,
 			func(n *NodeList) { n.Edges.EdgeTypes = []*EdgeType{} },
@@ -493,36 +487,16 @@ func (nlq *NodeListQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*No
 			return nil, err
 		}
 	}
+	if query := nlq.withDocuments; query != nil {
+		if err := nlq.loadDocuments(ctx, query, nodes,
+			func(n *NodeList) { n.Edges.Documents = []*Document{} },
+			func(n *NodeList, e *Document) { n.Edges.Documents = append(n.Edges.Documents, e) }); err != nil {
+			return nil, err
+		}
+	}
 	return nodes, nil
 }
 
-func (nlq *NodeListQuery) loadDocument(ctx context.Context, query *DocumentQuery, nodes []*NodeList, init func(*NodeList), assign func(*NodeList, *Document)) error {
-	fks := make([]driver.Value, 0, len(nodes))
-	nodeids := make(map[uuid.UUID]*NodeList)
-	for i := range nodes {
-		fks = append(fks, nodes[i].ID)
-		nodeids[nodes[i].ID] = nodes[i]
-	}
-	if len(query.ctx.Fields) > 0 {
-		query.ctx.AppendFieldOnce(document.FieldNodeListID)
-	}
-	query.Where(predicate.Document(func(s *sql.Selector) {
-		s.Where(sql.InValues(s.C(nodelist.DocumentColumn), fks...))
-	}))
-	neighbors, err := query.All(ctx)
-	if err != nil {
-		return err
-	}
-	for _, n := range neighbors {
-		fk := n.NodeListID
-		node, ok := nodeids[fk]
-		if !ok {
-			return fmt.Errorf(`unexpected referenced foreign-key "node_list_id" returned %v for node %v`, fk, n.ID)
-		}
-		assign(node, n)
-	}
-	return nil
-}
 func (nlq *NodeListQuery) loadEdgeTypes(ctx context.Context, query *EdgeTypeQuery, nodes []*NodeList, init func(*NodeList), assign func(*NodeList, *EdgeType)) error {
 	edgeIDs := make([]driver.Value, len(nodes))
 	byID := make(map[uuid.UUID]*NodeList)
@@ -642,6 +616,36 @@ func (nlq *NodeListQuery) loadNodes(ctx context.Context, query *NodeQuery, nodes
 		for kn := range nodes {
 			assign(kn, n)
 		}
+	}
+	return nil
+}
+func (nlq *NodeListQuery) loadDocuments(ctx context.Context, query *DocumentQuery, nodes []*NodeList, init func(*NodeList), assign func(*NodeList, *Document)) error {
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[uuid.UUID]*NodeList)
+	for i := range nodes {
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
+		if init != nil {
+			init(nodes[i])
+		}
+	}
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(document.FieldNodeListID)
+	}
+	query.Where(predicate.Document(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(nodelist.DocumentsColumn), fks...))
+	}))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		fk := n.NodeListID
+		node, ok := nodeids[fk]
+		if !ok {
+			return fmt.Errorf(`unexpected referenced foreign-key "node_list_id" returned %v for node %v`, fk, n.ID)
+		}
+		assign(node, n)
 	}
 	return nil
 }

--- a/internal/backends/ent/nodelist_update.go
+++ b/internal/backends/ent/nodelist_update.go
@@ -152,18 +152,7 @@ func (nlu *NodeListUpdate) ExecX(ctx context.Context) {
 	}
 }
 
-// check runs all checks and user-defined validators on the builder.
-func (nlu *NodeListUpdate) check() error {
-	if nlu.mutation.DocumentCleared() && len(nlu.mutation.DocumentIDs()) > 0 {
-		return errors.New(`ent: clearing a required unique edge "NodeList.document"`)
-	}
-	return nil
-}
-
 func (nlu *NodeListUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	if err := nlu.check(); err != nil {
-		return n, err
-	}
 	_spec := sqlgraph.NewUpdateSpec(nodelist.Table, nodelist.Columns, sqlgraph.NewFieldSpec(nodelist.FieldID, field.TypeUUID))
 	if ps := nlu.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
@@ -419,18 +408,7 @@ func (nluo *NodeListUpdateOne) ExecX(ctx context.Context) {
 	}
 }
 
-// check runs all checks and user-defined validators on the builder.
-func (nluo *NodeListUpdateOne) check() error {
-	if nluo.mutation.DocumentCleared() && len(nluo.mutation.DocumentIDs()) > 0 {
-		return errors.New(`ent: clearing a required unique edge "NodeList.document"`)
-	}
-	return nil
-}
-
 func (nluo *NodeListUpdateOne) sqlSave(ctx context.Context) (_node *NodeList, err error) {
-	if err := nluo.check(); err != nil {
-		return _node, err
-	}
 	_spec := sqlgraph.NewUpdateSpec(nodelist.Table, nodelist.Columns, sqlgraph.NewFieldSpec(nodelist.FieldID, field.TypeUUID))
 	id, ok := nluo.mutation.ID()
 	if !ok {

--- a/internal/backends/ent/person.go
+++ b/internal/backends/ent/person.go
@@ -16,9 +16,6 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/google/uuid"
 	"github.com/protobom/protobom/pkg/sbom"
-	"github.com/protobom/storage/internal/backends/ent/document"
-	"github.com/protobom/storage/internal/backends/ent/metadata"
-	"github.com/protobom/storage/internal/backends/ent/node"
 	"github.com/protobom/storage/internal/backends/ent/person"
 )
 
@@ -27,14 +24,8 @@ type Person struct {
 	config `json:"-"`
 	// ID of the ent.
 	ID uuid.UUID `json:"-"`
-	// DocumentID holds the value of the "document_id" field.
-	DocumentID uuid.UUID `json:"-"`
 	// ProtoMessage holds the value of the "proto_message" field.
 	ProtoMessage *sbom.Person `json:"-"`
-	// MetadataID holds the value of the "metadata_id" field.
-	MetadataID uuid.UUID `json:"-"`
-	// NodeID holds the value of the "node_id" field.
-	NodeID uuid.UUID `json:"-"`
 	// Name holds the value of the "name" field.
 	Name string `json:"name,omitempty"`
 	// IsOrg holds the value of the "is_org" field.
@@ -47,47 +38,34 @@ type Person struct {
 	Phone string `json:"phone,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the PersonQuery when eager-loading is set.
-	Edges           PersonEdges `json:"-"`
-	node_suppliers  *uuid.UUID
-	person_contacts *uuid.UUID
-	selectValues    sql.SelectValues
+	Edges        PersonEdges `json:"-"`
+	selectValues sql.SelectValues
 }
 
 // PersonEdges holds the relations/edges for other nodes in the graph.
 type PersonEdges struct {
-	// Document holds the value of the document edge.
-	Document *Document `json:"document,omitempty"`
 	// ContactOwner holds the value of the contact_owner edge.
-	ContactOwner *Person `json:"-"`
+	ContactOwner []*Person `json:"-"`
 	// Contacts holds the value of the contacts edge.
 	Contacts []*Person `json:"contacts,omitempty"`
+	// Documents holds the value of the documents edge.
+	Documents []*Document `json:"-"`
 	// Metadata holds the value of the metadata edge.
-	Metadata *Metadata `json:"-"`
-	// Node holds the value of the node edge.
-	Node *Node `json:"-"`
+	Metadata []*Metadata `json:"-"`
+	// OriginatorNodes holds the value of the originator_nodes edge.
+	OriginatorNodes []*Node `json:"-"`
+	// SupplierNodes holds the value of the supplier_nodes edge.
+	SupplierNodes []*Node `json:"-"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [5]bool
-}
-
-// DocumentOrErr returns the Document value or an error if the edge
-// was not loaded in eager-loading, or loaded but was not found.
-func (e PersonEdges) DocumentOrErr() (*Document, error) {
-	if e.Document != nil {
-		return e.Document, nil
-	} else if e.loadedTypes[0] {
-		return nil, &NotFoundError{label: document.Label}
-	}
-	return nil, &NotLoadedError{edge: "document"}
+	loadedTypes [6]bool
 }
 
 // ContactOwnerOrErr returns the ContactOwner value or an error if the edge
-// was not loaded in eager-loading, or loaded but was not found.
-func (e PersonEdges) ContactOwnerOrErr() (*Person, error) {
-	if e.ContactOwner != nil {
+// was not loaded in eager-loading.
+func (e PersonEdges) ContactOwnerOrErr() ([]*Person, error) {
+	if e.loadedTypes[0] {
 		return e.ContactOwner, nil
-	} else if e.loadedTypes[1] {
-		return nil, &NotFoundError{label: person.Label}
 	}
 	return nil, &NotLoadedError{edge: "contact_owner"}
 }
@@ -95,32 +73,46 @@ func (e PersonEdges) ContactOwnerOrErr() (*Person, error) {
 // ContactsOrErr returns the Contacts value or an error if the edge
 // was not loaded in eager-loading.
 func (e PersonEdges) ContactsOrErr() ([]*Person, error) {
-	if e.loadedTypes[2] {
+	if e.loadedTypes[1] {
 		return e.Contacts, nil
 	}
 	return nil, &NotLoadedError{edge: "contacts"}
 }
 
+// DocumentsOrErr returns the Documents value or an error if the edge
+// was not loaded in eager-loading.
+func (e PersonEdges) DocumentsOrErr() ([]*Document, error) {
+	if e.loadedTypes[2] {
+		return e.Documents, nil
+	}
+	return nil, &NotLoadedError{edge: "documents"}
+}
+
 // MetadataOrErr returns the Metadata value or an error if the edge
-// was not loaded in eager-loading, or loaded but was not found.
-func (e PersonEdges) MetadataOrErr() (*Metadata, error) {
-	if e.Metadata != nil {
+// was not loaded in eager-loading.
+func (e PersonEdges) MetadataOrErr() ([]*Metadata, error) {
+	if e.loadedTypes[3] {
 		return e.Metadata, nil
-	} else if e.loadedTypes[3] {
-		return nil, &NotFoundError{label: metadata.Label}
 	}
 	return nil, &NotLoadedError{edge: "metadata"}
 }
 
-// NodeOrErr returns the Node value or an error if the edge
-// was not loaded in eager-loading, or loaded but was not found.
-func (e PersonEdges) NodeOrErr() (*Node, error) {
-	if e.Node != nil {
-		return e.Node, nil
-	} else if e.loadedTypes[4] {
-		return nil, &NotFoundError{label: node.Label}
+// OriginatorNodesOrErr returns the OriginatorNodes value or an error if the edge
+// was not loaded in eager-loading.
+func (e PersonEdges) OriginatorNodesOrErr() ([]*Node, error) {
+	if e.loadedTypes[4] {
+		return e.OriginatorNodes, nil
 	}
-	return nil, &NotLoadedError{edge: "node"}
+	return nil, &NotLoadedError{edge: "originator_nodes"}
+}
+
+// SupplierNodesOrErr returns the SupplierNodes value or an error if the edge
+// was not loaded in eager-loading.
+func (e PersonEdges) SupplierNodesOrErr() ([]*Node, error) {
+	if e.loadedTypes[5] {
+		return e.SupplierNodes, nil
+	}
+	return nil, &NotLoadedError{edge: "supplier_nodes"}
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -134,12 +126,8 @@ func (*Person) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case person.FieldName, person.FieldEmail, person.FieldURL, person.FieldPhone:
 			values[i] = new(sql.NullString)
-		case person.FieldID, person.FieldDocumentID, person.FieldMetadataID, person.FieldNodeID:
+		case person.FieldID:
 			values[i] = new(uuid.UUID)
-		case person.ForeignKeys[0]: // node_suppliers
-			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
-		case person.ForeignKeys[1]: // person_contacts
-			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -161,29 +149,11 @@ func (pe *Person) assignValues(columns []string, values []any) error {
 			} else if value != nil {
 				pe.ID = *value
 			}
-		case person.FieldDocumentID:
-			if value, ok := values[i].(*uuid.UUID); !ok {
-				return fmt.Errorf("unexpected type %T for field document_id", values[i])
-			} else if value != nil {
-				pe.DocumentID = *value
-			}
 		case person.FieldProtoMessage:
 			if value, ok := values[i].(*sql.NullScanner); !ok {
 				return fmt.Errorf("unexpected type %T for field proto_message", values[i])
 			} else if value.Valid {
 				pe.ProtoMessage = value.S.(*sbom.Person)
-			}
-		case person.FieldMetadataID:
-			if value, ok := values[i].(*uuid.UUID); !ok {
-				return fmt.Errorf("unexpected type %T for field metadata_id", values[i])
-			} else if value != nil {
-				pe.MetadataID = *value
-			}
-		case person.FieldNodeID:
-			if value, ok := values[i].(*uuid.UUID); !ok {
-				return fmt.Errorf("unexpected type %T for field node_id", values[i])
-			} else if value != nil {
-				pe.NodeID = *value
 			}
 		case person.FieldName:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -215,20 +185,6 @@ func (pe *Person) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				pe.Phone = value.String
 			}
-		case person.ForeignKeys[0]:
-			if value, ok := values[i].(*sql.NullScanner); !ok {
-				return fmt.Errorf("unexpected type %T for field node_suppliers", values[i])
-			} else if value.Valid {
-				pe.node_suppliers = new(uuid.UUID)
-				*pe.node_suppliers = *value.S.(*uuid.UUID)
-			}
-		case person.ForeignKeys[1]:
-			if value, ok := values[i].(*sql.NullScanner); !ok {
-				return fmt.Errorf("unexpected type %T for field person_contacts", values[i])
-			} else if value.Valid {
-				pe.person_contacts = new(uuid.UUID)
-				*pe.person_contacts = *value.S.(*uuid.UUID)
-			}
 		default:
 			pe.selectValues.Set(columns[i], values[i])
 		}
@@ -242,11 +198,6 @@ func (pe *Person) Value(name string) (ent.Value, error) {
 	return pe.selectValues.Get(name)
 }
 
-// QueryDocument queries the "document" edge of the Person entity.
-func (pe *Person) QueryDocument() *DocumentQuery {
-	return NewPersonClient(pe.config).QueryDocument(pe)
-}
-
 // QueryContactOwner queries the "contact_owner" edge of the Person entity.
 func (pe *Person) QueryContactOwner() *PersonQuery {
 	return NewPersonClient(pe.config).QueryContactOwner(pe)
@@ -257,14 +208,24 @@ func (pe *Person) QueryContacts() *PersonQuery {
 	return NewPersonClient(pe.config).QueryContacts(pe)
 }
 
+// QueryDocuments queries the "documents" edge of the Person entity.
+func (pe *Person) QueryDocuments() *DocumentQuery {
+	return NewPersonClient(pe.config).QueryDocuments(pe)
+}
+
 // QueryMetadata queries the "metadata" edge of the Person entity.
 func (pe *Person) QueryMetadata() *MetadataQuery {
 	return NewPersonClient(pe.config).QueryMetadata(pe)
 }
 
-// QueryNode queries the "node" edge of the Person entity.
-func (pe *Person) QueryNode() *NodeQuery {
-	return NewPersonClient(pe.config).QueryNode(pe)
+// QueryOriginatorNodes queries the "originator_nodes" edge of the Person entity.
+func (pe *Person) QueryOriginatorNodes() *NodeQuery {
+	return NewPersonClient(pe.config).QueryOriginatorNodes(pe)
+}
+
+// QuerySupplierNodes queries the "supplier_nodes" edge of the Person entity.
+func (pe *Person) QuerySupplierNodes() *NodeQuery {
+	return NewPersonClient(pe.config).QuerySupplierNodes(pe)
 }
 
 // Update returns a builder for updating this Person.
@@ -290,19 +251,10 @@ func (pe *Person) String() string {
 	var builder strings.Builder
 	builder.WriteString("Person(")
 	builder.WriteString(fmt.Sprintf("id=%v, ", pe.ID))
-	builder.WriteString("document_id=")
-	builder.WriteString(fmt.Sprintf("%v", pe.DocumentID))
-	builder.WriteString(", ")
 	if v := pe.ProtoMessage; v != nil {
 		builder.WriteString("proto_message=")
 		builder.WriteString(fmt.Sprintf("%v", *v))
 	}
-	builder.WriteString(", ")
-	builder.WriteString("metadata_id=")
-	builder.WriteString(fmt.Sprintf("%v", pe.MetadataID))
-	builder.WriteString(", ")
-	builder.WriteString("node_id=")
-	builder.WriteString(fmt.Sprintf("%v", pe.NodeID))
 	builder.WriteString(", ")
 	builder.WriteString("name=")
 	builder.WriteString(pe.Name)

--- a/internal/backends/ent/person/person.go
+++ b/internal/backends/ent/person/person.go
@@ -19,14 +19,8 @@ const (
 	Label = "person"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
-	// FieldDocumentID holds the string denoting the document_id field in the database.
-	FieldDocumentID = "document_id"
 	// FieldProtoMessage holds the string denoting the proto_message field in the database.
 	FieldProtoMessage = "proto_message"
-	// FieldMetadataID holds the string denoting the metadata_id field in the database.
-	FieldMetadataID = "metadata_id"
-	// FieldNodeID holds the string denoting the node_id field in the database.
-	FieldNodeID = "node_id"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
 	// FieldIsOrg holds the string denoting the is_org field in the database.
@@ -37,56 +31,50 @@ const (
 	FieldURL = "url"
 	// FieldPhone holds the string denoting the phone field in the database.
 	FieldPhone = "phone"
-	// EdgeDocument holds the string denoting the document edge name in mutations.
-	EdgeDocument = "document"
 	// EdgeContactOwner holds the string denoting the contact_owner edge name in mutations.
 	EdgeContactOwner = "contact_owner"
 	// EdgeContacts holds the string denoting the contacts edge name in mutations.
 	EdgeContacts = "contacts"
+	// EdgeDocuments holds the string denoting the documents edge name in mutations.
+	EdgeDocuments = "documents"
 	// EdgeMetadata holds the string denoting the metadata edge name in mutations.
 	EdgeMetadata = "metadata"
-	// EdgeNode holds the string denoting the node edge name in mutations.
-	EdgeNode = "node"
+	// EdgeOriginatorNodes holds the string denoting the originator_nodes edge name in mutations.
+	EdgeOriginatorNodes = "originator_nodes"
+	// EdgeSupplierNodes holds the string denoting the supplier_nodes edge name in mutations.
+	EdgeSupplierNodes = "supplier_nodes"
 	// Table holds the table name of the person in the database.
 	Table = "persons"
-	// DocumentTable is the table that holds the document relation/edge.
-	DocumentTable = "persons"
-	// DocumentInverseTable is the table name for the Document entity.
+	// ContactOwnerTable is the table that holds the contact_owner relation/edge. The primary key declared below.
+	ContactOwnerTable = "person_contacts"
+	// ContactsTable is the table that holds the contacts relation/edge. The primary key declared below.
+	ContactsTable = "person_contacts"
+	// DocumentsTable is the table that holds the documents relation/edge. The primary key declared below.
+	DocumentsTable = "document_persons"
+	// DocumentsInverseTable is the table name for the Document entity.
 	// It exists in this package in order to avoid circular dependency with the "document" package.
-	DocumentInverseTable = "documents"
-	// DocumentColumn is the table column denoting the document relation/edge.
-	DocumentColumn = "document_id"
-	// ContactOwnerTable is the table that holds the contact_owner relation/edge.
-	ContactOwnerTable = "persons"
-	// ContactOwnerColumn is the table column denoting the contact_owner relation/edge.
-	ContactOwnerColumn = "person_contacts"
-	// ContactsTable is the table that holds the contacts relation/edge.
-	ContactsTable = "persons"
-	// ContactsColumn is the table column denoting the contacts relation/edge.
-	ContactsColumn = "person_contacts"
-	// MetadataTable is the table that holds the metadata relation/edge.
-	MetadataTable = "persons"
+	DocumentsInverseTable = "documents"
+	// MetadataTable is the table that holds the metadata relation/edge. The primary key declared below.
+	MetadataTable = "metadata_authors"
 	// MetadataInverseTable is the table name for the Metadata entity.
 	// It exists in this package in order to avoid circular dependency with the "metadata" package.
 	MetadataInverseTable = "metadata"
-	// MetadataColumn is the table column denoting the metadata relation/edge.
-	MetadataColumn = "metadata_id"
-	// NodeTable is the table that holds the node relation/edge.
-	NodeTable = "persons"
-	// NodeInverseTable is the table name for the Node entity.
+	// OriginatorNodesTable is the table that holds the originator_nodes relation/edge. The primary key declared below.
+	OriginatorNodesTable = "node_originators"
+	// OriginatorNodesInverseTable is the table name for the Node entity.
 	// It exists in this package in order to avoid circular dependency with the "node" package.
-	NodeInverseTable = "nodes"
-	// NodeColumn is the table column denoting the node relation/edge.
-	NodeColumn = "node_id"
+	OriginatorNodesInverseTable = "nodes"
+	// SupplierNodesTable is the table that holds the supplier_nodes relation/edge. The primary key declared below.
+	SupplierNodesTable = "node_suppliers"
+	// SupplierNodesInverseTable is the table name for the Node entity.
+	// It exists in this package in order to avoid circular dependency with the "node" package.
+	SupplierNodesInverseTable = "nodes"
 )
 
 // Columns holds all SQL columns for person fields.
 var Columns = []string{
 	FieldID,
-	FieldDocumentID,
 	FieldProtoMessage,
-	FieldMetadataID,
-	FieldNodeID,
 	FieldName,
 	FieldIsOrg,
 	FieldEmail,
@@ -94,22 +82,31 @@ var Columns = []string{
 	FieldPhone,
 }
 
-// ForeignKeys holds the SQL foreign-keys that are owned by the "persons"
-// table and are not defined as standalone fields in the schema.
-var ForeignKeys = []string{
-	"node_suppliers",
-	"person_contacts",
-}
+var (
+	// ContactOwnerPrimaryKey and ContactOwnerColumn2 are the table columns denoting the
+	// primary key for the contact_owner relation (M2M).
+	ContactOwnerPrimaryKey = []string{"person_id", "contact_owner_id"}
+	// ContactsPrimaryKey and ContactsColumn2 are the table columns denoting the
+	// primary key for the contacts relation (M2M).
+	ContactsPrimaryKey = []string{"person_id", "contact_owner_id"}
+	// DocumentsPrimaryKey and DocumentsColumn2 are the table columns denoting the
+	// primary key for the documents relation (M2M).
+	DocumentsPrimaryKey = []string{"document_id", "person_id"}
+	// MetadataPrimaryKey and MetadataColumn2 are the table columns denoting the
+	// primary key for the metadata relation (M2M).
+	MetadataPrimaryKey = []string{"metadata_id", "person_id"}
+	// OriginatorNodesPrimaryKey and OriginatorNodesColumn2 are the table columns denoting the
+	// primary key for the originator_nodes relation (M2M).
+	OriginatorNodesPrimaryKey = []string{"node_id", "person_id"}
+	// SupplierNodesPrimaryKey and SupplierNodesColumn2 are the table columns denoting the
+	// primary key for the supplier_nodes relation (M2M).
+	SupplierNodesPrimaryKey = []string{"node_id", "person_id"}
+)
 
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
-			return true
-		}
-	}
-	for i := range ForeignKeys {
-		if column == ForeignKeys[i] {
 			return true
 		}
 	}
@@ -123,8 +120,6 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/protobom/storage/internal/backends/ent/runtime"
 var (
 	Hooks [2]ent.Hook
-	// DefaultDocumentID holds the default value on creation for the "document_id" field.
-	DefaultDocumentID func() uuid.UUID
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() uuid.UUID
 )
@@ -135,21 +130,6 @@ type OrderOption func(*sql.Selector)
 // ByID orders the results by the id field.
 func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
-}
-
-// ByDocumentID orders the results by the document_id field.
-func ByDocumentID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldDocumentID, opts...).ToFunc()
-}
-
-// ByMetadataID orders the results by the metadata_id field.
-func ByMetadataID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldMetadataID, opts...).ToFunc()
-}
-
-// ByNodeID orders the results by the node_id field.
-func ByNodeID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldNodeID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
@@ -177,17 +157,17 @@ func ByPhone(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPhone, opts...).ToFunc()
 }
 
-// ByDocumentField orders the results by document field.
-func ByDocumentField(field string, opts ...sql.OrderTermOption) OrderOption {
+// ByContactOwnerCount orders the results by contact_owner count.
+func ByContactOwnerCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newDocumentStep(), sql.OrderByField(field, opts...))
+		sqlgraph.OrderByNeighborsCount(s, newContactOwnerStep(), opts...)
 	}
 }
 
-// ByContactOwnerField orders the results by contact_owner field.
-func ByContactOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
+// ByContactOwner orders the results by contact_owner terms.
+func ByContactOwner(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newContactOwnerStep(), sql.OrderByField(field, opts...))
+		sqlgraph.OrderByNeighborTerms(s, newContactOwnerStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
@@ -205,51 +185,100 @@ func ByContacts(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	}
 }
 
-// ByMetadataField orders the results by metadata field.
-func ByMetadataField(field string, opts ...sql.OrderTermOption) OrderOption {
+// ByDocumentsCount orders the results by documents count.
+func ByDocumentsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newMetadataStep(), sql.OrderByField(field, opts...))
+		sqlgraph.OrderByNeighborsCount(s, newDocumentsStep(), opts...)
 	}
 }
 
-// ByNodeField orders the results by node field.
-func ByNodeField(field string, opts ...sql.OrderTermOption) OrderOption {
+// ByDocuments orders the results by documents terms.
+func ByDocuments(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newNodeStep(), sql.OrderByField(field, opts...))
+		sqlgraph.OrderByNeighborTerms(s, newDocumentsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
-func newDocumentStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(DocumentInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
-	)
+
+// ByMetadataCount orders the results by metadata count.
+func ByMetadataCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newMetadataStep(), opts...)
+	}
+}
+
+// ByMetadata orders the results by metadata terms.
+func ByMetadata(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newMetadataStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByOriginatorNodesCount orders the results by originator_nodes count.
+func ByOriginatorNodesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newOriginatorNodesStep(), opts...)
+	}
+}
+
+// ByOriginatorNodes orders the results by originator_nodes terms.
+func ByOriginatorNodes(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOriginatorNodesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// BySupplierNodesCount orders the results by supplier_nodes count.
+func BySupplierNodesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newSupplierNodesStep(), opts...)
+	}
+}
+
+// BySupplierNodes orders the results by supplier_nodes terms.
+func BySupplierNodes(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newSupplierNodesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
 }
 func newContactOwnerStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(Table, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, true, ContactOwnerTable, ContactOwnerColumn),
+		sqlgraph.Edge(sqlgraph.M2M, true, ContactOwnerTable, ContactOwnerPrimaryKey...),
 	)
 }
 func newContactsStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(Table, FieldID),
-		sqlgraph.Edge(sqlgraph.O2M, false, ContactsTable, ContactsColumn),
+		sqlgraph.Edge(sqlgraph.M2M, false, ContactsTable, ContactsPrimaryKey...),
+	)
+}
+func newDocumentsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(DocumentsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
 	)
 }
 func newMetadataStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(MetadataInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, true, MetadataTable, MetadataColumn),
+		sqlgraph.Edge(sqlgraph.M2M, true, MetadataTable, MetadataPrimaryKey...),
 	)
 }
-func newNodeStep() *sqlgraph.Step {
+func newOriginatorNodesStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(NodeInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, true, NodeTable, NodeColumn),
+		sqlgraph.To(OriginatorNodesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, OriginatorNodesTable, OriginatorNodesPrimaryKey...),
+	)
+}
+func newSupplierNodesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(SupplierNodesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, SupplierNodesTable, SupplierNodesPrimaryKey...),
 	)
 }

--- a/internal/backends/ent/person/where.go
+++ b/internal/backends/ent/person/where.go
@@ -60,24 +60,9 @@ func IDLTE(id uuid.UUID) predicate.Person {
 	return predicate.Person(sql.FieldLTE(FieldID, id))
 }
 
-// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
-func DocumentID(v uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldEQ(FieldDocumentID, v))
-}
-
 // ProtoMessage applies equality check predicate on the "proto_message" field. It's identical to ProtoMessageEQ.
 func ProtoMessage(v *sbom.Person) predicate.Person {
 	return predicate.Person(sql.FieldEQ(FieldProtoMessage, v))
-}
-
-// MetadataID applies equality check predicate on the "metadata_id" field. It's identical to MetadataIDEQ.
-func MetadataID(v uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldEQ(FieldMetadataID, v))
-}
-
-// NodeID applies equality check predicate on the "node_id" field. It's identical to NodeIDEQ.
-func NodeID(v uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldEQ(FieldNodeID, v))
 }
 
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
@@ -103,36 +88,6 @@ func URL(v string) predicate.Person {
 // Phone applies equality check predicate on the "phone" field. It's identical to PhoneEQ.
 func Phone(v string) predicate.Person {
 	return predicate.Person(sql.FieldEQ(FieldPhone, v))
-}
-
-// DocumentIDEQ applies the EQ predicate on the "document_id" field.
-func DocumentIDEQ(v uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldEQ(FieldDocumentID, v))
-}
-
-// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
-func DocumentIDNEQ(v uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldNEQ(FieldDocumentID, v))
-}
-
-// DocumentIDIn applies the In predicate on the "document_id" field.
-func DocumentIDIn(vs ...uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
-func DocumentIDNotIn(vs ...uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldNotIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDIsNil applies the IsNil predicate on the "document_id" field.
-func DocumentIDIsNil() predicate.Person {
-	return predicate.Person(sql.FieldIsNull(FieldDocumentID))
-}
-
-// DocumentIDNotNil applies the NotNil predicate on the "document_id" field.
-func DocumentIDNotNil() predicate.Person {
-	return predicate.Person(sql.FieldNotNull(FieldDocumentID))
 }
 
 // ProtoMessageEQ applies the EQ predicate on the "proto_message" field.
@@ -173,66 +128,6 @@ func ProtoMessageLT(v *sbom.Person) predicate.Person {
 // ProtoMessageLTE applies the LTE predicate on the "proto_message" field.
 func ProtoMessageLTE(v *sbom.Person) predicate.Person {
 	return predicate.Person(sql.FieldLTE(FieldProtoMessage, v))
-}
-
-// MetadataIDEQ applies the EQ predicate on the "metadata_id" field.
-func MetadataIDEQ(v uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldEQ(FieldMetadataID, v))
-}
-
-// MetadataIDNEQ applies the NEQ predicate on the "metadata_id" field.
-func MetadataIDNEQ(v uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldNEQ(FieldMetadataID, v))
-}
-
-// MetadataIDIn applies the In predicate on the "metadata_id" field.
-func MetadataIDIn(vs ...uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldIn(FieldMetadataID, vs...))
-}
-
-// MetadataIDNotIn applies the NotIn predicate on the "metadata_id" field.
-func MetadataIDNotIn(vs ...uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldNotIn(FieldMetadataID, vs...))
-}
-
-// MetadataIDIsNil applies the IsNil predicate on the "metadata_id" field.
-func MetadataIDIsNil() predicate.Person {
-	return predicate.Person(sql.FieldIsNull(FieldMetadataID))
-}
-
-// MetadataIDNotNil applies the NotNil predicate on the "metadata_id" field.
-func MetadataIDNotNil() predicate.Person {
-	return predicate.Person(sql.FieldNotNull(FieldMetadataID))
-}
-
-// NodeIDEQ applies the EQ predicate on the "node_id" field.
-func NodeIDEQ(v uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldEQ(FieldNodeID, v))
-}
-
-// NodeIDNEQ applies the NEQ predicate on the "node_id" field.
-func NodeIDNEQ(v uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldNEQ(FieldNodeID, v))
-}
-
-// NodeIDIn applies the In predicate on the "node_id" field.
-func NodeIDIn(vs ...uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldIn(FieldNodeID, vs...))
-}
-
-// NodeIDNotIn applies the NotIn predicate on the "node_id" field.
-func NodeIDNotIn(vs ...uuid.UUID) predicate.Person {
-	return predicate.Person(sql.FieldNotIn(FieldNodeID, vs...))
-}
-
-// NodeIDIsNil applies the IsNil predicate on the "node_id" field.
-func NodeIDIsNil() predicate.Person {
-	return predicate.Person(sql.FieldIsNull(FieldNodeID))
-}
-
-// NodeIDNotNil applies the NotNil predicate on the "node_id" field.
-func NodeIDNotNil() predicate.Person {
-	return predicate.Person(sql.FieldNotNull(FieldNodeID))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.
@@ -505,35 +400,12 @@ func PhoneContainsFold(v string) predicate.Person {
 	return predicate.Person(sql.FieldContainsFold(FieldPhone, v))
 }
 
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.Person {
-	return predicate.Person(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.Person {
-	return predicate.Person(func(s *sql.Selector) {
-		step := newDocumentStep()
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
 // HasContactOwner applies the HasEdge predicate on the "contact_owner" edge.
 func HasContactOwner() predicate.Person {
 	return predicate.Person(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, ContactOwnerTable, ContactOwnerColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, ContactOwnerTable, ContactOwnerPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -556,7 +428,7 @@ func HasContacts() predicate.Person {
 	return predicate.Person(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, ContactsTable, ContactsColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, ContactsTable, ContactsPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -574,12 +446,35 @@ func HasContactsWith(preds ...predicate.Person) predicate.Person {
 	})
 }
 
+// HasDocuments applies the HasEdge predicate on the "documents" edge.
+func HasDocuments() predicate.Person {
+	return predicate.Person(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasDocumentsWith applies the HasEdge predicate on the "documents" edge with a given conditions (other predicates).
+func HasDocumentsWith(preds ...predicate.Document) predicate.Person {
+	return predicate.Person(func(s *sql.Selector) {
+		step := newDocumentsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasMetadata applies the HasEdge predicate on the "metadata" edge.
 func HasMetadata() predicate.Person {
 	return predicate.Person(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, MetadataTable, MetadataColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, MetadataTable, MetadataPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
@@ -597,21 +492,44 @@ func HasMetadataWith(preds ...predicate.Metadata) predicate.Person {
 	})
 }
 
-// HasNode applies the HasEdge predicate on the "node" edge.
-func HasNode() predicate.Person {
+// HasOriginatorNodes applies the HasEdge predicate on the "originator_nodes" edge.
+func HasOriginatorNodes() predicate.Person {
 	return predicate.Person(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, NodeTable, NodeColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, OriginatorNodesTable, OriginatorNodesPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
 }
 
-// HasNodeWith applies the HasEdge predicate on the "node" edge with a given conditions (other predicates).
-func HasNodeWith(preds ...predicate.Node) predicate.Person {
+// HasOriginatorNodesWith applies the HasEdge predicate on the "originator_nodes" edge with a given conditions (other predicates).
+func HasOriginatorNodesWith(preds ...predicate.Node) predicate.Person {
 	return predicate.Person(func(s *sql.Selector) {
-		step := newNodeStep()
+		step := newOriginatorNodesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasSupplierNodes applies the HasEdge predicate on the "supplier_nodes" edge.
+func HasSupplierNodes() predicate.Person {
+	return predicate.Person(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, SupplierNodesTable, SupplierNodesPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasSupplierNodesWith applies the HasEdge predicate on the "supplier_nodes" edge with a given conditions (other predicates).
+func HasSupplierNodesWith(preds ...predicate.Node) predicate.Person {
+	return predicate.Person(func(s *sql.Selector) {
+		step := newSupplierNodesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/backends/ent/person_create.go
+++ b/internal/backends/ent/person_create.go
@@ -32,51 +32,9 @@ type PersonCreate struct {
 	conflict []sql.ConflictOption
 }
 
-// SetDocumentID sets the "document_id" field.
-func (pc *PersonCreate) SetDocumentID(u uuid.UUID) *PersonCreate {
-	pc.mutation.SetDocumentID(u)
-	return pc
-}
-
-// SetNillableDocumentID sets the "document_id" field if the given value is not nil.
-func (pc *PersonCreate) SetNillableDocumentID(u *uuid.UUID) *PersonCreate {
-	if u != nil {
-		pc.SetDocumentID(*u)
-	}
-	return pc
-}
-
 // SetProtoMessage sets the "proto_message" field.
 func (pc *PersonCreate) SetProtoMessage(s *sbom.Person) *PersonCreate {
 	pc.mutation.SetProtoMessage(s)
-	return pc
-}
-
-// SetMetadataID sets the "metadata_id" field.
-func (pc *PersonCreate) SetMetadataID(u uuid.UUID) *PersonCreate {
-	pc.mutation.SetMetadataID(u)
-	return pc
-}
-
-// SetNillableMetadataID sets the "metadata_id" field if the given value is not nil.
-func (pc *PersonCreate) SetNillableMetadataID(u *uuid.UUID) *PersonCreate {
-	if u != nil {
-		pc.SetMetadataID(*u)
-	}
-	return pc
-}
-
-// SetNodeID sets the "node_id" field.
-func (pc *PersonCreate) SetNodeID(u uuid.UUID) *PersonCreate {
-	pc.mutation.SetNodeID(u)
-	return pc
-}
-
-// SetNillableNodeID sets the "node_id" field if the given value is not nil.
-func (pc *PersonCreate) SetNillableNodeID(u *uuid.UUID) *PersonCreate {
-	if u != nil {
-		pc.SetNodeID(*u)
-	}
 	return pc
 }
 
@@ -124,28 +82,19 @@ func (pc *PersonCreate) SetNillableID(u *uuid.UUID) *PersonCreate {
 	return pc
 }
 
-// SetDocument sets the "document" edge to the Document entity.
-func (pc *PersonCreate) SetDocument(d *Document) *PersonCreate {
-	return pc.SetDocumentID(d.ID)
-}
-
-// SetContactOwnerID sets the "contact_owner" edge to the Person entity by ID.
-func (pc *PersonCreate) SetContactOwnerID(id uuid.UUID) *PersonCreate {
-	pc.mutation.SetContactOwnerID(id)
+// AddContactOwnerIDs adds the "contact_owner" edge to the Person entity by IDs.
+func (pc *PersonCreate) AddContactOwnerIDs(ids ...uuid.UUID) *PersonCreate {
+	pc.mutation.AddContactOwnerIDs(ids...)
 	return pc
 }
 
-// SetNillableContactOwnerID sets the "contact_owner" edge to the Person entity by ID if the given value is not nil.
-func (pc *PersonCreate) SetNillableContactOwnerID(id *uuid.UUID) *PersonCreate {
-	if id != nil {
-		pc = pc.SetContactOwnerID(*id)
+// AddContactOwner adds the "contact_owner" edges to the Person entity.
+func (pc *PersonCreate) AddContactOwner(p ...*Person) *PersonCreate {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
 	}
-	return pc
-}
-
-// SetContactOwner sets the "contact_owner" edge to the Person entity.
-func (pc *PersonCreate) SetContactOwner(p *Person) *PersonCreate {
-	return pc.SetContactOwnerID(p.ID)
+	return pc.AddContactOwnerIDs(ids...)
 }
 
 // AddContactIDs adds the "contacts" edge to the Person entity by IDs.
@@ -163,14 +112,64 @@ func (pc *PersonCreate) AddContacts(p ...*Person) *PersonCreate {
 	return pc.AddContactIDs(ids...)
 }
 
-// SetMetadata sets the "metadata" edge to the Metadata entity.
-func (pc *PersonCreate) SetMetadata(m *Metadata) *PersonCreate {
-	return pc.SetMetadataID(m.ID)
+// AddDocumentIDs adds the "documents" edge to the Document entity by IDs.
+func (pc *PersonCreate) AddDocumentIDs(ids ...uuid.UUID) *PersonCreate {
+	pc.mutation.AddDocumentIDs(ids...)
+	return pc
 }
 
-// SetNode sets the "node" edge to the Node entity.
-func (pc *PersonCreate) SetNode(n *Node) *PersonCreate {
-	return pc.SetNodeID(n.ID)
+// AddDocuments adds the "documents" edges to the Document entity.
+func (pc *PersonCreate) AddDocuments(d ...*Document) *PersonCreate {
+	ids := make([]uuid.UUID, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return pc.AddDocumentIDs(ids...)
+}
+
+// AddMetadatumIDs adds the "metadata" edge to the Metadata entity by IDs.
+func (pc *PersonCreate) AddMetadatumIDs(ids ...uuid.UUID) *PersonCreate {
+	pc.mutation.AddMetadatumIDs(ids...)
+	return pc
+}
+
+// AddMetadata adds the "metadata" edges to the Metadata entity.
+func (pc *PersonCreate) AddMetadata(m ...*Metadata) *PersonCreate {
+	ids := make([]uuid.UUID, len(m))
+	for i := range m {
+		ids[i] = m[i].ID
+	}
+	return pc.AddMetadatumIDs(ids...)
+}
+
+// AddOriginatorNodeIDs adds the "originator_nodes" edge to the Node entity by IDs.
+func (pc *PersonCreate) AddOriginatorNodeIDs(ids ...uuid.UUID) *PersonCreate {
+	pc.mutation.AddOriginatorNodeIDs(ids...)
+	return pc
+}
+
+// AddOriginatorNodes adds the "originator_nodes" edges to the Node entity.
+func (pc *PersonCreate) AddOriginatorNodes(n ...*Node) *PersonCreate {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return pc.AddOriginatorNodeIDs(ids...)
+}
+
+// AddSupplierNodeIDs adds the "supplier_nodes" edge to the Node entity by IDs.
+func (pc *PersonCreate) AddSupplierNodeIDs(ids ...uuid.UUID) *PersonCreate {
+	pc.mutation.AddSupplierNodeIDs(ids...)
+	return pc
+}
+
+// AddSupplierNodes adds the "supplier_nodes" edges to the Node entity.
+func (pc *PersonCreate) AddSupplierNodes(n ...*Node) *PersonCreate {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return pc.AddSupplierNodeIDs(ids...)
 }
 
 // Mutation returns the PersonMutation object of the builder.
@@ -210,13 +209,6 @@ func (pc *PersonCreate) ExecX(ctx context.Context) {
 
 // defaults sets the default values of the builder before save.
 func (pc *PersonCreate) defaults() error {
-	if _, ok := pc.mutation.DocumentID(); !ok {
-		if person.DefaultDocumentID == nil {
-			return fmt.Errorf("ent: uninitialized person.DefaultDocumentID (forgotten import ent/runtime?)")
-		}
-		v := person.DefaultDocumentID()
-		pc.mutation.SetDocumentID(v)
-	}
 	if _, ok := pc.mutation.ID(); !ok {
 		if person.DefaultID == nil {
 			return fmt.Errorf("ent: uninitialized person.DefaultID (forgotten import ent/runtime?)")
@@ -246,6 +238,9 @@ func (pc *PersonCreate) check() error {
 	}
 	if _, ok := pc.mutation.Phone(); !ok {
 		return &ValidationError{Name: "phone", err: errors.New(`ent: missing required field "Person.phone"`)}
+	}
+	if len(pc.mutation.DocumentsIDs()) == 0 {
+		return &ValidationError{Name: "documents", err: errors.New(`ent: missing required edge "Person.documents"`)}
 	}
 	return nil
 }
@@ -307,29 +302,12 @@ func (pc *PersonCreate) createSpec() (*Person, *sqlgraph.CreateSpec) {
 		_spec.SetField(person.FieldPhone, field.TypeString, value)
 		_node.Phone = value
 	}
-	if nodes := pc.mutation.DocumentIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   person.DocumentTable,
-			Columns: []string{person.DocumentColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeUUID),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_node.DocumentID = nodes[0]
-		_spec.Edges = append(_spec.Edges, edge)
-	}
 	if nodes := pc.mutation.ContactOwnerIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
 			Table:   person.ContactOwnerTable,
-			Columns: []string{person.ContactOwnerColumn},
+			Columns: person.ContactOwnerPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -338,18 +316,33 @@ func (pc *PersonCreate) createSpec() (*Person, *sqlgraph.CreateSpec) {
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.person_contacts = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := pc.mutation.ContactsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   person.ContactsTable,
-			Columns: []string{person.ContactsColumn},
+			Columns: person.ContactsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := pc.mutation.DocumentsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.DocumentsTable,
+			Columns: person.DocumentsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(document.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -359,10 +352,10 @@ func (pc *PersonCreate) createSpec() (*Person, *sqlgraph.CreateSpec) {
 	}
 	if nodes := pc.mutation.MetadataIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
 			Table:   person.MetadataTable,
-			Columns: []string{person.MetadataColumn},
+			Columns: person.MetadataPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(metadata.FieldID, field.TypeUUID),
@@ -371,15 +364,14 @@ func (pc *PersonCreate) createSpec() (*Person, *sqlgraph.CreateSpec) {
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.MetadataID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
-	if nodes := pc.mutation.NodeIDs(); len(nodes) > 0 {
+	if nodes := pc.mutation.OriginatorNodesIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
-			Table:   person.NodeTable,
-			Columns: []string{person.NodeColumn},
+			Table:   person.OriginatorNodesTable,
+			Columns: person.OriginatorNodesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
@@ -388,7 +380,22 @@ func (pc *PersonCreate) createSpec() (*Person, *sqlgraph.CreateSpec) {
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.NodeID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := pc.mutation.SupplierNodesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.SupplierNodesTable,
+			Columns: person.SupplierNodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec
@@ -398,7 +405,7 @@ func (pc *PersonCreate) createSpec() (*Person, *sqlgraph.CreateSpec) {
 // of the `INSERT` statement. For example:
 //
 //	client.Person.Create().
-//		SetDocumentID(v).
+//		SetProtoMessage(v).
 //		OnConflict(
 //			// Update the row with the new values
 //			// the was proposed for insertion.
@@ -407,7 +414,7 @@ func (pc *PersonCreate) createSpec() (*Person, *sqlgraph.CreateSpec) {
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.PersonUpsert) {
-//			SetDocumentID(v+v).
+//			SetProtoMessage(v+v).
 //		}).
 //		Exec(ctx)
 func (pc *PersonCreate) OnConflict(opts ...sql.ConflictOption) *PersonUpsertOne {
@@ -442,42 +449,6 @@ type (
 		*sql.UpdateSet
 	}
 )
-
-// SetMetadataID sets the "metadata_id" field.
-func (u *PersonUpsert) SetMetadataID(v uuid.UUID) *PersonUpsert {
-	u.Set(person.FieldMetadataID, v)
-	return u
-}
-
-// UpdateMetadataID sets the "metadata_id" field to the value that was provided on create.
-func (u *PersonUpsert) UpdateMetadataID() *PersonUpsert {
-	u.SetExcluded(person.FieldMetadataID)
-	return u
-}
-
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (u *PersonUpsert) ClearMetadataID() *PersonUpsert {
-	u.SetNull(person.FieldMetadataID)
-	return u
-}
-
-// SetNodeID sets the "node_id" field.
-func (u *PersonUpsert) SetNodeID(v uuid.UUID) *PersonUpsert {
-	u.Set(person.FieldNodeID, v)
-	return u
-}
-
-// UpdateNodeID sets the "node_id" field to the value that was provided on create.
-func (u *PersonUpsert) UpdateNodeID() *PersonUpsert {
-	u.SetExcluded(person.FieldNodeID)
-	return u
-}
-
-// ClearNodeID clears the value of the "node_id" field.
-func (u *PersonUpsert) ClearNodeID() *PersonUpsert {
-	u.SetNull(person.FieldNodeID)
-	return u
-}
 
 // SetName sets the "name" field.
 func (u *PersonUpsert) SetName(v string) *PersonUpsert {
@@ -556,9 +527,6 @@ func (u *PersonUpsertOne) UpdateNewValues() *PersonUpsertOne {
 		if _, exists := u.create.mutation.ID(); exists {
 			s.SetIgnore(person.FieldID)
 		}
-		if _, exists := u.create.mutation.DocumentID(); exists {
-			s.SetIgnore(person.FieldDocumentID)
-		}
 		if _, exists := u.create.mutation.ProtoMessage(); exists {
 			s.SetIgnore(person.FieldProtoMessage)
 		}
@@ -591,48 +559,6 @@ func (u *PersonUpsertOne) Update(set func(*PersonUpsert)) *PersonUpsertOne {
 		set(&PersonUpsert{UpdateSet: update})
 	}))
 	return u
-}
-
-// SetMetadataID sets the "metadata_id" field.
-func (u *PersonUpsertOne) SetMetadataID(v uuid.UUID) *PersonUpsertOne {
-	return u.Update(func(s *PersonUpsert) {
-		s.SetMetadataID(v)
-	})
-}
-
-// UpdateMetadataID sets the "metadata_id" field to the value that was provided on create.
-func (u *PersonUpsertOne) UpdateMetadataID() *PersonUpsertOne {
-	return u.Update(func(s *PersonUpsert) {
-		s.UpdateMetadataID()
-	})
-}
-
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (u *PersonUpsertOne) ClearMetadataID() *PersonUpsertOne {
-	return u.Update(func(s *PersonUpsert) {
-		s.ClearMetadataID()
-	})
-}
-
-// SetNodeID sets the "node_id" field.
-func (u *PersonUpsertOne) SetNodeID(v uuid.UUID) *PersonUpsertOne {
-	return u.Update(func(s *PersonUpsert) {
-		s.SetNodeID(v)
-	})
-}
-
-// UpdateNodeID sets the "node_id" field to the value that was provided on create.
-func (u *PersonUpsertOne) UpdateNodeID() *PersonUpsertOne {
-	return u.Update(func(s *PersonUpsert) {
-		s.UpdateNodeID()
-	})
-}
-
-// ClearNodeID clears the value of the "node_id" field.
-func (u *PersonUpsertOne) ClearNodeID() *PersonUpsertOne {
-	return u.Update(func(s *PersonUpsert) {
-		s.ClearNodeID()
-	})
 }
 
 // SetName sets the "name" field.
@@ -841,7 +767,7 @@ func (pcb *PersonCreateBulk) ExecX(ctx context.Context) {
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.PersonUpsert) {
-//			SetDocumentID(v+v).
+//			SetProtoMessage(v+v).
 //		}).
 //		Exec(ctx)
 func (pcb *PersonCreateBulk) OnConflict(opts ...sql.ConflictOption) *PersonUpsertBulk {
@@ -888,9 +814,6 @@ func (u *PersonUpsertBulk) UpdateNewValues() *PersonUpsertBulk {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(person.FieldID)
 			}
-			if _, exists := b.mutation.DocumentID(); exists {
-				s.SetIgnore(person.FieldDocumentID)
-			}
 			if _, exists := b.mutation.ProtoMessage(); exists {
 				s.SetIgnore(person.FieldProtoMessage)
 			}
@@ -924,48 +847,6 @@ func (u *PersonUpsertBulk) Update(set func(*PersonUpsert)) *PersonUpsertBulk {
 		set(&PersonUpsert{UpdateSet: update})
 	}))
 	return u
-}
-
-// SetMetadataID sets the "metadata_id" field.
-func (u *PersonUpsertBulk) SetMetadataID(v uuid.UUID) *PersonUpsertBulk {
-	return u.Update(func(s *PersonUpsert) {
-		s.SetMetadataID(v)
-	})
-}
-
-// UpdateMetadataID sets the "metadata_id" field to the value that was provided on create.
-func (u *PersonUpsertBulk) UpdateMetadataID() *PersonUpsertBulk {
-	return u.Update(func(s *PersonUpsert) {
-		s.UpdateMetadataID()
-	})
-}
-
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (u *PersonUpsertBulk) ClearMetadataID() *PersonUpsertBulk {
-	return u.Update(func(s *PersonUpsert) {
-		s.ClearMetadataID()
-	})
-}
-
-// SetNodeID sets the "node_id" field.
-func (u *PersonUpsertBulk) SetNodeID(v uuid.UUID) *PersonUpsertBulk {
-	return u.Update(func(s *PersonUpsert) {
-		s.SetNodeID(v)
-	})
-}
-
-// UpdateNodeID sets the "node_id" field to the value that was provided on create.
-func (u *PersonUpsertBulk) UpdateNodeID() *PersonUpsertBulk {
-	return u.Update(func(s *PersonUpsert) {
-		s.UpdateNodeID()
-	})
-}
-
-// ClearNodeID clears the value of the "node_id" field.
-func (u *PersonUpsertBulk) ClearNodeID() *PersonUpsertBulk {
-	return u.Update(func(s *PersonUpsert) {
-		s.ClearNodeID()
-	})
 }
 
 // SetName sets the "name" field.

--- a/internal/backends/ent/person_update.go
+++ b/internal/backends/ent/person_update.go
@@ -35,46 +35,6 @@ func (pu *PersonUpdate) Where(ps ...predicate.Person) *PersonUpdate {
 	return pu
 }
 
-// SetMetadataID sets the "metadata_id" field.
-func (pu *PersonUpdate) SetMetadataID(u uuid.UUID) *PersonUpdate {
-	pu.mutation.SetMetadataID(u)
-	return pu
-}
-
-// SetNillableMetadataID sets the "metadata_id" field if the given value is not nil.
-func (pu *PersonUpdate) SetNillableMetadataID(u *uuid.UUID) *PersonUpdate {
-	if u != nil {
-		pu.SetMetadataID(*u)
-	}
-	return pu
-}
-
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (pu *PersonUpdate) ClearMetadataID() *PersonUpdate {
-	pu.mutation.ClearMetadataID()
-	return pu
-}
-
-// SetNodeID sets the "node_id" field.
-func (pu *PersonUpdate) SetNodeID(u uuid.UUID) *PersonUpdate {
-	pu.mutation.SetNodeID(u)
-	return pu
-}
-
-// SetNillableNodeID sets the "node_id" field if the given value is not nil.
-func (pu *PersonUpdate) SetNillableNodeID(u *uuid.UUID) *PersonUpdate {
-	if u != nil {
-		pu.SetNodeID(*u)
-	}
-	return pu
-}
-
-// ClearNodeID clears the value of the "node_id" field.
-func (pu *PersonUpdate) ClearNodeID() *PersonUpdate {
-	pu.mutation.ClearNodeID()
-	return pu
-}
-
 // SetName sets the "name" field.
 func (pu *PersonUpdate) SetName(s string) *PersonUpdate {
 	pu.mutation.SetName(s)
@@ -145,23 +105,19 @@ func (pu *PersonUpdate) SetNillablePhone(s *string) *PersonUpdate {
 	return pu
 }
 
-// SetContactOwnerID sets the "contact_owner" edge to the Person entity by ID.
-func (pu *PersonUpdate) SetContactOwnerID(id uuid.UUID) *PersonUpdate {
-	pu.mutation.SetContactOwnerID(id)
+// AddContactOwnerIDs adds the "contact_owner" edge to the Person entity by IDs.
+func (pu *PersonUpdate) AddContactOwnerIDs(ids ...uuid.UUID) *PersonUpdate {
+	pu.mutation.AddContactOwnerIDs(ids...)
 	return pu
 }
 
-// SetNillableContactOwnerID sets the "contact_owner" edge to the Person entity by ID if the given value is not nil.
-func (pu *PersonUpdate) SetNillableContactOwnerID(id *uuid.UUID) *PersonUpdate {
-	if id != nil {
-		pu = pu.SetContactOwnerID(*id)
+// AddContactOwner adds the "contact_owner" edges to the Person entity.
+func (pu *PersonUpdate) AddContactOwner(p ...*Person) *PersonUpdate {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
 	}
-	return pu
-}
-
-// SetContactOwner sets the "contact_owner" edge to the Person entity.
-func (pu *PersonUpdate) SetContactOwner(p *Person) *PersonUpdate {
-	return pu.SetContactOwnerID(p.ID)
+	return pu.AddContactOwnerIDs(ids...)
 }
 
 // AddContactIDs adds the "contacts" edge to the Person entity by IDs.
@@ -179,14 +135,49 @@ func (pu *PersonUpdate) AddContacts(p ...*Person) *PersonUpdate {
 	return pu.AddContactIDs(ids...)
 }
 
-// SetMetadata sets the "metadata" edge to the Metadata entity.
-func (pu *PersonUpdate) SetMetadata(m *Metadata) *PersonUpdate {
-	return pu.SetMetadataID(m.ID)
+// AddMetadatumIDs adds the "metadata" edge to the Metadata entity by IDs.
+func (pu *PersonUpdate) AddMetadatumIDs(ids ...uuid.UUID) *PersonUpdate {
+	pu.mutation.AddMetadatumIDs(ids...)
+	return pu
 }
 
-// SetNode sets the "node" edge to the Node entity.
-func (pu *PersonUpdate) SetNode(n *Node) *PersonUpdate {
-	return pu.SetNodeID(n.ID)
+// AddMetadata adds the "metadata" edges to the Metadata entity.
+func (pu *PersonUpdate) AddMetadata(m ...*Metadata) *PersonUpdate {
+	ids := make([]uuid.UUID, len(m))
+	for i := range m {
+		ids[i] = m[i].ID
+	}
+	return pu.AddMetadatumIDs(ids...)
+}
+
+// AddOriginatorNodeIDs adds the "originator_nodes" edge to the Node entity by IDs.
+func (pu *PersonUpdate) AddOriginatorNodeIDs(ids ...uuid.UUID) *PersonUpdate {
+	pu.mutation.AddOriginatorNodeIDs(ids...)
+	return pu
+}
+
+// AddOriginatorNodes adds the "originator_nodes" edges to the Node entity.
+func (pu *PersonUpdate) AddOriginatorNodes(n ...*Node) *PersonUpdate {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return pu.AddOriginatorNodeIDs(ids...)
+}
+
+// AddSupplierNodeIDs adds the "supplier_nodes" edge to the Node entity by IDs.
+func (pu *PersonUpdate) AddSupplierNodeIDs(ids ...uuid.UUID) *PersonUpdate {
+	pu.mutation.AddSupplierNodeIDs(ids...)
+	return pu
+}
+
+// AddSupplierNodes adds the "supplier_nodes" edges to the Node entity.
+func (pu *PersonUpdate) AddSupplierNodes(n ...*Node) *PersonUpdate {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return pu.AddSupplierNodeIDs(ids...)
 }
 
 // Mutation returns the PersonMutation object of the builder.
@@ -194,10 +185,25 @@ func (pu *PersonUpdate) Mutation() *PersonMutation {
 	return pu.mutation
 }
 
-// ClearContactOwner clears the "contact_owner" edge to the Person entity.
+// ClearContactOwner clears all "contact_owner" edges to the Person entity.
 func (pu *PersonUpdate) ClearContactOwner() *PersonUpdate {
 	pu.mutation.ClearContactOwner()
 	return pu
+}
+
+// RemoveContactOwnerIDs removes the "contact_owner" edge to Person entities by IDs.
+func (pu *PersonUpdate) RemoveContactOwnerIDs(ids ...uuid.UUID) *PersonUpdate {
+	pu.mutation.RemoveContactOwnerIDs(ids...)
+	return pu
+}
+
+// RemoveContactOwner removes "contact_owner" edges to Person entities.
+func (pu *PersonUpdate) RemoveContactOwner(p ...*Person) *PersonUpdate {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return pu.RemoveContactOwnerIDs(ids...)
 }
 
 // ClearContacts clears all "contacts" edges to the Person entity.
@@ -221,16 +227,67 @@ func (pu *PersonUpdate) RemoveContacts(p ...*Person) *PersonUpdate {
 	return pu.RemoveContactIDs(ids...)
 }
 
-// ClearMetadata clears the "metadata" edge to the Metadata entity.
+// ClearMetadata clears all "metadata" edges to the Metadata entity.
 func (pu *PersonUpdate) ClearMetadata() *PersonUpdate {
 	pu.mutation.ClearMetadata()
 	return pu
 }
 
-// ClearNode clears the "node" edge to the Node entity.
-func (pu *PersonUpdate) ClearNode() *PersonUpdate {
-	pu.mutation.ClearNode()
+// RemoveMetadatumIDs removes the "metadata" edge to Metadata entities by IDs.
+func (pu *PersonUpdate) RemoveMetadatumIDs(ids ...uuid.UUID) *PersonUpdate {
+	pu.mutation.RemoveMetadatumIDs(ids...)
 	return pu
+}
+
+// RemoveMetadata removes "metadata" edges to Metadata entities.
+func (pu *PersonUpdate) RemoveMetadata(m ...*Metadata) *PersonUpdate {
+	ids := make([]uuid.UUID, len(m))
+	for i := range m {
+		ids[i] = m[i].ID
+	}
+	return pu.RemoveMetadatumIDs(ids...)
+}
+
+// ClearOriginatorNodes clears all "originator_nodes" edges to the Node entity.
+func (pu *PersonUpdate) ClearOriginatorNodes() *PersonUpdate {
+	pu.mutation.ClearOriginatorNodes()
+	return pu
+}
+
+// RemoveOriginatorNodeIDs removes the "originator_nodes" edge to Node entities by IDs.
+func (pu *PersonUpdate) RemoveOriginatorNodeIDs(ids ...uuid.UUID) *PersonUpdate {
+	pu.mutation.RemoveOriginatorNodeIDs(ids...)
+	return pu
+}
+
+// RemoveOriginatorNodes removes "originator_nodes" edges to Node entities.
+func (pu *PersonUpdate) RemoveOriginatorNodes(n ...*Node) *PersonUpdate {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return pu.RemoveOriginatorNodeIDs(ids...)
+}
+
+// ClearSupplierNodes clears all "supplier_nodes" edges to the Node entity.
+func (pu *PersonUpdate) ClearSupplierNodes() *PersonUpdate {
+	pu.mutation.ClearSupplierNodes()
+	return pu
+}
+
+// RemoveSupplierNodeIDs removes the "supplier_nodes" edge to Node entities by IDs.
+func (pu *PersonUpdate) RemoveSupplierNodeIDs(ids ...uuid.UUID) *PersonUpdate {
+	pu.mutation.RemoveSupplierNodeIDs(ids...)
+	return pu
+}
+
+// RemoveSupplierNodes removes "supplier_nodes" edges to Node entities.
+func (pu *PersonUpdate) RemoveSupplierNodes(n ...*Node) *PersonUpdate {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return pu.RemoveSupplierNodeIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -286,10 +343,10 @@ func (pu *PersonUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if pu.mutation.ContactOwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
 			Table:   person.ContactOwnerTable,
-			Columns: []string{person.ContactOwnerColumn},
+			Columns: person.ContactOwnerPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -297,12 +354,28 @@ func (pu *PersonUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := pu.mutation.ContactOwnerIDs(); len(nodes) > 0 {
+	if nodes := pu.mutation.RemovedContactOwnerIDs(); len(nodes) > 0 && !pu.mutation.ContactOwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
 			Table:   person.ContactOwnerTable,
-			Columns: []string{person.ContactOwnerColumn},
+			Columns: person.ContactOwnerPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.ContactOwnerIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.ContactOwnerTable,
+			Columns: person.ContactOwnerPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -315,10 +388,10 @@ func (pu *PersonUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if pu.mutation.ContactsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   person.ContactsTable,
-			Columns: []string{person.ContactsColumn},
+			Columns: person.ContactsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -328,10 +401,10 @@ func (pu *PersonUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := pu.mutation.RemovedContactsIDs(); len(nodes) > 0 && !pu.mutation.ContactsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   person.ContactsTable,
-			Columns: []string{person.ContactsColumn},
+			Columns: person.ContactsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -344,10 +417,10 @@ func (pu *PersonUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := pu.mutation.ContactsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   person.ContactsTable,
-			Columns: []string{person.ContactsColumn},
+			Columns: person.ContactsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -360,10 +433,10 @@ func (pu *PersonUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if pu.mutation.MetadataCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
 			Table:   person.MetadataTable,
-			Columns: []string{person.MetadataColumn},
+			Columns: person.MetadataPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(metadata.FieldID, field.TypeUUID),
@@ -371,12 +444,28 @@ func (pu *PersonUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := pu.mutation.MetadataIDs(); len(nodes) > 0 {
+	if nodes := pu.mutation.RemovedMetadataIDs(); len(nodes) > 0 && !pu.mutation.MetadataCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
 			Table:   person.MetadataTable,
-			Columns: []string{person.MetadataColumn},
+			Columns: person.MetadataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(metadata.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.MetadataIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.MetadataTable,
+			Columns: person.MetadataPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(metadata.FieldID, field.TypeUUID),
@@ -387,12 +476,12 @@ func (pu *PersonUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if pu.mutation.NodeCleared() {
+	if pu.mutation.OriginatorNodesCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
-			Table:   person.NodeTable,
-			Columns: []string{person.NodeColumn},
+			Table:   person.OriginatorNodesTable,
+			Columns: person.OriginatorNodesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
@@ -400,12 +489,73 @@ func (pu *PersonUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := pu.mutation.NodeIDs(); len(nodes) > 0 {
+	if nodes := pu.mutation.RemovedOriginatorNodesIDs(); len(nodes) > 0 && !pu.mutation.OriginatorNodesCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
-			Table:   person.NodeTable,
-			Columns: []string{person.NodeColumn},
+			Table:   person.OriginatorNodesTable,
+			Columns: person.OriginatorNodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.OriginatorNodesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.OriginatorNodesTable,
+			Columns: person.OriginatorNodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if pu.mutation.SupplierNodesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.SupplierNodesTable,
+			Columns: person.SupplierNodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.RemovedSupplierNodesIDs(); len(nodes) > 0 && !pu.mutation.SupplierNodesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.SupplierNodesTable,
+			Columns: person.SupplierNodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.SupplierNodesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.SupplierNodesTable,
+			Columns: person.SupplierNodesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
@@ -434,46 +584,6 @@ type PersonUpdateOne struct {
 	fields   []string
 	hooks    []Hook
 	mutation *PersonMutation
-}
-
-// SetMetadataID sets the "metadata_id" field.
-func (puo *PersonUpdateOne) SetMetadataID(u uuid.UUID) *PersonUpdateOne {
-	puo.mutation.SetMetadataID(u)
-	return puo
-}
-
-// SetNillableMetadataID sets the "metadata_id" field if the given value is not nil.
-func (puo *PersonUpdateOne) SetNillableMetadataID(u *uuid.UUID) *PersonUpdateOne {
-	if u != nil {
-		puo.SetMetadataID(*u)
-	}
-	return puo
-}
-
-// ClearMetadataID clears the value of the "metadata_id" field.
-func (puo *PersonUpdateOne) ClearMetadataID() *PersonUpdateOne {
-	puo.mutation.ClearMetadataID()
-	return puo
-}
-
-// SetNodeID sets the "node_id" field.
-func (puo *PersonUpdateOne) SetNodeID(u uuid.UUID) *PersonUpdateOne {
-	puo.mutation.SetNodeID(u)
-	return puo
-}
-
-// SetNillableNodeID sets the "node_id" field if the given value is not nil.
-func (puo *PersonUpdateOne) SetNillableNodeID(u *uuid.UUID) *PersonUpdateOne {
-	if u != nil {
-		puo.SetNodeID(*u)
-	}
-	return puo
-}
-
-// ClearNodeID clears the value of the "node_id" field.
-func (puo *PersonUpdateOne) ClearNodeID() *PersonUpdateOne {
-	puo.mutation.ClearNodeID()
-	return puo
 }
 
 // SetName sets the "name" field.
@@ -546,23 +656,19 @@ func (puo *PersonUpdateOne) SetNillablePhone(s *string) *PersonUpdateOne {
 	return puo
 }
 
-// SetContactOwnerID sets the "contact_owner" edge to the Person entity by ID.
-func (puo *PersonUpdateOne) SetContactOwnerID(id uuid.UUID) *PersonUpdateOne {
-	puo.mutation.SetContactOwnerID(id)
+// AddContactOwnerIDs adds the "contact_owner" edge to the Person entity by IDs.
+func (puo *PersonUpdateOne) AddContactOwnerIDs(ids ...uuid.UUID) *PersonUpdateOne {
+	puo.mutation.AddContactOwnerIDs(ids...)
 	return puo
 }
 
-// SetNillableContactOwnerID sets the "contact_owner" edge to the Person entity by ID if the given value is not nil.
-func (puo *PersonUpdateOne) SetNillableContactOwnerID(id *uuid.UUID) *PersonUpdateOne {
-	if id != nil {
-		puo = puo.SetContactOwnerID(*id)
+// AddContactOwner adds the "contact_owner" edges to the Person entity.
+func (puo *PersonUpdateOne) AddContactOwner(p ...*Person) *PersonUpdateOne {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
 	}
-	return puo
-}
-
-// SetContactOwner sets the "contact_owner" edge to the Person entity.
-func (puo *PersonUpdateOne) SetContactOwner(p *Person) *PersonUpdateOne {
-	return puo.SetContactOwnerID(p.ID)
+	return puo.AddContactOwnerIDs(ids...)
 }
 
 // AddContactIDs adds the "contacts" edge to the Person entity by IDs.
@@ -580,14 +686,49 @@ func (puo *PersonUpdateOne) AddContacts(p ...*Person) *PersonUpdateOne {
 	return puo.AddContactIDs(ids...)
 }
 
-// SetMetadata sets the "metadata" edge to the Metadata entity.
-func (puo *PersonUpdateOne) SetMetadata(m *Metadata) *PersonUpdateOne {
-	return puo.SetMetadataID(m.ID)
+// AddMetadatumIDs adds the "metadata" edge to the Metadata entity by IDs.
+func (puo *PersonUpdateOne) AddMetadatumIDs(ids ...uuid.UUID) *PersonUpdateOne {
+	puo.mutation.AddMetadatumIDs(ids...)
+	return puo
 }
 
-// SetNode sets the "node" edge to the Node entity.
-func (puo *PersonUpdateOne) SetNode(n *Node) *PersonUpdateOne {
-	return puo.SetNodeID(n.ID)
+// AddMetadata adds the "metadata" edges to the Metadata entity.
+func (puo *PersonUpdateOne) AddMetadata(m ...*Metadata) *PersonUpdateOne {
+	ids := make([]uuid.UUID, len(m))
+	for i := range m {
+		ids[i] = m[i].ID
+	}
+	return puo.AddMetadatumIDs(ids...)
+}
+
+// AddOriginatorNodeIDs adds the "originator_nodes" edge to the Node entity by IDs.
+func (puo *PersonUpdateOne) AddOriginatorNodeIDs(ids ...uuid.UUID) *PersonUpdateOne {
+	puo.mutation.AddOriginatorNodeIDs(ids...)
+	return puo
+}
+
+// AddOriginatorNodes adds the "originator_nodes" edges to the Node entity.
+func (puo *PersonUpdateOne) AddOriginatorNodes(n ...*Node) *PersonUpdateOne {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return puo.AddOriginatorNodeIDs(ids...)
+}
+
+// AddSupplierNodeIDs adds the "supplier_nodes" edge to the Node entity by IDs.
+func (puo *PersonUpdateOne) AddSupplierNodeIDs(ids ...uuid.UUID) *PersonUpdateOne {
+	puo.mutation.AddSupplierNodeIDs(ids...)
+	return puo
+}
+
+// AddSupplierNodes adds the "supplier_nodes" edges to the Node entity.
+func (puo *PersonUpdateOne) AddSupplierNodes(n ...*Node) *PersonUpdateOne {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return puo.AddSupplierNodeIDs(ids...)
 }
 
 // Mutation returns the PersonMutation object of the builder.
@@ -595,10 +736,25 @@ func (puo *PersonUpdateOne) Mutation() *PersonMutation {
 	return puo.mutation
 }
 
-// ClearContactOwner clears the "contact_owner" edge to the Person entity.
+// ClearContactOwner clears all "contact_owner" edges to the Person entity.
 func (puo *PersonUpdateOne) ClearContactOwner() *PersonUpdateOne {
 	puo.mutation.ClearContactOwner()
 	return puo
+}
+
+// RemoveContactOwnerIDs removes the "contact_owner" edge to Person entities by IDs.
+func (puo *PersonUpdateOne) RemoveContactOwnerIDs(ids ...uuid.UUID) *PersonUpdateOne {
+	puo.mutation.RemoveContactOwnerIDs(ids...)
+	return puo
+}
+
+// RemoveContactOwner removes "contact_owner" edges to Person entities.
+func (puo *PersonUpdateOne) RemoveContactOwner(p ...*Person) *PersonUpdateOne {
+	ids := make([]uuid.UUID, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return puo.RemoveContactOwnerIDs(ids...)
 }
 
 // ClearContacts clears all "contacts" edges to the Person entity.
@@ -622,16 +778,67 @@ func (puo *PersonUpdateOne) RemoveContacts(p ...*Person) *PersonUpdateOne {
 	return puo.RemoveContactIDs(ids...)
 }
 
-// ClearMetadata clears the "metadata" edge to the Metadata entity.
+// ClearMetadata clears all "metadata" edges to the Metadata entity.
 func (puo *PersonUpdateOne) ClearMetadata() *PersonUpdateOne {
 	puo.mutation.ClearMetadata()
 	return puo
 }
 
-// ClearNode clears the "node" edge to the Node entity.
-func (puo *PersonUpdateOne) ClearNode() *PersonUpdateOne {
-	puo.mutation.ClearNode()
+// RemoveMetadatumIDs removes the "metadata" edge to Metadata entities by IDs.
+func (puo *PersonUpdateOne) RemoveMetadatumIDs(ids ...uuid.UUID) *PersonUpdateOne {
+	puo.mutation.RemoveMetadatumIDs(ids...)
 	return puo
+}
+
+// RemoveMetadata removes "metadata" edges to Metadata entities.
+func (puo *PersonUpdateOne) RemoveMetadata(m ...*Metadata) *PersonUpdateOne {
+	ids := make([]uuid.UUID, len(m))
+	for i := range m {
+		ids[i] = m[i].ID
+	}
+	return puo.RemoveMetadatumIDs(ids...)
+}
+
+// ClearOriginatorNodes clears all "originator_nodes" edges to the Node entity.
+func (puo *PersonUpdateOne) ClearOriginatorNodes() *PersonUpdateOne {
+	puo.mutation.ClearOriginatorNodes()
+	return puo
+}
+
+// RemoveOriginatorNodeIDs removes the "originator_nodes" edge to Node entities by IDs.
+func (puo *PersonUpdateOne) RemoveOriginatorNodeIDs(ids ...uuid.UUID) *PersonUpdateOne {
+	puo.mutation.RemoveOriginatorNodeIDs(ids...)
+	return puo
+}
+
+// RemoveOriginatorNodes removes "originator_nodes" edges to Node entities.
+func (puo *PersonUpdateOne) RemoveOriginatorNodes(n ...*Node) *PersonUpdateOne {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return puo.RemoveOriginatorNodeIDs(ids...)
+}
+
+// ClearSupplierNodes clears all "supplier_nodes" edges to the Node entity.
+func (puo *PersonUpdateOne) ClearSupplierNodes() *PersonUpdateOne {
+	puo.mutation.ClearSupplierNodes()
+	return puo
+}
+
+// RemoveSupplierNodeIDs removes the "supplier_nodes" edge to Node entities by IDs.
+func (puo *PersonUpdateOne) RemoveSupplierNodeIDs(ids ...uuid.UUID) *PersonUpdateOne {
+	puo.mutation.RemoveSupplierNodeIDs(ids...)
+	return puo
+}
+
+// RemoveSupplierNodes removes "supplier_nodes" edges to Node entities.
+func (puo *PersonUpdateOne) RemoveSupplierNodes(n ...*Node) *PersonUpdateOne {
+	ids := make([]uuid.UUID, len(n))
+	for i := range n {
+		ids[i] = n[i].ID
+	}
+	return puo.RemoveSupplierNodeIDs(ids...)
 }
 
 // Where appends a list predicates to the PersonUpdate builder.
@@ -717,10 +924,10 @@ func (puo *PersonUpdateOne) sqlSave(ctx context.Context) (_node *Person, err err
 	}
 	if puo.mutation.ContactOwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
 			Table:   person.ContactOwnerTable,
-			Columns: []string{person.ContactOwnerColumn},
+			Columns: person.ContactOwnerPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -728,12 +935,28 @@ func (puo *PersonUpdateOne) sqlSave(ctx context.Context) (_node *Person, err err
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := puo.mutation.ContactOwnerIDs(); len(nodes) > 0 {
+	if nodes := puo.mutation.RemovedContactOwnerIDs(); len(nodes) > 0 && !puo.mutation.ContactOwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
 			Table:   person.ContactOwnerTable,
-			Columns: []string{person.ContactOwnerColumn},
+			Columns: person.ContactOwnerPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.ContactOwnerIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.ContactOwnerTable,
+			Columns: person.ContactOwnerPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -746,10 +969,10 @@ func (puo *PersonUpdateOne) sqlSave(ctx context.Context) (_node *Person, err err
 	}
 	if puo.mutation.ContactsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   person.ContactsTable,
-			Columns: []string{person.ContactsColumn},
+			Columns: person.ContactsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -759,10 +982,10 @@ func (puo *PersonUpdateOne) sqlSave(ctx context.Context) (_node *Person, err err
 	}
 	if nodes := puo.mutation.RemovedContactsIDs(); len(nodes) > 0 && !puo.mutation.ContactsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   person.ContactsTable,
-			Columns: []string{person.ContactsColumn},
+			Columns: person.ContactsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -775,10 +998,10 @@ func (puo *PersonUpdateOne) sqlSave(ctx context.Context) (_node *Person, err err
 	}
 	if nodes := puo.mutation.ContactsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   person.ContactsTable,
-			Columns: []string{person.ContactsColumn},
+			Columns: person.ContactsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(person.FieldID, field.TypeUUID),
@@ -791,10 +1014,10 @@ func (puo *PersonUpdateOne) sqlSave(ctx context.Context) (_node *Person, err err
 	}
 	if puo.mutation.MetadataCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
 			Table:   person.MetadataTable,
-			Columns: []string{person.MetadataColumn},
+			Columns: person.MetadataPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(metadata.FieldID, field.TypeUUID),
@@ -802,12 +1025,28 @@ func (puo *PersonUpdateOne) sqlSave(ctx context.Context) (_node *Person, err err
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := puo.mutation.MetadataIDs(); len(nodes) > 0 {
+	if nodes := puo.mutation.RemovedMetadataIDs(); len(nodes) > 0 && !puo.mutation.MetadataCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
 			Table:   person.MetadataTable,
-			Columns: []string{person.MetadataColumn},
+			Columns: person.MetadataPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(metadata.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.MetadataIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.MetadataTable,
+			Columns: person.MetadataPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(metadata.FieldID, field.TypeUUID),
@@ -818,12 +1057,12 @@ func (puo *PersonUpdateOne) sqlSave(ctx context.Context) (_node *Person, err err
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if puo.mutation.NodeCleared() {
+	if puo.mutation.OriginatorNodesCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
-			Table:   person.NodeTable,
-			Columns: []string{person.NodeColumn},
+			Table:   person.OriginatorNodesTable,
+			Columns: person.OriginatorNodesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
@@ -831,12 +1070,73 @@ func (puo *PersonUpdateOne) sqlSave(ctx context.Context) (_node *Person, err err
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := puo.mutation.NodeIDs(); len(nodes) > 0 {
+	if nodes := puo.mutation.RemovedOriginatorNodesIDs(); len(nodes) > 0 && !puo.mutation.OriginatorNodesCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
+			Rel:     sqlgraph.M2M,
 			Inverse: true,
-			Table:   person.NodeTable,
-			Columns: []string{person.NodeColumn},
+			Table:   person.OriginatorNodesTable,
+			Columns: person.OriginatorNodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.OriginatorNodesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.OriginatorNodesTable,
+			Columns: person.OriginatorNodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if puo.mutation.SupplierNodesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.SupplierNodesTable,
+			Columns: person.SupplierNodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.RemovedSupplierNodesIDs(); len(nodes) > 0 && !puo.mutation.SupplierNodesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.SupplierNodesTable,
+			Columns: person.SupplierNodesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.SupplierNodesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   person.SupplierNodesTable,
+			Columns: person.SupplierNodesPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(node.FieldID, field.TypeUUID),

--- a/internal/backends/ent/property/where.go
+++ b/internal/backends/ent/property/where.go
@@ -60,19 +60,9 @@ func IDLTE(id uuid.UUID) predicate.Property {
 	return predicate.Property(sql.FieldLTE(FieldID, id))
 }
 
-// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
-func DocumentID(v uuid.UUID) predicate.Property {
-	return predicate.Property(sql.FieldEQ(FieldDocumentID, v))
-}
-
 // ProtoMessage applies equality check predicate on the "proto_message" field. It's identical to ProtoMessageEQ.
 func ProtoMessage(v *sbom.Property) predicate.Property {
 	return predicate.Property(sql.FieldEQ(FieldProtoMessage, v))
-}
-
-// NodeID applies equality check predicate on the "node_id" field. It's identical to NodeIDEQ.
-func NodeID(v uuid.UUID) predicate.Property {
-	return predicate.Property(sql.FieldEQ(FieldNodeID, v))
 }
 
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
@@ -83,36 +73,6 @@ func Name(v string) predicate.Property {
 // Data applies equality check predicate on the "data" field. It's identical to DataEQ.
 func Data(v string) predicate.Property {
 	return predicate.Property(sql.FieldEQ(FieldData, v))
-}
-
-// DocumentIDEQ applies the EQ predicate on the "document_id" field.
-func DocumentIDEQ(v uuid.UUID) predicate.Property {
-	return predicate.Property(sql.FieldEQ(FieldDocumentID, v))
-}
-
-// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
-func DocumentIDNEQ(v uuid.UUID) predicate.Property {
-	return predicate.Property(sql.FieldNEQ(FieldDocumentID, v))
-}
-
-// DocumentIDIn applies the In predicate on the "document_id" field.
-func DocumentIDIn(vs ...uuid.UUID) predicate.Property {
-	return predicate.Property(sql.FieldIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
-func DocumentIDNotIn(vs ...uuid.UUID) predicate.Property {
-	return predicate.Property(sql.FieldNotIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDIsNil applies the IsNil predicate on the "document_id" field.
-func DocumentIDIsNil() predicate.Property {
-	return predicate.Property(sql.FieldIsNull(FieldDocumentID))
-}
-
-// DocumentIDNotNil applies the NotNil predicate on the "document_id" field.
-func DocumentIDNotNil() predicate.Property {
-	return predicate.Property(sql.FieldNotNull(FieldDocumentID))
 }
 
 // ProtoMessageEQ applies the EQ predicate on the "proto_message" field.
@@ -153,26 +113,6 @@ func ProtoMessageLT(v *sbom.Property) predicate.Property {
 // ProtoMessageLTE applies the LTE predicate on the "proto_message" field.
 func ProtoMessageLTE(v *sbom.Property) predicate.Property {
 	return predicate.Property(sql.FieldLTE(FieldProtoMessage, v))
-}
-
-// NodeIDEQ applies the EQ predicate on the "node_id" field.
-func NodeIDEQ(v uuid.UUID) predicate.Property {
-	return predicate.Property(sql.FieldEQ(FieldNodeID, v))
-}
-
-// NodeIDNEQ applies the NEQ predicate on the "node_id" field.
-func NodeIDNEQ(v uuid.UUID) predicate.Property {
-	return predicate.Property(sql.FieldNEQ(FieldNodeID, v))
-}
-
-// NodeIDIn applies the In predicate on the "node_id" field.
-func NodeIDIn(vs ...uuid.UUID) predicate.Property {
-	return predicate.Property(sql.FieldIn(FieldNodeID, vs...))
-}
-
-// NodeIDNotIn applies the NotIn predicate on the "node_id" field.
-func NodeIDNotIn(vs ...uuid.UUID) predicate.Property {
-	return predicate.Property(sql.FieldNotIn(FieldNodeID, vs...))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.
@@ -305,21 +245,21 @@ func DataContainsFold(v string) predicate.Property {
 	return predicate.Property(sql.FieldContainsFold(FieldData, v))
 }
 
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.Property {
+// HasDocuments applies the HasEdge predicate on the "documents" edge.
+func HasDocuments() predicate.Property {
 	return predicate.Property(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
 }
 
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.Property {
+// HasDocumentsWith applies the HasEdge predicate on the "documents" edge with a given conditions (other predicates).
+func HasDocumentsWith(preds ...predicate.Document) predicate.Property {
 	return predicate.Property(func(s *sql.Selector) {
-		step := newDocumentStep()
+		step := newDocumentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -328,21 +268,21 @@ func HasDocumentWith(preds ...predicate.Document) predicate.Property {
 	})
 }
 
-// HasNode applies the HasEdge predicate on the "node" edge.
-func HasNode() predicate.Property {
+// HasNodes applies the HasEdge predicate on the "nodes" edge.
+func HasNodes() predicate.Property {
 	return predicate.Property(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, NodeTable, NodeColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, NodesTable, NodesPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
 }
 
-// HasNodeWith applies the HasEdge predicate on the "node" edge with a given conditions (other predicates).
-func HasNodeWith(preds ...predicate.Node) predicate.Property {
+// HasNodesWith applies the HasEdge predicate on the "nodes" edge with a given conditions (other predicates).
+func HasNodesWith(preds ...predicate.Node) predicate.Property {
 	return predicate.Property(func(s *sql.Selector) {
-		step := newNodeStep()
+		step := newNodesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/backends/ent/property_query.go
+++ b/internal/backends/ent/property_query.go
@@ -9,6 +9,7 @@ package ent
 
 import (
 	"context"
+	"database/sql/driver"
 	"fmt"
 	"math"
 
@@ -26,12 +27,12 @@ import (
 // PropertyQuery is the builder for querying Property entities.
 type PropertyQuery struct {
 	config
-	ctx          *QueryContext
-	order        []property.OrderOption
-	inters       []Interceptor
-	predicates   []predicate.Property
-	withDocument *DocumentQuery
-	withNode     *NodeQuery
+	ctx           *QueryContext
+	order         []property.OrderOption
+	inters        []Interceptor
+	predicates    []predicate.Property
+	withDocuments *DocumentQuery
+	withNodes     *NodeQuery
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -68,8 +69,8 @@ func (pq *PropertyQuery) Order(o ...property.OrderOption) *PropertyQuery {
 	return pq
 }
 
-// QueryDocument chains the current query on the "document" edge.
-func (pq *PropertyQuery) QueryDocument() *DocumentQuery {
+// QueryDocuments chains the current query on the "documents" edge.
+func (pq *PropertyQuery) QueryDocuments() *DocumentQuery {
 	query := (&DocumentClient{config: pq.config}).Query()
 	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
 		if err := pq.prepareQuery(ctx); err != nil {
@@ -82,7 +83,7 @@ func (pq *PropertyQuery) QueryDocument() *DocumentQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(property.Table, property.FieldID, selector),
 			sqlgraph.To(document.Table, document.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, property.DocumentTable, property.DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, property.DocumentsTable, property.DocumentsPrimaryKey...),
 		)
 		fromU = sqlgraph.SetNeighbors(pq.driver.Dialect(), step)
 		return fromU, nil
@@ -90,8 +91,8 @@ func (pq *PropertyQuery) QueryDocument() *DocumentQuery {
 	return query
 }
 
-// QueryNode chains the current query on the "node" edge.
-func (pq *PropertyQuery) QueryNode() *NodeQuery {
+// QueryNodes chains the current query on the "nodes" edge.
+func (pq *PropertyQuery) QueryNodes() *NodeQuery {
 	query := (&NodeClient{config: pq.config}).Query()
 	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
 		if err := pq.prepareQuery(ctx); err != nil {
@@ -104,7 +105,7 @@ func (pq *PropertyQuery) QueryNode() *NodeQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(property.Table, property.FieldID, selector),
 			sqlgraph.To(node.Table, node.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, property.NodeTable, property.NodeColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, property.NodesTable, property.NodesPrimaryKey...),
 		)
 		fromU = sqlgraph.SetNeighbors(pq.driver.Dialect(), step)
 		return fromU, nil
@@ -299,38 +300,38 @@ func (pq *PropertyQuery) Clone() *PropertyQuery {
 		return nil
 	}
 	return &PropertyQuery{
-		config:       pq.config,
-		ctx:          pq.ctx.Clone(),
-		order:        append([]property.OrderOption{}, pq.order...),
-		inters:       append([]Interceptor{}, pq.inters...),
-		predicates:   append([]predicate.Property{}, pq.predicates...),
-		withDocument: pq.withDocument.Clone(),
-		withNode:     pq.withNode.Clone(),
+		config:        pq.config,
+		ctx:           pq.ctx.Clone(),
+		order:         append([]property.OrderOption{}, pq.order...),
+		inters:        append([]Interceptor{}, pq.inters...),
+		predicates:    append([]predicate.Property{}, pq.predicates...),
+		withDocuments: pq.withDocuments.Clone(),
+		withNodes:     pq.withNodes.Clone(),
 		// clone intermediate query.
 		sql:  pq.sql.Clone(),
 		path: pq.path,
 	}
 }
 
-// WithDocument tells the query-builder to eager-load the nodes that are connected to
-// the "document" edge. The optional arguments are used to configure the query builder of the edge.
-func (pq *PropertyQuery) WithDocument(opts ...func(*DocumentQuery)) *PropertyQuery {
+// WithDocuments tells the query-builder to eager-load the nodes that are connected to
+// the "documents" edge. The optional arguments are used to configure the query builder of the edge.
+func (pq *PropertyQuery) WithDocuments(opts ...func(*DocumentQuery)) *PropertyQuery {
 	query := (&DocumentClient{config: pq.config}).Query()
 	for _, opt := range opts {
 		opt(query)
 	}
-	pq.withDocument = query
+	pq.withDocuments = query
 	return pq
 }
 
-// WithNode tells the query-builder to eager-load the nodes that are connected to
-// the "node" edge. The optional arguments are used to configure the query builder of the edge.
-func (pq *PropertyQuery) WithNode(opts ...func(*NodeQuery)) *PropertyQuery {
+// WithNodes tells the query-builder to eager-load the nodes that are connected to
+// the "nodes" edge. The optional arguments are used to configure the query builder of the edge.
+func (pq *PropertyQuery) WithNodes(opts ...func(*NodeQuery)) *PropertyQuery {
 	query := (&NodeClient{config: pq.config}).Query()
 	for _, opt := range opts {
 		opt(query)
 	}
-	pq.withNode = query
+	pq.withNodes = query
 	return pq
 }
 
@@ -340,12 +341,12 @@ func (pq *PropertyQuery) WithNode(opts ...func(*NodeQuery)) *PropertyQuery {
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"-"`
+//		ProtoMessage *sbom.Property `json:"-"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
 //	client.Property.Query().
-//		GroupBy(property.FieldDocumentID).
+//		GroupBy(property.FieldProtoMessage).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
 func (pq *PropertyQuery) GroupBy(field string, fields ...string) *PropertyGroupBy {
@@ -363,11 +364,11 @@ func (pq *PropertyQuery) GroupBy(field string, fields ...string) *PropertyGroupB
 // Example:
 //
 //	var v []struct {
-//		DocumentID uuid.UUID `json:"-"`
+//		ProtoMessage *sbom.Property `json:"-"`
 //	}
 //
 //	client.Property.Query().
-//		Select(property.FieldDocumentID).
+//		Select(property.FieldProtoMessage).
 //		Scan(ctx, &v)
 func (pq *PropertyQuery) Select(fields ...string) *PropertySelect {
 	pq.ctx.Fields = append(pq.ctx.Fields, fields...)
@@ -413,8 +414,8 @@ func (pq *PropertyQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Pro
 		nodes       = []*Property{}
 		_spec       = pq.querySpec()
 		loadedTypes = [2]bool{
-			pq.withDocument != nil,
-			pq.withNode != nil,
+			pq.withDocuments != nil,
+			pq.withNodes != nil,
 		}
 	)
 	_spec.ScanValues = func(columns []string) ([]any, error) {
@@ -435,75 +436,141 @@ func (pq *PropertyQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Pro
 	if len(nodes) == 0 {
 		return nodes, nil
 	}
-	if query := pq.withDocument; query != nil {
-		if err := pq.loadDocument(ctx, query, nodes, nil,
-			func(n *Property, e *Document) { n.Edges.Document = e }); err != nil {
+	if query := pq.withDocuments; query != nil {
+		if err := pq.loadDocuments(ctx, query, nodes,
+			func(n *Property) { n.Edges.Documents = []*Document{} },
+			func(n *Property, e *Document) { n.Edges.Documents = append(n.Edges.Documents, e) }); err != nil {
 			return nil, err
 		}
 	}
-	if query := pq.withNode; query != nil {
-		if err := pq.loadNode(ctx, query, nodes, nil,
-			func(n *Property, e *Node) { n.Edges.Node = e }); err != nil {
+	if query := pq.withNodes; query != nil {
+		if err := pq.loadNodes(ctx, query, nodes,
+			func(n *Property) { n.Edges.Nodes = []*Node{} },
+			func(n *Property, e *Node) { n.Edges.Nodes = append(n.Edges.Nodes, e) }); err != nil {
 			return nil, err
 		}
 	}
 	return nodes, nil
 }
 
-func (pq *PropertyQuery) loadDocument(ctx context.Context, query *DocumentQuery, nodes []*Property, init func(*Property), assign func(*Property, *Document)) error {
-	ids := make([]uuid.UUID, 0, len(nodes))
-	nodeids := make(map[uuid.UUID][]*Property)
-	for i := range nodes {
-		fk := nodes[i].DocumentID
-		if _, ok := nodeids[fk]; !ok {
-			ids = append(ids, fk)
+func (pq *PropertyQuery) loadDocuments(ctx context.Context, query *DocumentQuery, nodes []*Property, init func(*Property), assign func(*Property, *Document)) error {
+	edgeIDs := make([]driver.Value, len(nodes))
+	byID := make(map[uuid.UUID]*Property)
+	nids := make(map[uuid.UUID]map[*Property]struct{})
+	for i, node := range nodes {
+		edgeIDs[i] = node.ID
+		byID[node.ID] = node
+		if init != nil {
+			init(node)
 		}
-		nodeids[fk] = append(nodeids[fk], nodes[i])
 	}
-	if len(ids) == 0 {
-		return nil
+	query.Where(func(s *sql.Selector) {
+		joinT := sql.Table(property.DocumentsTable)
+		s.Join(joinT).On(s.C(document.FieldID), joinT.C(property.DocumentsPrimaryKey[0]))
+		s.Where(sql.InValues(joinT.C(property.DocumentsPrimaryKey[1]), edgeIDs...))
+		columns := s.SelectedColumns()
+		s.Select(joinT.C(property.DocumentsPrimaryKey[1]))
+		s.AppendSelect(columns...)
+		s.SetDistinct(false)
+	})
+	if err := query.prepareQuery(ctx); err != nil {
+		return err
 	}
-	query.Where(document.IDIn(ids...))
-	neighbors, err := query.All(ctx)
+	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
+		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+			assign := spec.Assign
+			values := spec.ScanValues
+			spec.ScanValues = func(columns []string) ([]any, error) {
+				values, err := values(columns[1:])
+				if err != nil {
+					return nil, err
+				}
+				return append([]any{new(uuid.UUID)}, values...), nil
+			}
+			spec.Assign = func(columns []string, values []any) error {
+				outValue := *values[0].(*uuid.UUID)
+				inValue := *values[1].(*uuid.UUID)
+				if nids[inValue] == nil {
+					nids[inValue] = map[*Property]struct{}{byID[outValue]: {}}
+					return assign(columns[1:], values[1:])
+				}
+				nids[inValue][byID[outValue]] = struct{}{}
+				return nil
+			}
+		})
+	})
+	neighbors, err := withInterceptors[[]*Document](ctx, query, qr, query.inters)
 	if err != nil {
 		return err
 	}
 	for _, n := range neighbors {
-		nodes, ok := nodeids[n.ID]
+		nodes, ok := nids[n.ID]
 		if !ok {
-			return fmt.Errorf(`unexpected foreign-key "document_id" returned %v`, n.ID)
+			return fmt.Errorf(`unexpected "documents" node returned %v`, n.ID)
 		}
-		for i := range nodes {
-			assign(nodes[i], n)
+		for kn := range nodes {
+			assign(kn, n)
 		}
 	}
 	return nil
 }
-func (pq *PropertyQuery) loadNode(ctx context.Context, query *NodeQuery, nodes []*Property, init func(*Property), assign func(*Property, *Node)) error {
-	ids := make([]uuid.UUID, 0, len(nodes))
-	nodeids := make(map[uuid.UUID][]*Property)
-	for i := range nodes {
-		fk := nodes[i].NodeID
-		if _, ok := nodeids[fk]; !ok {
-			ids = append(ids, fk)
+func (pq *PropertyQuery) loadNodes(ctx context.Context, query *NodeQuery, nodes []*Property, init func(*Property), assign func(*Property, *Node)) error {
+	edgeIDs := make([]driver.Value, len(nodes))
+	byID := make(map[uuid.UUID]*Property)
+	nids := make(map[uuid.UUID]map[*Property]struct{})
+	for i, node := range nodes {
+		edgeIDs[i] = node.ID
+		byID[node.ID] = node
+		if init != nil {
+			init(node)
 		}
-		nodeids[fk] = append(nodeids[fk], nodes[i])
 	}
-	if len(ids) == 0 {
-		return nil
+	query.Where(func(s *sql.Selector) {
+		joinT := sql.Table(property.NodesTable)
+		s.Join(joinT).On(s.C(node.FieldID), joinT.C(property.NodesPrimaryKey[0]))
+		s.Where(sql.InValues(joinT.C(property.NodesPrimaryKey[1]), edgeIDs...))
+		columns := s.SelectedColumns()
+		s.Select(joinT.C(property.NodesPrimaryKey[1]))
+		s.AppendSelect(columns...)
+		s.SetDistinct(false)
+	})
+	if err := query.prepareQuery(ctx); err != nil {
+		return err
 	}
-	query.Where(node.IDIn(ids...))
-	neighbors, err := query.All(ctx)
+	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
+		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+			assign := spec.Assign
+			values := spec.ScanValues
+			spec.ScanValues = func(columns []string) ([]any, error) {
+				values, err := values(columns[1:])
+				if err != nil {
+					return nil, err
+				}
+				return append([]any{new(uuid.UUID)}, values...), nil
+			}
+			spec.Assign = func(columns []string, values []any) error {
+				outValue := *values[0].(*uuid.UUID)
+				inValue := *values[1].(*uuid.UUID)
+				if nids[inValue] == nil {
+					nids[inValue] = map[*Property]struct{}{byID[outValue]: {}}
+					return assign(columns[1:], values[1:])
+				}
+				nids[inValue][byID[outValue]] = struct{}{}
+				return nil
+			}
+		})
+	})
+	neighbors, err := withInterceptors[[]*Node](ctx, query, qr, query.inters)
 	if err != nil {
 		return err
 	}
 	for _, n := range neighbors {
-		nodes, ok := nodeids[n.ID]
+		nodes, ok := nids[n.ID]
 		if !ok {
-			return fmt.Errorf(`unexpected foreign-key "node_id" returned %v`, n.ID)
+			return fmt.Errorf(`unexpected "nodes" node returned %v`, n.ID)
 		}
-		for i := range nodes {
-			assign(nodes[i], n)
+		for kn := range nodes {
+			assign(kn, n)
 		}
 	}
 	return nil
@@ -533,12 +600,6 @@ func (pq *PropertyQuery) querySpec() *sqlgraph.QuerySpec {
 			if fields[i] != property.FieldID {
 				_spec.Node.Columns = append(_spec.Node.Columns, fields[i])
 			}
-		}
-		if pq.withDocument != nil {
-			_spec.Node.AddColumnOnce(property.FieldDocumentID)
-		}
-		if pq.withNode != nil {
-			_spec.Node.AddColumnOnce(property.FieldNodeID)
 		}
 	}
 	if ps := pq.predicates; len(ps) > 0 {

--- a/internal/backends/ent/purpose/purpose.go
+++ b/internal/backends/ent/purpose/purpose.go
@@ -12,7 +12,6 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
-	"github.com/google/uuid"
 )
 
 const (
@@ -20,41 +19,40 @@ const (
 	Label = "purpose"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
-	// FieldDocumentID holds the string denoting the document_id field in the database.
-	FieldDocumentID = "document_id"
-	// FieldNodeID holds the string denoting the node_id field in the database.
-	FieldNodeID = "node_id"
 	// FieldPrimaryPurpose holds the string denoting the primary_purpose field in the database.
 	FieldPrimaryPurpose = "primary_purpose"
-	// EdgeDocument holds the string denoting the document edge name in mutations.
-	EdgeDocument = "document"
-	// EdgeNode holds the string denoting the node edge name in mutations.
-	EdgeNode = "node"
+	// EdgeDocuments holds the string denoting the documents edge name in mutations.
+	EdgeDocuments = "documents"
+	// EdgeNodes holds the string denoting the nodes edge name in mutations.
+	EdgeNodes = "nodes"
 	// Table holds the table name of the purpose in the database.
 	Table = "purposes"
-	// DocumentTable is the table that holds the document relation/edge.
-	DocumentTable = "purposes"
-	// DocumentInverseTable is the table name for the Document entity.
+	// DocumentsTable is the table that holds the documents relation/edge. The primary key declared below.
+	DocumentsTable = "document_purposes"
+	// DocumentsInverseTable is the table name for the Document entity.
 	// It exists in this package in order to avoid circular dependency with the "document" package.
-	DocumentInverseTable = "documents"
-	// DocumentColumn is the table column denoting the document relation/edge.
-	DocumentColumn = "document_id"
-	// NodeTable is the table that holds the node relation/edge.
-	NodeTable = "purposes"
-	// NodeInverseTable is the table name for the Node entity.
+	DocumentsInverseTable = "documents"
+	// NodesTable is the table that holds the nodes relation/edge. The primary key declared below.
+	NodesTable = "node_primary_purposes"
+	// NodesInverseTable is the table name for the Node entity.
 	// It exists in this package in order to avoid circular dependency with the "node" package.
-	NodeInverseTable = "nodes"
-	// NodeColumn is the table column denoting the node relation/edge.
-	NodeColumn = "node_id"
+	NodesInverseTable = "nodes"
 )
 
 // Columns holds all SQL columns for purpose fields.
 var Columns = []string{
 	FieldID,
-	FieldDocumentID,
-	FieldNodeID,
 	FieldPrimaryPurpose,
 }
+
+var (
+	// DocumentsPrimaryKey and DocumentsColumn2 are the table columns denoting the
+	// primary key for the documents relation (M2M).
+	DocumentsPrimaryKey = []string{"document_id", "purpose_id"}
+	// NodesPrimaryKey and NodesColumn2 are the table columns denoting the
+	// primary key for the nodes relation (M2M).
+	NodesPrimaryKey = []string{"node_id", "purpose_id"}
+)
 
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
@@ -65,11 +63,6 @@ func ValidColumn(column string) bool {
 	}
 	return false
 }
-
-var (
-	// DefaultDocumentID holds the default value on creation for the "document_id" field.
-	DefaultDocumentID func() uuid.UUID
-)
 
 // PrimaryPurpose defines the type for the "primary_purpose" enum field.
 type PrimaryPurpose string
@@ -129,45 +122,49 @@ func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
-// ByDocumentID orders the results by the document_id field.
-func ByDocumentID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldDocumentID, opts...).ToFunc()
-}
-
-// ByNodeID orders the results by the node_id field.
-func ByNodeID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldNodeID, opts...).ToFunc()
-}
-
 // ByPrimaryPurpose orders the results by the primary_purpose field.
 func ByPrimaryPurpose(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPrimaryPurpose, opts...).ToFunc()
 }
 
-// ByDocumentField orders the results by document field.
-func ByDocumentField(field string, opts ...sql.OrderTermOption) OrderOption {
+// ByDocumentsCount orders the results by documents count.
+func ByDocumentsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newDocumentStep(), sql.OrderByField(field, opts...))
+		sqlgraph.OrderByNeighborsCount(s, newDocumentsStep(), opts...)
 	}
 }
 
-// ByNodeField orders the results by node field.
-func ByNodeField(field string, opts ...sql.OrderTermOption) OrderOption {
+// ByDocuments orders the results by documents terms.
+func ByDocuments(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newNodeStep(), sql.OrderByField(field, opts...))
+		sqlgraph.OrderByNeighborTerms(s, newDocumentsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
-func newDocumentStep() *sqlgraph.Step {
+
+// ByNodesCount orders the results by nodes count.
+func ByNodesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newNodesStep(), opts...)
+	}
+}
+
+// ByNodes orders the results by nodes terms.
+func ByNodes(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newNodesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newDocumentsStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(DocumentInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
+		sqlgraph.To(DocumentsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
 	)
 }
-func newNodeStep() *sqlgraph.Step {
+func newNodesStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(NodeInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, true, NodeTable, NodeColumn),
+		sqlgraph.To(NodesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, NodesTable, NodesPrimaryKey...),
 	)
 }

--- a/internal/backends/ent/purpose/where.go
+++ b/internal/backends/ent/purpose/where.go
@@ -10,7 +10,6 @@ package purpose
 import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
-	"github.com/google/uuid"
 	"github.com/protobom/storage/internal/backends/ent/predicate"
 )
 
@@ -59,66 +58,6 @@ func IDLTE(id int) predicate.Purpose {
 	return predicate.Purpose(sql.FieldLTE(FieldID, id))
 }
 
-// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
-func DocumentID(v uuid.UUID) predicate.Purpose {
-	return predicate.Purpose(sql.FieldEQ(FieldDocumentID, v))
-}
-
-// NodeID applies equality check predicate on the "node_id" field. It's identical to NodeIDEQ.
-func NodeID(v uuid.UUID) predicate.Purpose {
-	return predicate.Purpose(sql.FieldEQ(FieldNodeID, v))
-}
-
-// DocumentIDEQ applies the EQ predicate on the "document_id" field.
-func DocumentIDEQ(v uuid.UUID) predicate.Purpose {
-	return predicate.Purpose(sql.FieldEQ(FieldDocumentID, v))
-}
-
-// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
-func DocumentIDNEQ(v uuid.UUID) predicate.Purpose {
-	return predicate.Purpose(sql.FieldNEQ(FieldDocumentID, v))
-}
-
-// DocumentIDIn applies the In predicate on the "document_id" field.
-func DocumentIDIn(vs ...uuid.UUID) predicate.Purpose {
-	return predicate.Purpose(sql.FieldIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
-func DocumentIDNotIn(vs ...uuid.UUID) predicate.Purpose {
-	return predicate.Purpose(sql.FieldNotIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDIsNil applies the IsNil predicate on the "document_id" field.
-func DocumentIDIsNil() predicate.Purpose {
-	return predicate.Purpose(sql.FieldIsNull(FieldDocumentID))
-}
-
-// DocumentIDNotNil applies the NotNil predicate on the "document_id" field.
-func DocumentIDNotNil() predicate.Purpose {
-	return predicate.Purpose(sql.FieldNotNull(FieldDocumentID))
-}
-
-// NodeIDEQ applies the EQ predicate on the "node_id" field.
-func NodeIDEQ(v uuid.UUID) predicate.Purpose {
-	return predicate.Purpose(sql.FieldEQ(FieldNodeID, v))
-}
-
-// NodeIDNEQ applies the NEQ predicate on the "node_id" field.
-func NodeIDNEQ(v uuid.UUID) predicate.Purpose {
-	return predicate.Purpose(sql.FieldNEQ(FieldNodeID, v))
-}
-
-// NodeIDIn applies the In predicate on the "node_id" field.
-func NodeIDIn(vs ...uuid.UUID) predicate.Purpose {
-	return predicate.Purpose(sql.FieldIn(FieldNodeID, vs...))
-}
-
-// NodeIDNotIn applies the NotIn predicate on the "node_id" field.
-func NodeIDNotIn(vs ...uuid.UUID) predicate.Purpose {
-	return predicate.Purpose(sql.FieldNotIn(FieldNodeID, vs...))
-}
-
 // PrimaryPurposeEQ applies the EQ predicate on the "primary_purpose" field.
 func PrimaryPurposeEQ(v PrimaryPurpose) predicate.Purpose {
 	return predicate.Purpose(sql.FieldEQ(FieldPrimaryPurpose, v))
@@ -139,21 +78,21 @@ func PrimaryPurposeNotIn(vs ...PrimaryPurpose) predicate.Purpose {
 	return predicate.Purpose(sql.FieldNotIn(FieldPrimaryPurpose, vs...))
 }
 
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.Purpose {
+// HasDocuments applies the HasEdge predicate on the "documents" edge.
+func HasDocuments() predicate.Purpose {
 	return predicate.Purpose(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
 }
 
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.Purpose {
+// HasDocumentsWith applies the HasEdge predicate on the "documents" edge with a given conditions (other predicates).
+func HasDocumentsWith(preds ...predicate.Document) predicate.Purpose {
 	return predicate.Purpose(func(s *sql.Selector) {
-		step := newDocumentStep()
+		step := newDocumentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -162,21 +101,21 @@ func HasDocumentWith(preds ...predicate.Document) predicate.Purpose {
 	})
 }
 
-// HasNode applies the HasEdge predicate on the "node" edge.
-func HasNode() predicate.Purpose {
+// HasNodes applies the HasEdge predicate on the "nodes" edge.
+func HasNodes() predicate.Purpose {
 	return predicate.Purpose(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, NodeTable, NodeColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, NodesTable, NodesPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
 }
 
-// HasNodeWith applies the HasEdge predicate on the "node" edge with a given conditions (other predicates).
-func HasNodeWith(preds ...predicate.Node) predicate.Purpose {
+// HasNodesWith applies the HasEdge predicate on the "nodes" edge with a given conditions (other predicates).
+func HasNodesWith(preds ...predicate.Node) predicate.Purpose {
 	return predicate.Purpose(func(s *sql.Selector) {
-		step := newNodeStep()
+		step := newNodesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/backends/ent/runtime/runtime.go
+++ b/internal/backends/ent/runtime/runtime.go
@@ -21,7 +21,6 @@ import (
 	"github.com/protobom/storage/internal/backends/ent/nodelist"
 	"github.com/protobom/storage/internal/backends/ent/person"
 	"github.com/protobom/storage/internal/backends/ent/property"
-	"github.com/protobom/storage/internal/backends/ent/purpose"
 	"github.com/protobom/storage/internal/backends/ent/schema"
 	"github.com/protobom/storage/internal/backends/ent/sourcedata"
 	"github.com/protobom/storage/internal/backends/ent/tool"
@@ -40,6 +39,8 @@ func init() {
 	// annotation.DefaultIsUnique holds the default value on creation for the is_unique field.
 	annotation.DefaultIsUnique = annotationDescIsUnique.Default.(bool)
 	documentMixin := schema.Document{}.Mixin()
+	documentMixinHooks0 := documentMixin[0].Hooks()
+	document.Hooks[0] = documentMixinHooks0[0]
 	documentMixinFields0 := documentMixin[0].Fields()
 	_ = documentMixinFields0
 	documentFields := schema.Document{}.Fields()
@@ -49,86 +50,60 @@ func init() {
 	// document.DefaultID holds the default value on creation for the id field.
 	document.DefaultID = documentDescID.Default.(func() uuid.UUID)
 	documenttypeMixin := schema.DocumentType{}.Mixin()
-	documenttypeMixinHooks1 := documenttypeMixin[1].Hooks()
-	documenttype.Hooks[0] = documenttypeMixinHooks1[0]
+	documenttypeMixinHooks0 := documenttypeMixin[0].Hooks()
+	documenttype.Hooks[0] = documenttypeMixinHooks0[0]
 	documenttypeMixinFields0 := documenttypeMixin[0].Fields()
 	_ = documenttypeMixinFields0
-	documenttypeMixinFields1 := documenttypeMixin[1].Fields()
-	_ = documenttypeMixinFields1
 	documenttypeFields := schema.DocumentType{}.Fields()
 	_ = documenttypeFields
-	// documenttypeDescDocumentID is the schema descriptor for document_id field.
-	documenttypeDescDocumentID := documenttypeMixinFields0[0].Descriptor()
-	// documenttype.DefaultDocumentID holds the default value on creation for the document_id field.
-	documenttype.DefaultDocumentID = documenttypeDescDocumentID.Default.(func() uuid.UUID)
 	// documenttypeDescID is the schema descriptor for id field.
-	documenttypeDescID := documenttypeMixinFields1[0].Descriptor()
+	documenttypeDescID := documenttypeMixinFields0[0].Descriptor()
 	// documenttype.DefaultID holds the default value on creation for the id field.
 	documenttype.DefaultID = documenttypeDescID.Default.(func() uuid.UUID)
 	edgetypeMixin := schema.EdgeType{}.Mixin()
-	edgetypeMixinHooks1 := edgetypeMixin[1].Hooks()
-	edgetype.Hooks[0] = edgetypeMixinHooks1[0]
+	edgetypeMixinHooks0 := edgetypeMixin[0].Hooks()
+	edgetype.Hooks[0] = edgetypeMixinHooks0[0]
 	edgetypeMixinFields0 := edgetypeMixin[0].Fields()
 	_ = edgetypeMixinFields0
-	edgetypeMixinFields1 := edgetypeMixin[1].Fields()
-	_ = edgetypeMixinFields1
 	edgetypeFields := schema.EdgeType{}.Fields()
 	_ = edgetypeFields
-	// edgetypeDescDocumentID is the schema descriptor for document_id field.
-	edgetypeDescDocumentID := edgetypeMixinFields0[0].Descriptor()
-	// edgetype.DefaultDocumentID holds the default value on creation for the document_id field.
-	edgetype.DefaultDocumentID = edgetypeDescDocumentID.Default.(func() uuid.UUID)
 	// edgetypeDescID is the schema descriptor for id field.
-	edgetypeDescID := edgetypeMixinFields1[0].Descriptor()
+	edgetypeDescID := edgetypeMixinFields0[0].Descriptor()
 	// edgetype.DefaultID holds the default value on creation for the id field.
 	edgetype.DefaultID = edgetypeDescID.Default.(func() uuid.UUID)
 	externalreferenceMixin := schema.ExternalReference{}.Mixin()
-	externalreferenceMixinHooks1 := externalreferenceMixin[1].Hooks()
-	externalreference.Hooks[0] = externalreferenceMixinHooks1[0]
+	externalreferenceMixinHooks0 := externalreferenceMixin[0].Hooks()
+	externalreference.Hooks[0] = externalreferenceMixinHooks0[0]
 	externalreferenceMixinFields0 := externalreferenceMixin[0].Fields()
 	_ = externalreferenceMixinFields0
-	externalreferenceMixinFields1 := externalreferenceMixin[1].Fields()
-	_ = externalreferenceMixinFields1
 	externalreferenceFields := schema.ExternalReference{}.Fields()
 	_ = externalreferenceFields
-	// externalreferenceDescDocumentID is the schema descriptor for document_id field.
-	externalreferenceDescDocumentID := externalreferenceMixinFields0[0].Descriptor()
-	// externalreference.DefaultDocumentID holds the default value on creation for the document_id field.
-	externalreference.DefaultDocumentID = externalreferenceDescDocumentID.Default.(func() uuid.UUID)
 	// externalreferenceDescID is the schema descriptor for id field.
-	externalreferenceDescID := externalreferenceMixinFields1[0].Descriptor()
+	externalreferenceDescID := externalreferenceMixinFields0[0].Descriptor()
 	// externalreference.DefaultID holds the default value on creation for the id field.
 	externalreference.DefaultID = externalreferenceDescID.Default.(func() uuid.UUID)
 	hashesentryMixin := schema.HashesEntry{}.Mixin()
+	hashesentryMixinHooks0 := hashesentryMixin[0].Hooks()
 	hashesentryHooks := schema.HashesEntry{}.Hooks()
-	hashesentry.Hooks[0] = hashesentryHooks[0]
+	hashesentry.Hooks[0] = hashesentryMixinHooks0[0]
+	hashesentry.Hooks[1] = hashesentryHooks[0]
 	hashesentryMixinFields0 := hashesentryMixin[0].Fields()
 	_ = hashesentryMixinFields0
-	hashesentryMixinFields1 := hashesentryMixin[1].Fields()
-	_ = hashesentryMixinFields1
 	hashesentryFields := schema.HashesEntry{}.Fields()
 	_ = hashesentryFields
-	// hashesentryDescDocumentID is the schema descriptor for document_id field.
-	hashesentryDescDocumentID := hashesentryMixinFields0[0].Descriptor()
-	// hashesentry.DefaultDocumentID holds the default value on creation for the document_id field.
-	hashesentry.DefaultDocumentID = hashesentryDescDocumentID.Default.(func() uuid.UUID)
 	// hashesentryDescID is the schema descriptor for id field.
-	hashesentryDescID := hashesentryMixinFields1[0].Descriptor()
+	hashesentryDescID := hashesentryMixinFields0[0].Descriptor()
 	// hashesentry.DefaultID holds the default value on creation for the id field.
 	hashesentry.DefaultID = hashesentryDescID.Default.(func() uuid.UUID)
 	identifiersentryMixin := schema.IdentifiersEntry{}.Mixin()
+	identifiersentryMixinHooks0 := identifiersentryMixin[0].Hooks()
+	identifiersentry.Hooks[0] = identifiersentryMixinHooks0[0]
 	identifiersentryMixinFields0 := identifiersentryMixin[0].Fields()
 	_ = identifiersentryMixinFields0
-	identifiersentryMixinFields1 := identifiersentryMixin[1].Fields()
-	_ = identifiersentryMixinFields1
 	identifiersentryFields := schema.IdentifiersEntry{}.Fields()
 	_ = identifiersentryFields
-	// identifiersentryDescDocumentID is the schema descriptor for document_id field.
-	identifiersentryDescDocumentID := identifiersentryMixinFields0[0].Descriptor()
-	// identifiersentry.DefaultDocumentID holds the default value on creation for the document_id field.
-	identifiersentry.DefaultDocumentID = identifiersentryDescDocumentID.Default.(func() uuid.UUID)
 	// identifiersentryDescID is the schema descriptor for id field.
-	identifiersentryDescID := identifiersentryMixinFields1[0].Descriptor()
+	identifiersentryDescID := identifiersentryMixinFields0[0].Descriptor()
 	// identifiersentry.DefaultID holds the default value on creation for the id field.
 	identifiersentry.DefaultID = identifiersentryDescID.Default.(func() uuid.UUID)
 	metadataMixin := schema.Metadata{}.Mixin()
@@ -139,7 +114,7 @@ func init() {
 	metadataFields := schema.Metadata{}.Fields()
 	_ = metadataFields
 	// metadataDescNativeID is the schema descriptor for native_id field.
-	metadataDescNativeID := metadataFields[0].Descriptor()
+	metadataDescNativeID := metadataFields[1].Descriptor()
 	// metadata.NativeIDValidator is a validator for the "native_id" field. It is called by the builders before save.
 	metadata.NativeIDValidator = metadataDescNativeID.Validators[0].(func(string) error)
 	// metadataDescID is the schema descriptor for id field.
@@ -147,24 +122,18 @@ func init() {
 	// metadata.DefaultID holds the default value on creation for the id field.
 	metadata.DefaultID = metadataDescID.Default.(func() uuid.UUID)
 	nodeMixin := schema.Node{}.Mixin()
-	nodeMixinHooks1 := nodeMixin[1].Hooks()
-	node.Hooks[0] = nodeMixinHooks1[0]
+	nodeMixinHooks0 := nodeMixin[0].Hooks()
+	node.Hooks[0] = nodeMixinHooks0[0]
 	nodeMixinFields0 := nodeMixin[0].Fields()
 	_ = nodeMixinFields0
-	nodeMixinFields1 := nodeMixin[1].Fields()
-	_ = nodeMixinFields1
 	nodeFields := schema.Node{}.Fields()
 	_ = nodeFields
-	// nodeDescDocumentID is the schema descriptor for document_id field.
-	nodeDescDocumentID := nodeMixinFields0[0].Descriptor()
-	// node.DefaultDocumentID holds the default value on creation for the document_id field.
-	node.DefaultDocumentID = nodeDescDocumentID.Default.(func() uuid.UUID)
 	// nodeDescNativeID is the schema descriptor for native_id field.
 	nodeDescNativeID := nodeFields[0].Descriptor()
 	// node.NativeIDValidator is a validator for the "native_id" field. It is called by the builders before save.
 	node.NativeIDValidator = nodeDescNativeID.Validators[0].(func(string) error)
 	// nodeDescID is the schema descriptor for id field.
-	nodeDescID := nodeMixinFields1[0].Descriptor()
+	nodeDescID := nodeMixinFields0[0].Descriptor()
 	// node.DefaultID holds the default value on creation for the id field.
 	node.DefaultID = nodeDescID.Default.(func() uuid.UUID)
 	nodelistMixin := schema.NodeList{}.Mixin()
@@ -179,82 +148,49 @@ func init() {
 	// nodelist.DefaultID holds the default value on creation for the id field.
 	nodelist.DefaultID = nodelistDescID.Default.(func() uuid.UUID)
 	personMixin := schema.Person{}.Mixin()
-	personMixinHooks1 := personMixin[1].Hooks()
+	personMixinHooks0 := personMixin[0].Hooks()
 	personHooks := schema.Person{}.Hooks()
-	person.Hooks[0] = personMixinHooks1[0]
+	person.Hooks[0] = personMixinHooks0[0]
 	person.Hooks[1] = personHooks[0]
 	personMixinFields0 := personMixin[0].Fields()
 	_ = personMixinFields0
-	personMixinFields1 := personMixin[1].Fields()
-	_ = personMixinFields1
 	personFields := schema.Person{}.Fields()
 	_ = personFields
-	// personDescDocumentID is the schema descriptor for document_id field.
-	personDescDocumentID := personMixinFields0[0].Descriptor()
-	// person.DefaultDocumentID holds the default value on creation for the document_id field.
-	person.DefaultDocumentID = personDescDocumentID.Default.(func() uuid.UUID)
 	// personDescID is the schema descriptor for id field.
-	personDescID := personMixinFields1[0].Descriptor()
+	personDescID := personMixinFields0[0].Descriptor()
 	// person.DefaultID holds the default value on creation for the id field.
 	person.DefaultID = personDescID.Default.(func() uuid.UUID)
 	propertyMixin := schema.Property{}.Mixin()
-	propertyMixinHooks1 := propertyMixin[1].Hooks()
-	property.Hooks[0] = propertyMixinHooks1[0]
+	propertyMixinHooks0 := propertyMixin[0].Hooks()
+	property.Hooks[0] = propertyMixinHooks0[0]
 	propertyMixinFields0 := propertyMixin[0].Fields()
 	_ = propertyMixinFields0
-	propertyMixinFields1 := propertyMixin[1].Fields()
-	_ = propertyMixinFields1
 	propertyFields := schema.Property{}.Fields()
 	_ = propertyFields
-	// propertyDescDocumentID is the schema descriptor for document_id field.
-	propertyDescDocumentID := propertyMixinFields0[0].Descriptor()
-	// property.DefaultDocumentID holds the default value on creation for the document_id field.
-	property.DefaultDocumentID = propertyDescDocumentID.Default.(func() uuid.UUID)
 	// propertyDescID is the schema descriptor for id field.
-	propertyDescID := propertyMixinFields1[0].Descriptor()
+	propertyDescID := propertyMixinFields0[0].Descriptor()
 	// property.DefaultID holds the default value on creation for the id field.
 	property.DefaultID = propertyDescID.Default.(func() uuid.UUID)
-	purposeMixin := schema.Purpose{}.Mixin()
-	purposeMixinFields0 := purposeMixin[0].Fields()
-	_ = purposeMixinFields0
-	purposeFields := schema.Purpose{}.Fields()
-	_ = purposeFields
-	// purposeDescDocumentID is the schema descriptor for document_id field.
-	purposeDescDocumentID := purposeMixinFields0[0].Descriptor()
-	// purpose.DefaultDocumentID holds the default value on creation for the document_id field.
-	purpose.DefaultDocumentID = purposeDescDocumentID.Default.(func() uuid.UUID)
 	sourcedataMixin := schema.SourceData{}.Mixin()
-	sourcedataMixinHooks1 := sourcedataMixin[1].Hooks()
-	sourcedata.Hooks[0] = sourcedataMixinHooks1[0]
+	sourcedataMixinHooks0 := sourcedataMixin[0].Hooks()
+	sourcedata.Hooks[0] = sourcedataMixinHooks0[0]
 	sourcedataMixinFields0 := sourcedataMixin[0].Fields()
 	_ = sourcedataMixinFields0
-	sourcedataMixinFields1 := sourcedataMixin[1].Fields()
-	_ = sourcedataMixinFields1
 	sourcedataFields := schema.SourceData{}.Fields()
 	_ = sourcedataFields
-	// sourcedataDescDocumentID is the schema descriptor for document_id field.
-	sourcedataDescDocumentID := sourcedataMixinFields0[0].Descriptor()
-	// sourcedata.DefaultDocumentID holds the default value on creation for the document_id field.
-	sourcedata.DefaultDocumentID = sourcedataDescDocumentID.Default.(func() uuid.UUID)
 	// sourcedataDescID is the schema descriptor for id field.
-	sourcedataDescID := sourcedataMixinFields1[0].Descriptor()
+	sourcedataDescID := sourcedataMixinFields0[0].Descriptor()
 	// sourcedata.DefaultID holds the default value on creation for the id field.
 	sourcedata.DefaultID = sourcedataDescID.Default.(func() uuid.UUID)
 	toolMixin := schema.Tool{}.Mixin()
-	toolMixinHooks1 := toolMixin[1].Hooks()
-	tool.Hooks[0] = toolMixinHooks1[0]
+	toolMixinHooks0 := toolMixin[0].Hooks()
+	tool.Hooks[0] = toolMixinHooks0[0]
 	toolMixinFields0 := toolMixin[0].Fields()
 	_ = toolMixinFields0
-	toolMixinFields1 := toolMixin[1].Fields()
-	_ = toolMixinFields1
 	toolFields := schema.Tool{}.Fields()
 	_ = toolFields
-	// toolDescDocumentID is the schema descriptor for document_id field.
-	toolDescDocumentID := toolMixinFields0[0].Descriptor()
-	// tool.DefaultDocumentID holds the default value on creation for the document_id field.
-	tool.DefaultDocumentID = toolDescDocumentID.Default.(func() uuid.UUID)
 	// toolDescID is the schema descriptor for id field.
-	toolDescID := toolMixinFields1[0].Descriptor()
+	toolDescID := toolMixinFields0[0].Descriptor()
 	// tool.DefaultID holds the default value on creation for the id field.
 	tool.DefaultID = toolDescID.Default.(func() uuid.UUID)
 }

--- a/internal/backends/ent/schema/document.go
+++ b/internal/backends/ent/schema/document.go
@@ -11,7 +11,10 @@ import (
 	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
 	"github.com/google/uuid"
+
+	"github.com/protobom/storage/internal/backends/ent/schema/mixin"
 )
 
 type Document struct {
@@ -20,7 +23,7 @@ type Document struct {
 
 func (Document) Mixin() []ent.Mixin {
 	return []ent.Mixin{
-		UUIDMixin{},
+		mixin.UUID{},
 	}
 }
 
@@ -38,23 +41,37 @@ func (Document) Fields() []ent.Field {
 }
 
 func (Document) Edges() []ent.Edge {
-	const edgeRef = "document"
-
 	return []ent.Edge{
 		edge.To("annotations", Annotation.Type).
 			StructTag(`json:"-"`).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
-		edge.From("metadata", Metadata.Type).
-			Ref(edgeRef).
+		edge.To("metadata", Metadata.Type).
 			Unique().
 			Immutable().
 			Annotations(entsql.OnDelete(entsql.Cascade)).
 			Field("metadata_id"),
-		edge.From("node_list", NodeList.Type).
-			Ref(edgeRef).
+		edge.To("node_list", NodeList.Type).
 			Unique().
 			Immutable().
 			Annotations(entsql.OnDelete(entsql.Cascade)).
 			Field("node_list_id"),
+		edge.To("document_types", DocumentType.Type),
+		edge.To("edge_types", EdgeType.Type),
+		edge.To("external_references", ExternalReference.Type),
+		edge.To("hashes", HashesEntry.Type),
+		edge.To("identifiers", IdentifiersEntry.Type),
+		edge.To("nodes", Node.Type),
+		edge.To("persons", Person.Type),
+		edge.To("properties", Property.Type),
+		edge.To("purposes", Purpose.Type),
+		edge.To("source_data", SourceData.Type),
+		edge.To("tools", Tool.Type),
+	}
+}
+
+func (Document) Indexes() []ent.Index {
+	return []ent.Index{
+		index.Edges("metadata").StorageKey("idx_documents_metadata_id"),
+		index.Edges("node_list").StorageKey("idx_documents_node_list_id"),
 	}
 }

--- a/internal/backends/ent/schema/document_type.go
+++ b/internal/backends/ent/schema/document_type.go
@@ -11,8 +11,9 @@ import (
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
-	"github.com/google/uuid"
 	"github.com/protobom/protobom/pkg/sbom"
+
+	"github.com/protobom/storage/internal/backends/ent/schema/mixin"
 )
 
 type DocumentType struct {
@@ -21,14 +22,12 @@ type DocumentType struct {
 
 func (DocumentType) Mixin() []ent.Mixin {
 	return []ent.Mixin{
-		DocumentMixin{},
-		ProtoMessageMixin[*sbom.DocumentType]{},
+		mixin.ProtoMessage[*sbom.DocumentType]{},
 	}
 }
 
 func (DocumentType) Fields() []ent.Field {
 	return []ent.Field{
-		field.UUID("metadata_id", uuid.UUID{}),
 		field.Enum("type").
 			Values(enumValues(new(sbom.DocumentType_SBOMType))...).
 			Optional().
@@ -40,17 +39,19 @@ func (DocumentType) Fields() []ent.Field {
 
 func (DocumentType) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("metadata", Metadata.Type).
+		edge.From("documents", Document.Type).
 			Ref("document_types").
 			Required().
-			Unique().
-			Field("metadata_id"),
+			Immutable(),
+		edge.From("metadata", Metadata.Type).
+			Ref("document_types").
+			Required(),
 	}
 }
 
 func (DocumentType) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("metadata_id", "type", "name", "description").
+		index.Fields("type", "name", "description").
 			Unique().
 			StorageKey("idx_document_types"),
 	}

--- a/internal/backends/ent/schema/edge_type.go
+++ b/internal/backends/ent/schema/edge_type.go
@@ -14,6 +14,8 @@ import (
 	"entgo.io/ent/schema/index"
 	"github.com/google/uuid"
 	"github.com/protobom/protobom/pkg/sbom"
+
+	"github.com/protobom/storage/internal/backends/ent/schema/mixin"
 )
 
 type EdgeType struct {
@@ -22,8 +24,7 @@ type EdgeType struct {
 
 func (EdgeType) Mixin() []ent.Mixin {
 	return []ent.Mixin{
-		DocumentMixin{},
-		ProtoMessageMixin[*sbom.Edge]{},
+		mixin.ProtoMessage[*sbom.Edge]{},
 	}
 }
 
@@ -47,9 +48,12 @@ func (EdgeType) Edges() []ent.Edge {
 			Unique().
 			Annotations(entsql.OnDelete(entsql.Cascade)).
 			Field("to_node_id"),
-		edge.From("node_lists", NodeList.Type).
+		edge.From("documents", Document.Type).
 			Ref("edge_types").
-			Required(),
+			Required().
+			Immutable(),
+		edge.From("node_lists", NodeList.Type).
+			Ref("edge_types"),
 	}
 }
 

--- a/internal/backends/ent/schema/enum.go
+++ b/internal/backends/ent/schema/enum.go
@@ -1,0 +1,21 @@
+// --------------------------------------------------------------
+// SPDX-FileCopyrightText: Copyright © 2025 The Protobom Authors
+// SPDX-FileType: SOURCE
+// SPDX-License-Identifier: Apache-2.0
+// --------------------------------------------------------------
+
+package schema
+
+import "google.golang.org/protobuf/reflect/protoreflect"
+
+// enumValues returns the values of a protobuf enum type deterministically, preserving their order.
+func enumValues(enum protoreflect.Enum) []string {
+	values := []string{}
+
+	enumValues := enum.Descriptor().Values()
+	for idx := range enumValues.Len() {
+		values = append(values, string(enumValues.Get(idx).Name()))
+	}
+
+	return values
+}

--- a/internal/backends/ent/schema/external_reference.go
+++ b/internal/backends/ent/schema/external_reference.go
@@ -12,6 +12,8 @@ import (
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"github.com/protobom/protobom/pkg/sbom"
+
+	"github.com/protobom/storage/internal/backends/ent/schema/mixin"
 )
 
 type ExternalReference struct {
@@ -20,8 +22,7 @@ type ExternalReference struct {
 
 func (ExternalReference) Mixin() []ent.Mixin {
 	return []ent.Mixin{
-		DocumentMixin{},
-		ProtoMessageMixin[*sbom.ExternalReference]{},
+		mixin.ProtoMessage[*sbom.ExternalReference]{},
 	}
 }
 
@@ -40,6 +41,10 @@ func (ExternalReference) Edges() []ent.Edge {
 		edge.To("hashes", HashesEntry.Type).
 			StorageKey(edge.Table("ext_ref_hashes"), edge.Columns("ext_ref_id", "hash_entry_id")).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
+		edge.From("documents", Document.Type).
+			Ref("external_references").
+			Required().
+			Immutable(),
 		edge.From("nodes", Node.Type).
 			Ref("external_references").
 			Required(),

--- a/internal/backends/ent/schema/identifiers_entry.go
+++ b/internal/backends/ent/schema/identifiers_entry.go
@@ -11,6 +11,8 @@ import (
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
 	"github.com/protobom/protobom/pkg/sbom"
+
+	"github.com/protobom/storage/internal/backends/ent/schema/mixin"
 )
 
 type IdentifiersEntry struct {
@@ -19,8 +21,7 @@ type IdentifiersEntry struct {
 
 func (IdentifiersEntry) Mixin() []ent.Mixin {
 	return []ent.Mixin{
-		DocumentMixin{},
-		UUIDMixin{},
+		mixin.UUID{},
 	}
 }
 
@@ -33,6 +34,10 @@ func (IdentifiersEntry) Fields() []ent.Field {
 
 func (IdentifiersEntry) Edges() []ent.Edge {
 	return []ent.Edge{
+		edge.From("documents", Document.Type).
+			Ref("identifiers").
+			Required().
+			Immutable(),
 		edge.From("nodes", Node.Type).
 			Ref("identifiers").
 			Required(),

--- a/internal/backends/ent/schema/mixin/proto_message.go
+++ b/internal/backends/ent/schema/mixin/proto_message.go
@@ -1,0 +1,42 @@
+// --------------------------------------------------------------
+// SPDX-FileCopyrightText: Copyright © 2024 The Protobom Authors
+// SPDX-FileType: SOURCE
+// SPDX-License-Identifier: Apache-2.0
+// --------------------------------------------------------------
+
+package mixin
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/schema/field"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/protobom/storage/internal/backends/ent/hook"
+)
+
+const protoMessageField = "proto_message"
+
+// ProtoMessage adds the `proto_message` field containing the wire format bytes.
+type ProtoMessage[T proto.Message] struct {
+	UUID
+}
+
+func (pm ProtoMessage[T]) Fields() []ent.Field {
+	var goType T
+
+	return append(
+		pm.UUID.Fields(),
+		field.Bytes(protoMessageField).
+			GoType(goType).
+			Nillable().
+			Unique().
+			Immutable().
+			StructTag(`json:"-"`),
+	)
+}
+
+func (ProtoMessage[T]) Hooks() []ent.Hook {
+	return []ent.Hook{
+		hook.On(uuidHook, ent.OpCreate|ent.OpUpdate|ent.OpUpdateOne),
+	}
+}

--- a/internal/backends/ent/schema/mixin/uuid.go
+++ b/internal/backends/ent/schema/mixin/uuid.go
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // --------------------------------------------------------------
 
-package schema
+package mixin
 
 import (
 	"context"
@@ -12,83 +12,21 @@ import (
 	"fmt"
 
 	"entgo.io/ent"
-	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema"
-	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/mixin"
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/protobom/storage/internal/backends/ent/hook"
 )
 
-const protoMessageField = "proto_message"
-
-type (
-	// DocumentMixin adds the `document` edge and corresponding `document_id` edge field.
-	DocumentMixin struct {
-		mixin.Schema
-	}
-
-	// ProtoMessageMixin adds the `proto_message` field containing the wire format bytes.
-	ProtoMessageMixin[T proto.Message] struct {
-		UUIDMixin
-	}
-
-	// UUIDMixin replaces the default integer `id` field with a generated UUID.
-	UUIDMixin struct {
-		mixin.Schema
-	}
-)
-
-func (DocumentMixin) Annotations() []schema.Annotation {
-	return []schema.Annotation{
-		entsql.OnDelete(entsql.Cascade),
-	}
+// UUID replaces the default integer `id` field with a generated UUID.
+type UUID struct {
+	mixin.Schema
 }
 
-func (DocumentMixin) Fields() []ent.Field {
-	return []ent.Field{
-		field.UUID("document_id", uuid.UUID{}).
-			Optional().
-			Immutable().
-			Default(func() uuid.UUID { return uuid.Must(uuid.NewV7()) }),
-	}
-}
-
-func (DocumentMixin) Edges() []ent.Edge {
-	return []ent.Edge{
-		edge.To("document", Document.Type).
-			Unique().
-			Immutable().
-			Annotations(entsql.OnDelete(entsql.Cascade)).
-			Field("document_id"),
-	}
-}
-
-func (pmm ProtoMessageMixin[T]) Fields() []ent.Field {
-	var goType T
-
-	return append(
-		pmm.UUIDMixin.Fields(),
-		field.Bytes(protoMessageField).
-			GoType(goType).
-			Nillable().
-			Unique().
-			Immutable().
-			StructTag(`json:"-"`),
-	)
-}
-
-func (ProtoMessageMixin[T]) Hooks() []ent.Hook {
-	return []ent.Hook{
-		hook.On(uuidHook, ent.OpCreate|ent.OpUpdate|ent.OpUpdateOne),
-	}
-}
-
-func (UUIDMixin) Fields() []ent.Field {
+func (UUID) Fields() []ent.Field {
 	return []ent.Field{
 		field.UUID("id", uuid.UUID{}).
 			Unique().
@@ -99,16 +37,10 @@ func (UUIDMixin) Fields() []ent.Field {
 	}
 }
 
-// enumValues returns the values of a protobuf enum type deterministically, preserving their order.
-func enumValues(enum protoreflect.Enum) []string {
-	values := []string{}
-
-	enumValues := enum.Descriptor().Values()
-	for idx := range enumValues.Len() {
-		values = append(values, string(enumValues.Get(idx).Name()))
+func (UUID) Hooks() []ent.Hook {
+	return []ent.Hook{
+		hook.On(uuidHook, ent.OpCreate|ent.OpUpdate|ent.OpUpdateOne),
 	}
-
-	return values
 }
 
 func uuidHook(next ent.Mutator) ent.Mutator {

--- a/internal/backends/ent/schema/node_list.go
+++ b/internal/backends/ent/schema/node_list.go
@@ -12,6 +12,8 @@ import (
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"github.com/protobom/protobom/pkg/sbom"
+
+	"github.com/protobom/storage/internal/backends/ent/schema/mixin"
 )
 
 type NodeList struct {
@@ -20,7 +22,7 @@ type NodeList struct {
 
 func (NodeList) Mixin() []ent.Mixin {
 	return []ent.Mixin{
-		ProtoMessageMixin[*sbom.NodeList]{},
+		mixin.ProtoMessage[*sbom.NodeList]{},
 	}
 }
 
@@ -32,15 +34,15 @@ func (NodeList) Fields() []ent.Field {
 
 func (NodeList) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.To("document", Document.Type).
-			Required().
-			Unique().
-			Immutable(),
 		edge.To("edge_types", EdgeType.Type).
 			StorageKey(edge.Table("node_list_edges"), edge.Columns("node_list_id", "edge_type_id")).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
 		edge.To("nodes", Node.Type).
 			StorageKey(edge.Table("node_list_nodes"), edge.Columns("node_list_id", "node_id")).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
+		edge.From("documents", Document.Type).
+			Ref("node_list").
+			Required().
+			Immutable(),
 	}
 }

--- a/internal/backends/ent/schema/property.go
+++ b/internal/backends/ent/schema/property.go
@@ -11,8 +11,9 @@ import (
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
-	"github.com/google/uuid"
 	"github.com/protobom/protobom/pkg/sbom"
+
+	"github.com/protobom/storage/internal/backends/ent/schema/mixin"
 )
 
 type Property struct {
@@ -21,14 +22,12 @@ type Property struct {
 
 func (Property) Mixin() []ent.Mixin {
 	return []ent.Mixin{
-		DocumentMixin{},
-		ProtoMessageMixin[*sbom.Property]{},
+		mixin.ProtoMessage[*sbom.Property]{},
 	}
 }
 
 func (Property) Fields() []ent.Field {
 	return []ent.Field{
-		field.UUID("node_id", uuid.UUID{}),
 		field.String("name"),
 		field.String("data"),
 	}
@@ -36,11 +35,13 @@ func (Property) Fields() []ent.Field {
 
 func (Property) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("node", Node.Type).
+		edge.From("documents", Document.Type).
 			Ref("properties").
 			Required().
-			Unique().
-			Field("node_id"),
+			Immutable(),
+		edge.From("nodes", Node.Type).
+			Ref("properties").
+			Required(),
 	}
 }
 

--- a/internal/backends/ent/schema/purpose.go
+++ b/internal/backends/ent/schema/purpose.go
@@ -10,8 +10,6 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
-	"entgo.io/ent/schema/index"
-	"github.com/google/uuid"
 	"github.com/protobom/protobom/pkg/sbom"
 )
 
@@ -19,33 +17,20 @@ type Purpose struct {
 	ent.Schema
 }
 
-func (Purpose) Mixin() []ent.Mixin {
-	return []ent.Mixin{
-		DocumentMixin{},
-	}
-}
-
 func (Purpose) Fields() []ent.Field {
 	return []ent.Field{
-		field.UUID("node_id", uuid.UUID{}),
 		field.Enum("primary_purpose").Values(enumValues(new(sbom.Purpose))...),
 	}
 }
 
 func (Purpose) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("node", Node.Type).
-			Ref("primary_purpose").
+		edge.From("documents", Document.Type).
+			Ref("purposes").
 			Required().
-			Unique().
-			Field("node_id"),
-	}
-}
-
-func (Purpose) Indexes() []ent.Index {
-	return []ent.Index{
-		index.Fields("node_id", "primary_purpose").
-			Unique().
-			StorageKey("idx_purposes"),
+			Immutable(),
+		edge.From("nodes", Node.Type).
+			Ref("primary_purpose").
+			Required(),
 	}
 }

--- a/internal/backends/ent/schema/tool.go
+++ b/internal/backends/ent/schema/tool.go
@@ -11,8 +11,9 @@ import (
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
-	"github.com/google/uuid"
 	"github.com/protobom/protobom/pkg/sbom"
+
+	"github.com/protobom/storage/internal/backends/ent/schema/mixin"
 )
 
 type Tool struct {
@@ -21,14 +22,12 @@ type Tool struct {
 
 func (Tool) Mixin() []ent.Mixin {
 	return []ent.Mixin{
-		DocumentMixin{},
-		ProtoMessageMixin[*sbom.Tool]{},
+		mixin.ProtoMessage[*sbom.Tool]{},
 	}
 }
 
 func (Tool) Fields() []ent.Field {
 	return []ent.Field{
-		field.UUID("metadata_id", uuid.UUID{}),
 		field.String("name"),
 		field.String("version"),
 		field.String("vendor"),
@@ -37,17 +36,19 @@ func (Tool) Fields() []ent.Field {
 
 func (Tool) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("metadata", Metadata.Type).
+		edge.From("documents", Document.Type).
 			Ref("tools").
 			Required().
-			Unique().
-			Field("metadata_id"),
+			Immutable(),
+		edge.From("metadata", Metadata.Type).
+			Ref("tools").
+			Required(),
 	}
 }
 
 func (Tool) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("metadata_id", "name", "version", "vendor").
+		index.Fields("name", "version", "vendor").
 			Unique().
 			StorageKey("idx_tools"),
 	}

--- a/internal/backends/ent/sourcedata/where.go
+++ b/internal/backends/ent/sourcedata/where.go
@@ -60,19 +60,9 @@ func IDLTE(id uuid.UUID) predicate.SourceData {
 	return predicate.SourceData(sql.FieldLTE(FieldID, id))
 }
 
-// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
-func DocumentID(v uuid.UUID) predicate.SourceData {
-	return predicate.SourceData(sql.FieldEQ(FieldDocumentID, v))
-}
-
 // ProtoMessage applies equality check predicate on the "proto_message" field. It's identical to ProtoMessageEQ.
 func ProtoMessage(v *sbom.SourceData) predicate.SourceData {
 	return predicate.SourceData(sql.FieldEQ(FieldProtoMessage, v))
-}
-
-// MetadataID applies equality check predicate on the "metadata_id" field. It's identical to MetadataIDEQ.
-func MetadataID(v uuid.UUID) predicate.SourceData {
-	return predicate.SourceData(sql.FieldEQ(FieldMetadataID, v))
 }
 
 // Format applies equality check predicate on the "format" field. It's identical to FormatEQ.
@@ -88,36 +78,6 @@ func Size(v int64) predicate.SourceData {
 // URI applies equality check predicate on the "uri" field. It's identical to URIEQ.
 func URI(v string) predicate.SourceData {
 	return predicate.SourceData(sql.FieldEQ(FieldURI, v))
-}
-
-// DocumentIDEQ applies the EQ predicate on the "document_id" field.
-func DocumentIDEQ(v uuid.UUID) predicate.SourceData {
-	return predicate.SourceData(sql.FieldEQ(FieldDocumentID, v))
-}
-
-// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
-func DocumentIDNEQ(v uuid.UUID) predicate.SourceData {
-	return predicate.SourceData(sql.FieldNEQ(FieldDocumentID, v))
-}
-
-// DocumentIDIn applies the In predicate on the "document_id" field.
-func DocumentIDIn(vs ...uuid.UUID) predicate.SourceData {
-	return predicate.SourceData(sql.FieldIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
-func DocumentIDNotIn(vs ...uuid.UUID) predicate.SourceData {
-	return predicate.SourceData(sql.FieldNotIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDIsNil applies the IsNil predicate on the "document_id" field.
-func DocumentIDIsNil() predicate.SourceData {
-	return predicate.SourceData(sql.FieldIsNull(FieldDocumentID))
-}
-
-// DocumentIDNotNil applies the NotNil predicate on the "document_id" field.
-func DocumentIDNotNil() predicate.SourceData {
-	return predicate.SourceData(sql.FieldNotNull(FieldDocumentID))
 }
 
 // ProtoMessageEQ applies the EQ predicate on the "proto_message" field.
@@ -158,26 +118,6 @@ func ProtoMessageLT(v *sbom.SourceData) predicate.SourceData {
 // ProtoMessageLTE applies the LTE predicate on the "proto_message" field.
 func ProtoMessageLTE(v *sbom.SourceData) predicate.SourceData {
 	return predicate.SourceData(sql.FieldLTE(FieldProtoMessage, v))
-}
-
-// MetadataIDEQ applies the EQ predicate on the "metadata_id" field.
-func MetadataIDEQ(v uuid.UUID) predicate.SourceData {
-	return predicate.SourceData(sql.FieldEQ(FieldMetadataID, v))
-}
-
-// MetadataIDNEQ applies the NEQ predicate on the "metadata_id" field.
-func MetadataIDNEQ(v uuid.UUID) predicate.SourceData {
-	return predicate.SourceData(sql.FieldNEQ(FieldMetadataID, v))
-}
-
-// MetadataIDIn applies the In predicate on the "metadata_id" field.
-func MetadataIDIn(vs ...uuid.UUID) predicate.SourceData {
-	return predicate.SourceData(sql.FieldIn(FieldMetadataID, vs...))
-}
-
-// MetadataIDNotIn applies the NotIn predicate on the "metadata_id" field.
-func MetadataIDNotIn(vs ...uuid.UUID) predicate.SourceData {
-	return predicate.SourceData(sql.FieldNotIn(FieldMetadataID, vs...))
 }
 
 // FormatEQ applies the EQ predicate on the "format" field.
@@ -360,31 +300,44 @@ func URIContainsFold(v string) predicate.SourceData {
 	return predicate.SourceData(sql.FieldContainsFold(FieldURI, v))
 }
 
-// HashesIsNil applies the IsNil predicate on the "hashes" field.
-func HashesIsNil() predicate.SourceData {
-	return predicate.SourceData(sql.FieldIsNull(FieldHashes))
-}
-
-// HashesNotNil applies the NotNil predicate on the "hashes" field.
-func HashesNotNil() predicate.SourceData {
-	return predicate.SourceData(sql.FieldNotNull(FieldHashes))
-}
-
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.SourceData {
+// HasHashes applies the HasEdge predicate on the "hashes" edge.
+func HasHashes() predicate.SourceData {
 	return predicate.SourceData(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, HashesTable, HashesPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
 }
 
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.SourceData {
+// HasHashesWith applies the HasEdge predicate on the "hashes" edge with a given conditions (other predicates).
+func HasHashesWith(preds ...predicate.HashesEntry) predicate.SourceData {
 	return predicate.SourceData(func(s *sql.Selector) {
-		step := newDocumentStep()
+		step := newHashesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasDocuments applies the HasEdge predicate on the "documents" edge.
+func HasDocuments() predicate.SourceData {
+	return predicate.SourceData(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasDocumentsWith applies the HasEdge predicate on the "documents" edge with a given conditions (other predicates).
+func HasDocumentsWith(preds ...predicate.Document) predicate.SourceData {
+	return predicate.SourceData(func(s *sql.Selector) {
+		step := newDocumentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -398,7 +351,7 @@ func HasMetadata() predicate.SourceData {
 	return predicate.SourceData(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, MetadataTable, MetadataColumn),
+			sqlgraph.Edge(sqlgraph.O2M, true, MetadataTable, MetadataColumn),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})

--- a/internal/backends/ent/tool/where.go
+++ b/internal/backends/ent/tool/where.go
@@ -60,19 +60,9 @@ func IDLTE(id uuid.UUID) predicate.Tool {
 	return predicate.Tool(sql.FieldLTE(FieldID, id))
 }
 
-// DocumentID applies equality check predicate on the "document_id" field. It's identical to DocumentIDEQ.
-func DocumentID(v uuid.UUID) predicate.Tool {
-	return predicate.Tool(sql.FieldEQ(FieldDocumentID, v))
-}
-
 // ProtoMessage applies equality check predicate on the "proto_message" field. It's identical to ProtoMessageEQ.
 func ProtoMessage(v *sbom.Tool) predicate.Tool {
 	return predicate.Tool(sql.FieldEQ(FieldProtoMessage, v))
-}
-
-// MetadataID applies equality check predicate on the "metadata_id" field. It's identical to MetadataIDEQ.
-func MetadataID(v uuid.UUID) predicate.Tool {
-	return predicate.Tool(sql.FieldEQ(FieldMetadataID, v))
 }
 
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
@@ -88,36 +78,6 @@ func Version(v string) predicate.Tool {
 // Vendor applies equality check predicate on the "vendor" field. It's identical to VendorEQ.
 func Vendor(v string) predicate.Tool {
 	return predicate.Tool(sql.FieldEQ(FieldVendor, v))
-}
-
-// DocumentIDEQ applies the EQ predicate on the "document_id" field.
-func DocumentIDEQ(v uuid.UUID) predicate.Tool {
-	return predicate.Tool(sql.FieldEQ(FieldDocumentID, v))
-}
-
-// DocumentIDNEQ applies the NEQ predicate on the "document_id" field.
-func DocumentIDNEQ(v uuid.UUID) predicate.Tool {
-	return predicate.Tool(sql.FieldNEQ(FieldDocumentID, v))
-}
-
-// DocumentIDIn applies the In predicate on the "document_id" field.
-func DocumentIDIn(vs ...uuid.UUID) predicate.Tool {
-	return predicate.Tool(sql.FieldIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDNotIn applies the NotIn predicate on the "document_id" field.
-func DocumentIDNotIn(vs ...uuid.UUID) predicate.Tool {
-	return predicate.Tool(sql.FieldNotIn(FieldDocumentID, vs...))
-}
-
-// DocumentIDIsNil applies the IsNil predicate on the "document_id" field.
-func DocumentIDIsNil() predicate.Tool {
-	return predicate.Tool(sql.FieldIsNull(FieldDocumentID))
-}
-
-// DocumentIDNotNil applies the NotNil predicate on the "document_id" field.
-func DocumentIDNotNil() predicate.Tool {
-	return predicate.Tool(sql.FieldNotNull(FieldDocumentID))
 }
 
 // ProtoMessageEQ applies the EQ predicate on the "proto_message" field.
@@ -158,26 +118,6 @@ func ProtoMessageLT(v *sbom.Tool) predicate.Tool {
 // ProtoMessageLTE applies the LTE predicate on the "proto_message" field.
 func ProtoMessageLTE(v *sbom.Tool) predicate.Tool {
 	return predicate.Tool(sql.FieldLTE(FieldProtoMessage, v))
-}
-
-// MetadataIDEQ applies the EQ predicate on the "metadata_id" field.
-func MetadataIDEQ(v uuid.UUID) predicate.Tool {
-	return predicate.Tool(sql.FieldEQ(FieldMetadataID, v))
-}
-
-// MetadataIDNEQ applies the NEQ predicate on the "metadata_id" field.
-func MetadataIDNEQ(v uuid.UUID) predicate.Tool {
-	return predicate.Tool(sql.FieldNEQ(FieldMetadataID, v))
-}
-
-// MetadataIDIn applies the In predicate on the "metadata_id" field.
-func MetadataIDIn(vs ...uuid.UUID) predicate.Tool {
-	return predicate.Tool(sql.FieldIn(FieldMetadataID, vs...))
-}
-
-// MetadataIDNotIn applies the NotIn predicate on the "metadata_id" field.
-func MetadataIDNotIn(vs ...uuid.UUID) predicate.Tool {
-	return predicate.Tool(sql.FieldNotIn(FieldMetadataID, vs...))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.
@@ -375,21 +315,21 @@ func VendorContainsFold(v string) predicate.Tool {
 	return predicate.Tool(sql.FieldContainsFold(FieldVendor, v))
 }
 
-// HasDocument applies the HasEdge predicate on the "document" edge.
-func HasDocument() predicate.Tool {
+// HasDocuments applies the HasEdge predicate on the "documents" edge.
+func HasDocuments() predicate.Tool {
 	return predicate.Tool(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, DocumentTable, DocumentColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, DocumentsTable, DocumentsPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
 }
 
-// HasDocumentWith applies the HasEdge predicate on the "document" edge with a given conditions (other predicates).
-func HasDocumentWith(preds ...predicate.Document) predicate.Tool {
+// HasDocumentsWith applies the HasEdge predicate on the "documents" edge with a given conditions (other predicates).
+func HasDocumentsWith(preds ...predicate.Document) predicate.Tool {
 	return predicate.Tool(func(s *sql.Selector) {
-		step := newDocumentStep()
+		step := newDocumentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -403,7 +343,7 @@ func HasMetadata() predicate.Tool {
 	return predicate.Tool(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, MetadataTable, MetadataColumn),
+			sqlgraph.Edge(sqlgraph.M2M, true, MetadataTable, MetadataPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})


### PR DESCRIPTION
This PR removes the unique option from all inverse/from edges, meaning a child entity may now always belong to potentially multiple owners/parents. This is to allow proto messages in the database to be reused if the wire-format bytes of the message are identical.

Depends on #63

> [!NOTE]
> Only the following files are manually modified; the rest are auto-generated
>
> - `backends/ent/*.go`
> - `internal/backends/ent/schema/*.go`

### Miscellaneous

- move mixin schemas into separate package
- remove `DocumentMixin`, more duplicated code but better clarity
- fix cardinality of `Metadata` --> `SourceData` edge

/cc @ashearin @lmphil @pkwiatkowski1 @Strakeln @jmayer-lm @EphraimEM