### PR TITLE
Add storage-commiters as approvers

### DIFF
--- a/.miniprow.yaml
+++ b/.miniprow.yaml
@@ -1,0 +1,13 @@
+# Miniprow configuration for protobom/storage.
+#
+# Org-wide settings — the self-approval gate, the /override allow-list and
+# the release tagging policies — come from
+# github.com/protobom/.github/.miniprow.yaml and are locked there; this
+# file only adds this repository's maintainers.
+owners:
+  teams:
+    # Members of this GitHub team may /approve (and /lgtm) any pull request
+    # in this repository, as if listed in a root OWNERS file. Bare slugs
+    # resolve in the protobom org. Approvers implicitly review; a team that
+    # should only be able to /lgtm goes under `reviewers:` instead.
+    approvers: [storage-commiters]


### PR DESCRIPTION
This pull request adds a new `.miniprow.yaml` configuration file to specify repository-level approvers for the `protobom/storage` repository.

Repository configuration:

* Added a `.miniprow.yaml` file that designates the `storage-commiters` GitHub team as approvers for this repository, allowing them to `/approve` and `/lgtm` pull requests.